### PR TITLE
Changing order of Dev image before Mongo and allowing Mongo to fail

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -148,18 +148,3 @@ jobs:
             aksioinsurtech/cratis:latest-development
           build-args: |
             VERSION=${{ steps.release.outputs.version }}
-
-      - name: Build MongoDB Docker Image
-        continue-on-error: true
-        uses: docker/build-push-action@v2
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          file: ./Docker/MongoDB/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            aksioinsurtech/mongodb:${{ steps.release.outputs.version }}
-            aksioinsurtech/mongodb:latest
-          build-args: |
-            VERSION=${{ steps.release.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,20 +135,6 @@ jobs:
           build-args: |
             VERSION=${{ steps.release.outputs.version }}
 
-      - name: Build MongoDB Docker Image
-        uses: docker/build-push-action@v2
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          file: ./Docker/MongoDB/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            aksioinsurtech/mongodb:${{ steps.release.outputs.version }}
-            aksioinsurtech/mongodb:latest
-          build-args: |
-            VERSION=${{ steps.release.outputs.version }}
-
       - name: Build Development Docker Image
         uses: docker/build-push-action@v2
         with:
@@ -160,5 +146,20 @@ jobs:
           tags: |
             aksioinsurtech/cratis:${{ steps.release.outputs.version }}-development
             aksioinsurtech/cratis:latest-development
+          build-args: |
+            VERSION=${{ steps.release.outputs.version }}
+
+      - name: Build MongoDB Docker Image
+        continue-on-error: true
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Docker/MongoDB/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            aksioinsurtech/mongodb:${{ steps.release.outputs.version }}
+            aksioinsurtech/mongodb:latest
           build-args: |
             VERSION=${{ steps.release.outputs.version }}


### PR DESCRIPTION
### Fixed

- Removing the MongoDB image build from release workflow. If needed, we should move this to another repository. Right now in development we have the development image with MongoDB in it and configured correctly for single node cluster mode. 
