### PR TITLE
Fix-docker-images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,6 +105,7 @@ jobs:
           push: true
           tags: |
             aksioinsurtech/cratis:${{ steps.release.outputs.version }}-workbench
+            aksioinsurtech/cratis:latest-workbench
           build-args: |
             VERSION=${{ steps.release.outputs.version }}
 

--- a/Docker/Development/Dockerfile
+++ b/Docker/Development/Dockerfile
@@ -2,7 +2,7 @@
 # Server Build
 ARG CONFIGURATION=Release
 ARG VERSION
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS server-build
+FROM mcr.microsoft.com/dotnet/sdk:6.0.101 AS server-build
 WORKDIR /build
 
 COPY .editorconfig .

--- a/Docker/Production/Dockerfile
+++ b/Docker/Production/Dockerfile
@@ -2,7 +2,7 @@
 # Server Build
 ARG CONFIGURATION=Release
 ARG VERSION
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS server-build
+FROM mcr.microsoft.com/dotnet/sdk:6.0.101 AS server-build
 WORKDIR /build
 
 COPY .editorconfig .

--- a/Docker/Workbench/Dockerfile
+++ b/Docker/Workbench/Dockerfile
@@ -11,6 +11,7 @@ COPY .mocharc.js .
 COPY package.json .
 COPY tsconfig.json .
 COPY ./Source/Node ./Source/Node
+COPY ./Source/ApplicationModel/Frontend ./Source/ApplicationModel/Frontend
 COPY ./Source/Workbench ./Source/Workbench
 
 WORKDIR /build/Source/Workbench

--- a/Source/Fundamentals/Fundamentals.csproj
+++ b/Source/Fundamentals/Fundamentals.csproj
@@ -13,6 +13,8 @@
       <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="5.0.0" />
       <PackageReference Include="ObjectsComparer" Version="1.4.1" />
       <PackageReference Include="NJsonSchema" Version="10.6.6"/>
+      <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0"/>
+      <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJson)"/>
       <PackageReference Include="System.Reactive" Version="5.0.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Fixed

- Add missing `ApplicationModel/Frontend` for the Workbench Docker image
- Locking down Newtonsoft JSON version + System.IO.FileSystem.Primitives. NJsonSchema has a dependency to an earlier version of Newtonsoft, causing problems during publish with downgraded references.
- Add **latest** tag for Workbench docker image.
