### PR TITLE
Optimizing publish workflow, Fixes #115

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup .Net
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "6.0.100"
+          dotnet-version: "6.0.102"
 
       - name: Build .NET
         run: dotnet build --configuration Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup .Net
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '6.0.102'
 
       - name: Build .NET
         run: dotnet build --configuration Release
@@ -51,6 +51,21 @@ jobs:
         run: |
           export NODE_OPTIONS="--max-old-space-size=4096"
           yarn ci
+
+      - name: Build x64 Kernel - self contained, ready to run
+        working-directory: ./Source/Kernel/Server
+        run: dotnet publish -c Release -r linux-x64 -p:PublishReadyToRun=true --self-contained -o out/x64
+
+      - name: Build arm64 Kernel - self contained, ready to run
+        working-directory: ./Source/Kernel/Server
+        run: dotnet publish -c Release -r linux-arm64 -p:PublishReadyToRun=true --self-contained -o out/arm64
+
+      - name: Build Workbench
+        working-directory: ./Source/Workbench
+        run: |
+          # Set network timeout manually as a workaround till we're on Yarn 2: https://github.com/yarnpkg/yarn/issues/8242#issuecomment-661881292
+          yarn config set network-timeout 300000
+          yarn build
 
       - name: Release
         id: release
@@ -96,19 +111,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build Workbench Image
-        uses: docker/build-push-action@v2
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          file: ./Docker/Workbench/Dockerfile
-          push: true
-          tags: |
-            aksioinsurtech/cratis:${{ steps.release.outputs.version }}-workbench
-            aksioinsurtech/cratis:latest-workbench
-          build-args: |
-            VERSION=${{ steps.release.outputs.version }}
-
       - name: Build Production Docker Image
         uses: docker/build-push-action@v2
         with:
@@ -122,12 +124,26 @@ jobs:
           build-args: |
             VERSION=${{ steps.release.outputs.version }}
 
