### PR TITLE
Adding support for RemovedWith - #134

### DIFF
--- a/Samples/Bank/Domain/Accounts/Debit/Accounts.cs
+++ b/Samples/Bank/Domain/Accounts/Debit/Accounts.cs
@@ -15,7 +15,10 @@ namespace Domain.Accounts.Debit
         public Accounts(IEventLog eventLog) => _eventLog = eventLog;
 
         [HttpPost]
-        public Task Create([FromBody] CreateDebitAccount create) => _eventLog.Append(create.AccountId, new DebitAccountOpened(create.Name, create.Owner));
+        public Task Open([FromBody] OpenDebitAccount create) => _eventLog.Append(create.AccountId, new DebitAccountOpened(create.Name, create.Owner));
+
+        [HttpPost("close")]
+        public Task Close([FromBody] CloseDebitAccount close) => _eventLog.Append(close.AccountId, new DebitAccountClosed());
 
         [HttpPost("deposit")]
         public Task Deposit([FromBody] DepositToAccount deposit) => _eventLog.Append(deposit.AccountId, new DepositToDebitAccountPerformed(deposit.Amount));

--- a/Samples/Bank/Domain/Accounts/Debit/CloseDebitAccount.cs
+++ b/Samples/Bank/Domain/Accounts/Debit/CloseDebitAccount.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Concepts;
+using Concepts.Accounts;
+using Events.Accounts.Debit;
+
+namespace Domain.Accounts.Debit
+{
+    public record CloseDebitAccount(AccountId AccountId);
+}

--- a/Samples/Bank/Domain/Accounts/Debit/OpenDebitAccount.cs
+++ b/Samples/Bank/Domain/Accounts/Debit/OpenDebitAccount.cs
@@ -7,5 +7,5 @@ using Events.Accounts.Debit;
 
 namespace Domain.Accounts.Debit
 {
-    public record CreateDebitAccount(AccountId AccountId, AccountName Name, PersonId Owner);
+    public record OpenDebitAccount(AccountId AccountId, AccountName Name, PersonId Owner);
 }

--- a/Samples/Bank/Events/Accounts/Debit/DebitAccountClosed.cs
+++ b/Samples/Bank/Events/Accounts/Debit/DebitAccountClosed.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Concepts;
+using Concepts.Accounts;
+
+namespace Events.Accounts.Debit
+{
+    [EventType("7eca09ce-09fa-4b29-9aab-1695b1cf0c00")]
+    public record DebitAccountClosed();
+}

--- a/Samples/Bank/Read/Accounts/Debit/DebitAccountProjection.cs
+++ b/Samples/Bank/Read/Accounts/Debit/DebitAccountProjection.cs
@@ -19,6 +19,7 @@ namespace Read.Accounts.Debit
                 .From<DepositToDebitAccountPerformed>(_ => _
                     .Add(model => model.Balance).With(@event => @event.Amount))
                 .From<WithdrawalFromDebitAccountPerformed>(_ => _
-                    .Subtract(model => model.Balance).With(@event => @event.Amount));
+                    .Subtract(model => model.Balance).With(@event => @event.Amount))
+                .RemovedWith<DebitAccountClosed>();
     }
 }

--- a/Samples/Bank/Web/API/accounts/debit/CloseDebitAccount.ts
+++ b/Samples/Bank/Web/API/accounts/debit/CloseDebitAccount.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  **DO NOT EDIT** - This file is an automatically generated file.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Command } from '@aksio/cratis-applications-frontend/commands';
+
+export class CloseDebitAccount extends Command {
+    readonly route: string = '/api/accounts/debit/close';
+
+    accountId!: string;
+}

--- a/Samples/Bank/Web/API/accounts/debit/OpenDebitAccount.ts
+++ b/Samples/Bank/Web/API/accounts/debit/OpenDebitAccount.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  **DO NOT EDIT** - This file is an automatically generated file.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Command } from '@aksio/cratis-applications-frontend/commands';
+
+export class OpenDebitAccount extends Command {
+    readonly route: string = '/api/accounts/debit';
+
+    accountId!: string;
+    name!: string;
+    owner!: string;
+}

