### PR TITLE
Fixing logging for MongoDB to avoid Serilog going into a stack overflow

### DIFF
--- a/Source/Extensions/MongoDB/MongoDBClientFactory.cs
+++ b/Source/Extensions/MongoDB/MongoDBClientFactory.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Json;
 using Aksio.Cratis.Execution;
 using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Core.Events;
 
@@ -28,8 +30,8 @@ namespace Aksio.Cratis.Extensions.MongoDB
             settings.ClusterConfigurator = builder =>
             {
                 builder
-                    .Subscribe<CommandStartedEvent>(command => _logger.CommandStarted(command.RequestId, command.CommandName, command.Command))
-                    .Subscribe<CommandFailedEvent>(command => _logger.CommandFailed(command.RequestId, command.CommandName, command.Failure))
+                    .Subscribe<CommandStartedEvent>(command => _logger.CommandStarted(command.RequestId, command.CommandName, Serialize(command.Command.ToJson())))
+                    .Subscribe<CommandFailedEvent>(command => _logger.CommandFailed(command.RequestId, command.CommandName, Serialize(command.Failure)))
                     .Subscribe<CommandSucceededEvent>(command => _logger.CommandSucceeded(command.RequestId, command.CommandName));
             };
 
@@ -42,5 +44,9 @@ namespace Aksio.Cratis.Extensions.MongoDB
 
         /// <inheritdoc/>
         public IMongoClient Create(string connectionString) => Create(MongoClientSettings.FromConnectionString(connectionString));
+
+        object Serialize(Exception exception) => Serialize(JsonSerializer.Serialize(exception));
+
+        object Serialize(string input) => (object)(JsonSerializer.Deserialize<dynamic>(input) ?? new { });
     }
 }

--- a/Source/Extensions/MongoDB/MongoDBClientFactoryLogMessages.cs
+++ b/Source/Extensions/MongoDB/MongoDBClientFactoryLogMessages.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Logging;
-using MongoDB.Bson;
 
 namespace Aksio.Cratis.Extensions.MongoDB
 {
@@ -12,10 +11,10 @@ namespace Aksio.Cratis.Extensions.MongoDB
     public static partial class MongoDBClientFactoryLogMessages
     {
         [LoggerMessage(0, LogLevel.Trace, "Command ({RequestId}) '{CommandName}' started with content {Command}.")]
-        public static partial void CommandStarted(this ILogger logger, int requestId, string commandName, BsonDocument command);
+        public static partial void CommandStarted(this ILogger logger, int requestId, string commandName, object command);
 
-        [LoggerMessage(1, LogLevel.Error, "Command ({RequestId}) '{CommandName}' failed.")]
-        public static partial void CommandFailed(this ILogger logger, int requestId, string commandName, Exception ex);
+        [LoggerMessage(1, LogLevel.Error, "Command ({RequestId}) '{CommandName}' failed with '{failure}'")]
+        public static partial void CommandFailed(this ILogger logger, int requestId, string commandName, object failure);
 
         [LoggerMessage(2, LogLevel.Trace, "Command ({RequestId}) '{CommandName}' succeeded.")]
         public static partial void CommandSucceeded(this ILogger logger, int requestId, string commandName);


### PR DESCRIPTION
### Fixed

- When logging MongoDB commands or failures, Serilog went into stack overflow trying to convert some of the MongoDB specific types. Fixing this by converting to JSON first and then into an object that gets passed into the logger.