+      - name: Build Workbench Image
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Docker/Workbench/Dockerfile
+          push: true
+          tags: |
+            aksioinsurtech/cratis:${{ steps.release.outputs.version }}-workbench
+            aksioinsurtech/cratis:latest-workbench
+          build-args: |
+            VERSION=${{ steps.release.outputs.version }}
+
       - name: Build MongoDB Docker Image
         uses: docker/build-push-action@v2
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Docker/MongoDB/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             aksioinsurtech/mongodb:${{ steps.release.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,4 @@ dist
 .eslintcache
 
 wwwroot
+out

--- a/Docker/Development/Dockerfile
+++ b/Docker/Development/Dockerfile
@@ -1,37 +1,12 @@
 # syntax=docker/dockerfile:1
-# Server Build
-ARG CONFIGURATION=Release
-ARG VERSION
-FROM mcr.microsoft.com/dotnet/sdk:6.0.101 AS server-build
-WORKDIR /build
-
-COPY .editorconfig .
-COPY global.json .
-COPY Directory.Build.props .
-COPY Versions.props .
-COPY ./Source ./Source
-
-WORKDIR /build/Source/Kernel/Server
-
-ADD Docker/build-server.sh .
-RUN chmod +x ./build-server.sh
-RUN ./build-server.sh
-
-# Workbench
-ARG VERSION
-FROM aksioinsurtech/cratis:$VERSION-workbench as workbench
 
 ####################################
 # Cratis Server
 # Build runtime image
 ####################################
-ARG CONFIGURATION=Release
 ARG VERSION
 FROM mcr.microsoft.com/dotnet/runtime:6.0.1-focal
 
-WORKDIR /app
-
-RUN echo Configuration = ${CONFIGURATION}
 RUN echo Version = ${VERSION}
 
 # Install MongoDB dependencies
@@ -66,16 +41,20 @@ VOLUME /data/db /data/configdb
 RUN curl -LJ https://github.com/krallin/tini/releases/download/v0.19.0/tini-$(dpkg --print-architecture) --output /usr/bin/tini
 RUN chmod +x /usr/bin/tini
 
+WORKDIR /app
+
 # Create entrypoint that runs both MongoDB and Runtime
-COPY Docker/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+COPY Docker/entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+
+COPY Docker/copy-server-files.sh ./copy-server-files.sh
+RUN chmod +x ./copy-server-files.sh
+
+COPY ./Source/Kernel/Server/out ./out
+COPY ./Source/Workbench/wwwroot wwwroot
+
+RUN echo $PWD
+RUN ./copy-server-files.sh
 
 EXPOSE 80 11111 30000
-
-COPY --from=server-build /build/Source/Kernel/Server/out/*.dll .
-COPY --from=server-build /build/Source/Kernel/Server/out/*.json .
-COPY --from=server-build /build/Source/Kernel/Server/out/*.so .
-COPY --from=server-build /build/Source/Kernel/Server/out/Aksio.Cratis.Server .
-COPY --from=workbench /usr/share/nginx/html wwwroot
-
 ENTRYPOINT ["/usr/bin/tini", "--", "/bin/bash", "/app/entrypoint.sh"]

--- a/Docker/Production/Dockerfile
+++ b/Docker/Production/Dockerfile
@@ -1,25 +1,4 @@
 # syntax=docker/dockerfile:1
-# Server Build
-ARG CONFIGURATION=Release
-ARG VERSION
-FROM mcr.microsoft.com/dotnet/sdk:6.0.101 AS server-build
-WORKDIR /build
-
-COPY .editorconfig .
-COPY global.json .
-COPY Directory.Build.props .
-COPY Versions.props .
-COPY ./Source ./Source
-
-WORKDIR /build/Source/Kernel/Server
-
-ADD Docker/build-server.sh .
-RUN chmod +x ./build-server.sh
-RUN ./build-server.sh
-
-# Workbench
-ARG VERSION
-FROM aksioinsurtech/cratis:$VERSION-workbench as workbench
 
 ####################################
 # Cratis Server
@@ -36,10 +15,10 @@ RUN echo Version = ${VERSION}
 
 EXPOSE 80 11111 30000
 
-COPY --from=server-build /build/Source/Kernel/Server/out/*.dll .
-COPY --from=server-build /build/Source/Kernel/Server/out/*.json .
-COPY --from=server-build /build/Source/Kernel/Server/out/*.so .
-COPY --from=server-build /build/Source/Kernel/Server/out/Aksio.Cratis.Server .
-COPY --from=workbench /usr/share/nginx/html wwwroot
+COPY ./Source/Kernel/Server/out/x64/*.dll .
+COPY ./Source/Kernel/Server/out/x64/*.json .
+COPY ./Source/Kernel/Server/out/x64/*.so .
+COPY ./Source/Kernel/Server/out/x64/Aksio.Cratis.Server .
+COPY ./Source/Workbench/wwwroot wwwroot
 
 ENTRYPOINT ["./Aksio.Cratis.Server"]

--- a/Docker/Workbench/Dockerfile
+++ b/Docker/Workbench/Dockerfile
@@ -1,29 +1,6 @@
 # syntax=docker/dockerfile:1
-# Build
-FROM node:16 AS build
-ARG VERSION=1.0.0
-WORKDIR /build
-
-COPY .editorconfig .
-COPY .eslintrc.js .
-COPY .prettierrc .
-COPY .mocharc.js .
-COPY package.json .
-COPY tsconfig.json .
-COPY ./Source/Node ./Source/Node
-COPY ./Source/ApplicationModel/Frontend ./Source/ApplicationModel/Frontend
-COPY ./Source/Workbench ./Source/Workbench
-
-WORKDIR /build/Source/Workbench
-
-# Set network timeout manually as a workaround till we're on Yarn 2: https://github.com/yarnpkg/yarn/issues/8242#issuecomment-661881292
-RUN yarn config set network-timeout 300000
-RUN yarn
-RUN yarn build
-
-# Server
 FROM nginx
 
 WORKDIR /app
 
-COPY --from=build /build/Source/Workbench/wwwroot /usr/share/nginx/html
+COPY ./Source/Workbench/wwwroot /usr/share/nginx/html

--- a/Docker/build-server.sh
+++ b/Docker/build-server.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-CPU=$(dpkg --print-architecture)
-if [ $CPU == "amd64" ]; then
-    PID="linux-x64"
-else
-    PID="linux-arm64"
-fi
-
-dotnet publish -c Release -r $PID -p:PublishReadyToRun=true --self-contained -o out

--- a/Docker/copy-server-files.sh
+++ b/Docker/copy-server-files.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+CPU=$(dpkg --print-architecture)
+if [ $CPU == "amd64" ]; then
+    ARCH_FOLDER="x64"
+else
+    ARCH_FOLDER="arm64"
+fi
+
+cp ./out/$ARCH_FOLDER/*.dll .
+cp ./out/$ARCH_FOLDER/*.json .
+cp ./out/$ARCH_FOLDER/*.so .
+cp ./out/$ARCH_FOLDER/Aksio.Cratis.Server .
+rm -rf ./out

--- a/dockerize.sh
+++ b/dockerize.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Build .NET Server
+pushd .
+cd ./Source/Kernel/Server
+dotnet publish -c Release -r linux-x64 -p:PublishReadyToRun=true --self-contained -o out/x64
+dotnet publish -c Release -r linux-arm64 -p:PublishReadyToRun=true --self-contained -o out/arm64
+popd
+
+# Build Workbench
+pushd .
+cd ./Source/Workbench
+yarn config set network-timeout 300000
+yarn build
+popd
+
+# Build images
+docker build -t aksioinsurtech/cratis -f ./Docker/Production/Dockerfile .
+docker build -t aksioinsurtech/cratis:development -f ./Docker/Development/Dockerfile .
+
+# For building multiple CPU architectures (PS: this automatically pushes to Docker Hub):
+# docker buildx build -t aksioinsurtech/cratis:development -f ./Docker/Development/Dockerfile --platform linux/amd64,linux/arm64 --push .

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "6.0.100",
+      "version": "6.0.102",
       "rollForward": "latestFeature"
     }
   }


### PR DESCRIPTION
### Fixed

- Publish GitHub Actions workflow was very slow due to the multiple architecture build of the development image. This is now improved by doing the build of the binaries outside of Docker and then just copying these into the image. (#115).