--- a/Source/Clients/DotNET/Events/Projections/ChildrenBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/ChildrenBuilder.cs
@@ -23,7 +23,7 @@ namespace Aksio.Cratis.Events.Projections
         readonly Dictionary<EventType, FromDefinition> _fromDefintions = new();
         readonly string _modelName;
         string _identifiedBy = string.Empty;
-        string _removedWithEvent = string.Empty;
+        EventType? _removedWithEvent;
 
         /// <summary>
         /// /// Initializes a new instance of the <see cref="ProjectionBuilderFor{TModel}"/> class.
@@ -59,7 +59,7 @@ namespace Aksio.Cratis.Events.Projections
         /// <inheritdoc/>
         public IChildrenBuilder<TParentModel, TChildModel> RemovedWith<TEvent>()
         {
-            _removedWithEvent = _eventTypes.GetEventTypeFor(typeof(TEvent)).ToString();
+            _removedWithEvent = _eventTypes.GetEventTypeFor(typeof(TEvent));
             return this;
         }
 
@@ -71,7 +71,7 @@ namespace Aksio.Cratis.Events.Projections
                 new ModelDefinition(_modelName, _schemaGenerator.Generate(typeof(TChildModel)).ToJson()),
                 _fromDefintions,
                 new Dictionary<PropertyPath, ChildrenDefinition>(),
-                string.IsNullOrEmpty(_removedWithEvent) ? default : new RemovedWithDefinition(_removedWithEvent));
+                _removedWithEvent == default ? default : new RemovedWithDefinition(_removedWithEvent));
         }
     }
 }

--- a/Source/Clients/DotNET/Events/Projections/IProjectionBuilderFor.cs
+++ b/Source/Clients/DotNET/Events/Projections/IProjectionBuilderFor.cs
@@ -47,6 +47,13 @@ namespace Aksio.Cratis.Events.Projections
         IProjectionBuilderFor<TModel> From<TEvent>(Action<IFromBuilder<TModel, TEvent>> builderCallback);
 
         /// <summary>
+        /// Define an event type that causes a delete in the projected result.
+        /// </summary>
+        /// <typeparam name="TEvent">Type of event.</typeparam>
+        /// <returns>Builder continuation.</returns>
+        IProjectionBuilderFor<TModel> RemovedWith<TEvent>();
+
+        /// <summary>
         /// Start buildint the children projection for a specific child model.
         /// </summary>
         /// <param name="targetProperty">Expression for expressing the target property.</param>

--- a/Source/Clients/DotNET/Events/Projections/ProjectionBuilderFor.cs
+++ b/Source/Clients/DotNET/Events/Projections/ProjectionBuilderFor.cs
@@ -26,6 +26,7 @@ namespace Aksio.Cratis.Events.Projections
         bool _isRewindable = true;
         string _modelName;
         string? _name;
+        EventType? _removedWithEvent;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProjectionBuilderFor{TModel}"/> class.
@@ -83,6 +84,18 @@ namespace Aksio.Cratis.Events.Projections
         }
 
         /// <inheritdoc/>
+        public IProjectionBuilderFor<TModel> RemovedWith<TEvent>()
+        {
+            if (_removedWithEvent != default)
+            {
+                throw new RemovalAlreadyDefined(_identifier);
+            }
+
+            _removedWithEvent = _eventTypes.GetEventTypeFor(typeof(TEvent));
+            return this;
+        }
+
+        /// <inheritdoc/>
         public IProjectionBuilderFor<TModel> Children<TChildModel>(Expression<Func<TModel, IEnumerable<TChildModel>>> targetProperty, Action<IChildrenBuilder<TModel, TChildModel>> builderCallback)
         {
             var builder = new ChildrenBuilder<TModel, TChildModel>(_eventTypes, _schemaGenerator);
@@ -101,7 +114,8 @@ namespace Aksio.Cratis.Events.Projections
                 _isPassive,
                 _isRewindable,
                 _fromDefintions,
-                _childrenDefinitions);
+                _childrenDefinitions,
+                _removedWithEvent == default ? default : new RemovedWithDefinition(_removedWithEvent));
         }
     }
 }

