### PR TITLE
Elastic-logging

### DIFF
--- a/Samples/Bank/Main/Main.csproj
+++ b/Samples/Bank/Main/Main.csproj
@@ -1,9 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <ItemGroup>
-        <ProjectReference Include="../Concepts/Concepts.csproj"/>
-        <ProjectReference Include="../Domain/Domain.csproj"/>
-        <ProjectReference Include="../Events/Events.csproj"/>
-        <ProjectReference Include="../Integration/Integration.csproj"/>
-        <ProjectReference Include="../Read/Read.csproj"/>
+        <ProjectReference Include="../Concepts/Concepts.csproj" />
+        <ProjectReference Include="../Domain/Domain.csproj" />
+        <ProjectReference Include="../Events/Events.csproj" />
+        <ProjectReference Include="../Integration/Integration.csproj" />
+        <ProjectReference Include="../Read/Read.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
     </ItemGroup>
 </Project>

--- a/Samples/Bank/Main/appsettings.json
+++ b/Samples/Bank/Main/appsettings.json
@@ -1,7 +1,8 @@
 {
     "Serilog": {
         "Using": [
-            "Serilog.Sinks.Console"
+            "Serilog.Sinks.Console",
+            "Serilog.Sinks.Elasticsearch"
         ],
         "MinimumLevel": {
             "Default": "Verbose",
@@ -25,6 +26,14 @@
                 "Args": {
                     "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
                     "outputTemplate": "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}"
+                }
+            },
+            {
+                "Name": "Elasticsearch",
+                "Args": {
+                    "nodeUris": "http://localhost:9200",
+                    "indexFormat": "banksample-{0:yyyy.MM}",
+                    "emitEventFailure": "WriteToSelfLog"
                 }
             }
         ]

--- a/Source/ApplicationModel/Applications/Logging/LoggingHostBuilderExtensions.cs
+++ b/Source/ApplicationModel/Applications/Logging/LoggingHostBuilderExtensions.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Extensions.Hosting
 
             builder.UseSerilog();
 
+            Serilog.Debugging.SelfLog.Enable(Console.WriteLine);
+
             return new Serilog.Extensions.Logging.SerilogLoggerFactory();
         }
     }

--- a/Source/Fundamentals/Configuration/ConfigurationHostBuilderExtensions.cs
+++ b/Source/Fundamentals/Configuration/ConfigurationHostBuilderExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Configuration = new ConfigurationBuilder()
                   .SetBasePath(Directory.GetCurrentDirectory())
+                  .AddJsonFile("config/appsettings.json", optional: true, reloadOnChange: true)
                   .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
                   .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", optional: true, reloadOnChange: true)
                   .Build();

--- a/Source/Kernel/Server/Server.csproj
+++ b/Source/Kernel/Server/Server.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Serilog" Version="2.10.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+        <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
         <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0" />
         <PackageReference Include="Microsoft.Orleans.Server" Version="$(Orleans)" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="$(Swashbuckle)" />


### PR DESCRIPTION
### Added

- Look for **appsettings.json** in a **config** sub folder, this will help us configure everything when using Azure Container Instances due to its lack of not supporting indivdual file mounts.
- Configured Serilog to self-log, very useful for errors.
- Kernel now has Serilogs Elastic extension added to it.
- Added sample of how to use Serilogs Elastic for production for the Bank sample, which means also for the default template when creating a new Microservice.
