### PR TITLE
Adding search paths - to be able to have config files in subfolders

### DIFF
--- a/Documentation/application-model/configuration.md
+++ b/Documentation/application-model/configuration.md
@@ -53,3 +53,7 @@ public class MyController : Controller
 
 > Note: Effectively these are exactly the same, the `IOptions<>` means accessing the configuration needs to
 > go through the `Value` property of the `IOptions<>` interface.
+
+## Search Paths
+
+By default it will search for configuration files in `$PWD/config` and `$PWD`, in that order.

--- a/Source/ApplicationModel/Applications/HostBuilderExtensions.cs
+++ b/Source/ApplicationModel/Applications/HostBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.Hosting
                     _
                     .AddSingleton<ITypes>(types)
                     .AddSingleton<ProviderFor<IServiceProvider>>(() => Internals.ServiceProvider!)
-                    .AddConfigurationObjects(types)
+                    .AddConfigurationObjects(types, searchSubPaths: new[] { "config" })
                     .AddControllersFromProjectReferencedAssembles(types)
                     .AddSwaggerGen()
                     .AddEndpointsApiExplorer()

--- a/Source/Fundamentals/Configuration/ConfigurationHostBuilderExtensions.cs
+++ b/Source/Fundamentals/Configuration/ConfigurationHostBuilderExtensions.cs
@@ -52,35 +52,61 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services"><see cref="IServiceCollection"/> to use with.</param>
         /// <param name="types"><see cref="ITypes"/> for type discovery.</param>
         /// <param name="baseRelativePath">Optional base relative path, relative to the current running directory.</param>
+        /// <param name="searchSubPaths">Optional search sub paths, relative to the current running directory and the optional baseRelativePath.</param>
         /// <returns><see cref="IServiceCollection"/> for continuation.</returns>
-        public static IServiceCollection AddConfigurationObjects(this IServiceCollection services, ITypes types, string baseRelativePath = "")
+        /// <exception cref="MissingConfiguration">Thrown if a configuration object can't be resolved.</exception>
+        /// <remarks>
+        /// It will always search the current running directory. When given search paths, the current directory will be added as the
+        /// last search path, as a fallback.
+        /// </remarks>
+        public static IServiceCollection AddConfigurationObjects(
+            this IServiceCollection services,
+            ITypes types,
+            string baseRelativePath = "",
+            IEnumerable<string>? searchSubPaths = default)
         {
+            var allSearchSubPaths = new List<string>(searchSubPaths ?? Array.Empty<string>())
+            {
+                "./"
+            };
+            var allSearchPaths = allSearchSubPaths.Select(_ => Path.Combine(Directory.GetCurrentDirectory(), baseRelativePath, _)).Distinct().ToArray();
+
             foreach (var configurationObject in types.All.Where(_ => _.HasAttribute<ConfigurationAttribute>()))
             {
                 var attribute = configurationObject.GetCustomAttribute<ConfigurationAttribute>()!;
-                var basePath = Path.Combine(Directory.GetCurrentDirectory(), baseRelativePath);
 
                 var fileName = attribute.FileNameSet ? attribute.FileName : configurationObject.Name.ToLowerInvariant();
                 fileName = Path.HasExtension(fileName) ? fileName : $"{fileName}.json";
+                var found = false;
 
-                if (!attribute.Optional && !File.Exists(Path.Combine(basePath, fileName)))
+                foreach (var searchPath in allSearchPaths)
                 {
-                    continue;
+                    var path = Path.Combine(searchPath, fileName);
+                    if (!File.Exists(path))
+                    {
+                        continue;
+                    }
+                    found = true;
+
+                    var configuration = new ConfigurationBuilder()
+                        .SetBasePath(searchPath)
+                        .AddJsonFile(fileName, attribute.Optional)
+                        .Build();
+
+                    var configurationInstance = configuration.Get(configurationObject);
+                    services.AddSingleton(configurationObject, configurationInstance);
+
+                    var optionsType = typeof(IOptions<>).MakeGenericType(configurationObject);
+                    var optionsWrapperType = typeof(OptionsWrapper<>).MakeGenericType(configurationObject);
+                    var optionsWrapperInstance = Activator.CreateInstance(optionsWrapperType, new[] { configurationInstance });
+
+                    services.AddSingleton(optionsType, optionsWrapperInstance!);
                 }
 
-                var configuration = new ConfigurationBuilder()
-                    .SetBasePath(basePath)
-                    .AddJsonFile(fileName, attribute.Optional)
-                    .Build();
-
-                var configurationInstance = configuration.Get(configurationObject);
-                services.AddSingleton(configurationObject, configurationInstance);
-
-                var optionsType = typeof(IOptions<>).MakeGenericType(configurationObject);
-                var optionsWrapperType = typeof(OptionsWrapper<>).MakeGenericType(configurationObject);
-                var optionsWrapperInstance = Activator.CreateInstance(optionsWrapperType, new[] { configurationInstance });
-
-                services.AddSingleton(optionsType, optionsWrapperInstance!);
+                if (!found && !attribute.Optional)
+                {
+                    throw new MissingConfiguration(configurationObject, fileName);
+                }
             }
 
             return services;

--- a/Source/Fundamentals/Configuration/MissingConfiguration.cs
+++ b/Source/Fundamentals/Configuration/MissingConfiguration.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Exception that gets thrown when a specific configuration is missing.
+    /// </summary>
+    public class MissingConfiguration : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MissingConfiguration"/> class.
+        /// </summary>
+        /// <param name="type">Type of configuration object.</param>
+        /// <param name="file">File it was expecting to find.</param>
+        public MissingConfiguration(Type type, string file) : base($"Missing configuration file '${file}' for '${type.FullName}'")
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Added

- Adds search paths for config files. By default it adds `$PWD/config` and automatically also `$PWD` as fallback. This is very helpful when packaged and leverages with services like Azure Container Instances which can't mount files, only folders.