--- a/Source/Clients/DotNET/Events/Projections/RemovalAlreadyDefined.cs
+++ b/Source/Clients/DotNET/Events/Projections/RemovalAlreadyDefined.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Events.Projections
+{
+    /// <summary>
+    /// Exception that gets thrown when removal has already been defined.
+    /// </summary>
+    public class RemovalAlreadyDefined : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemovalAlreadyDefined"/> class.
+        /// </summary>
+        /// <param name="identifier">The <see cref="ProjectionId"/>.</param>
+        public RemovalAlreadyDefined(ProjectionId identifier) : base($"Removal already defined for projection '{identifier}'. You can only define one event type to be the removal event type.")
+        {
+        }
+    }
+}

--- a/Source/Fundamentals/Changes/Changeset.cs
+++ b/Source/Fundamentals/Changes/Changeset.cs
@@ -116,6 +116,7 @@ namespace Aksio.Cratis.Changes
         /// <inheritdoc/>
         public void Remove()
         {
+            Add(new Removed(InitialState.Clone()!));
         }
 
         /// <inheritdoc/>
@@ -130,6 +131,9 @@ namespace Aksio.Cratis.Changes
                     .Select(_ => _ as ChildAdded)
                     .Any(_ => _ != null && _.ChildrenProperty == childrenProperty && _.Key == key);
         }
+
+        /// <inheritdoc/>
+        public bool HasBeenRemoved() => Changes.Any(_ => _ is Removed);
 
         /// <inheritdoc/>
         public TChild GetChildByKey<TChild>(PropertyPath childrenProperty, PropertyPath identifiedByProperty, object key)

--- a/Source/Fundamentals/Changes/IChangeset.cs
+++ b/Source/Fundamentals/Changes/IChangeset.cs
@@ -92,6 +92,12 @@ namespace Aksio.Cratis.Changes
         bool HasChildBeenAddedWithKey(PropertyPath childrenProperty, object key);
 
         /// <summary>
+        /// Check if there has been issued a remove on the changeset.
+        /// </summary>
+        /// <returns>True if there has, false if not.</returns>
+        bool HasBeenRemoved();
+
+        /// <summary>
         /// Get a specific child from.
         /// </summary>
         /// <typeparam name="TChild">Type of child.</typeparam>

--- a/Source/Fundamentals/Changes/Removed.cs
+++ b/Source/Fundamentals/Changes/Removed.cs
@@ -4,8 +4,8 @@
 namespace Aksio.Cratis.Changes
 {
     /// <summary>
-    /// Represents an entry being removed.
+    /// Represents the removal of an item.
     /// </summary>
-    /// <param name="Key">The key of the object that was removed.</param>
-    public record RemovePerformed(object Key) : Change(null!);
+    /// <param name="State">State of the object being removed.</param>
+    public record Removed(object State) : Change(State);
 }

