### PR TITLE
Adding GZip and Brotli compression for Web responses

### DIFF
--- a/Source/ApplicationModel/Applications/ApplicationBuilderExtensions.cs
+++ b/Source/ApplicationModel/Applications/ApplicationBuilderExtensions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Builder
         {
             Internals.ServiceProvider = app.ApplicationServices;
 
+            app.UseResponseCompression();
             app.UseWebSockets();
             app.UseDefaultFiles();
             app.UseStaticFiles();

--- a/Source/ApplicationModel/Applications/HostBuilderExtensions.cs
+++ b/Source/ApplicationModel/Applications/HostBuilderExtensions.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO.Compression;
 using Aksio.Cratis.Applications;
 using Aksio.Cratis.Concepts;
 using Aksio.Cratis.DependencyInversion;
 using Aksio.Cratis.Hosting;
 using Aksio.Cratis.Types;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Hosting
@@ -42,6 +45,13 @@ namespace Microsoft.Extensions.Hosting
                     .AddControllersFromProjectReferencedAssembles(types)
                     .AddSwaggerGen()
                     .AddEndpointsApiExplorer()
+                    .AddResponseCompression(options =>
+                    {
+                        options.EnableForHttps = true;
+                        options.Providers.Add<BrotliCompressionProvider>();
+                        options.Providers.Add<GzipCompressionProvider>();
+                    })
+                    .Configure<GzipCompressionProviderOptions>(options => options.Level = CompressionLevel.SmallestSize)
 
                     // Temporarily adding this, due to a bug in .NET 6 (https://www.ingebrigtsen.info/2021/09/29/autofac-asp-net-core-6-hot-reload-debug-crash/):
                     .AddRazorPages();


### PR DESCRIPTION
### Added

- All HTTP & HTTPS requests will now have their responses compressed supporting GZip and Brotli, depending on `Accept-Encoding`.