--- a/Source/Kernel/Projections/Engine/InMemory/InMemoryProjectionResultStore.cs
+++ b/Source/Kernel/Projections/Engine/InMemory/InMemoryProjectionResultStore.cs
@@ -60,13 +60,19 @@ namespace Aksio.Cratis.Events.Projections.InMemory
         public Task ApplyChanges(object key, IChangeset<AppendedEvent, ExpandoObject> changeset)
         {
             var state = changeset.InitialState.Clone();
+            var collection = GetCollection();
+
+            if (changeset.HasBeenRemoved())
+            {
+                collection.Remove(key);
+                return Task.CompletedTask;
+            }
 
             foreach (var change in changeset.Changes)
             {
                 state = state.OverwriteWith((change.State as ExpandoObject)!);
             }
 
-            var collection = GetCollection();
             collection[key] = state;
 
             return Task.CompletedTask;

--- a/Source/Kernel/Projections/MongoDB/MongoDBProjectionResultStore.cs
+++ b/Source/Kernel/Projections/MongoDB/MongoDBProjectionResultStore.cs
@@ -83,6 +83,13 @@ namespace Aksio.Cratis.Events.Projections.MongoDB
             var hasChanges = false;
 
             var filter = Builders<BsonDocument>.Filter.Eq("_id", key.ToString());
+            var collection = GetCollection();
+
+            if (changeset.HasBeenRemoved())
+            {
+                await collection.DeleteOneAsync(filter);
+                return;
+            }
 
             UpdateDefinition<BsonDocument> UpdateProperty(string path, object value)
             {
@@ -143,7 +150,6 @@ namespace Aksio.Cratis.Events.Projections.MongoDB
 
             if (!hasChanges) return;
 
-            var collection = GetCollection();
             await collection.UpdateOneAsync(filter, updateBuilder, new UpdateOptions { IsUpsert = true });
 
             await Task.CompletedTask;

--- a/Source/Kernel/Projections/Shared/Definitions/ProjectionDefinition.cs
+++ b/Source/Kernel/Projections/Shared/Definitions/ProjectionDefinition.cs
@@ -14,6 +14,7 @@ namespace Aksio.Cratis.Events.Projections.Definitions
     /// <param name="IsPassive">Whether or not the projection is a passive projection.</param>
     /// <param name="IsRewindable">Whether or not the projection is rewindable.</param>
     /// <param name="From">All the <see cref="FromDefinition"/> for <see cref="EventType">event types</see>.</param>
+    ///
     /// <param name="Children">All the <see cref="ChildrenDefinition"/> for properties on model.</param>
     /// <param name="RemovedWith">The definition of what removes a child, if any.</param>
     public record ProjectionDefinition(

--- a/Source/Kernel/Projections/Shared/Definitions/RemovedWithDefinition.cs
+++ b/Source/Kernel/Projections/Shared/Definitions/RemovedWithDefinition.cs
@@ -6,6 +6,6 @@ namespace Aksio.Cratis.Events.Projections.Definitions
     /// <summary>
     /// Represents the definition of what removes an element in a child relationship.
     /// </summary>
-    /// <param name="event">The event that is causing the removal.</param>
-    public record RemovedWithDefinition(string @event);
+    /// <param name="Event">The event that is causing the removal.</param>
+    public record RemovedWithDefinition(EventType Event);
 }

--- a/Source/Workbench/Global.d.ts
+++ b/Source/Workbench/Global.d.ts
@@ -1,4 +1,4 @@
-// Copyright (c) Cratis. All rights reserved.
+// Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 declare module "*.module.css";


### PR DESCRIPTION
## Summary

Adds support for defining a `RemovedWith<TEvent>()` on the projection builder. This is implemented all the way down and will cause a document in e.g. MongoDB to actually be deleted.

A sample of usage:

```csharp
public class DebitAccountProjection : IProjectionFor<DebitAccount>
{
    public ProjectionId Identifier => "d1bb5522-5512-42ce-938a-d176536bb01d";

    public void Define(IProjectionBuilderFor<DebitAccount> builder) =>
        builder
            .From<DebitAccountOpened>(_ => _
                .Set(model => model.Name).To(@event => @event.Name)
                .Set(model => model.Owner).To(@event => @event.Owner))
            .From<DepositToDebitAccountPerformed>(_ => _
                .Add(model => model.Balance).With(@event => @event.Amount))
            .From<WithdrawalFromDebitAccountPerformed>(_ => _
                .Subtract(model => model.Balance).With(@event => @event.Amount))
            // ** NEW ** 
            .RemovedWith<DebitAccountClosed>();
}
```