### PR TITLE
Compliance-manager-fix

### DIFF
--- a/Samples/Bank/Main/appsettings.Elastic.json
+++ b/Samples/Bank/Main/appsettings.Elastic.json
@@ -2,6 +2,7 @@
     "Serilog": {
         "Using": [
             "Serilog.Sinks.Console",
+            "Serilog.Sinks.Elasticsearch"
         ],
         "MinimumLevel": {
             "Default": "Verbose",
@@ -25,6 +26,14 @@
                 "Args": {
                     "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
                     "outputTemplate": "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}"
+                }
+            },
+            {
+                "Name": "Elasticsearch",
+                "Args": {
+                    "nodeUris": "http://localhost:9200",
+                    "indexFormat": "banksample-{0:yyyy.MM}",
+                    "emitEventFailure": "WriteToSelfLog"
                 }
             }
         ]

--- a/Source/Kernel/Compliance/Engine/JsonComplianceManager.cs
+++ b/Source/Kernel/Compliance/Engine/JsonComplianceManager.cs
@@ -48,7 +48,7 @@ namespace Aksio.Cratis.Compliance
             {
                 if (schema.Properties is not null && value is not null)
                 {
-                    var propertySchema = schema.Properties.Single(_ => _.Key == property).Value;
+                    var propertySchema = schema.ActualProperties.Single(_ => _.Key == property).Value;
                     foreach (var metadata in GetMetadata(propertySchema).Concat(complianceMetadataForContainer).DistinctBy(_ => _.metadataType))
                     {
                         if (_propertyValueHandlers.ContainsKey(metadata.metadataType))
@@ -59,7 +59,7 @@ namespace Aksio.Cratis.Compliance
 
                     if (value is JsonObject jsonObjectValue)
                     {
-                        await HandleActionFor(propertySchema, identifier, jsonObjectValue, action);
+                        await HandleActionFor(propertySchema.ActualSchema, identifier, jsonObjectValue, action);
                     }
                 }
             }

--- a/Source/Kernel/Server/appsettings.Development.json
+++ b/Source/Kernel/Server/appsettings.Development.json
@@ -1,14 +1,32 @@
 {
     "Serilog": {
+        "Using": [
+            "Serilog.Sinks.Console"
+        ],
         "MinimumLevel": {
             "Default": "Verbose",
             "Override": {
+                "Aksio": "Information",
                 "Microsoft": "Warning",
                 "Microsoft.Hosting.Lifetime": "Information",
                 "System": "Warning",
                 "Orleans": "Information"
             }
-        }
+        },
+        "Enrich": [
+            "FromLogContext",
+            "WithMachineName",
+            "WithThreadId"
+        ],
+        "WriteTo": [
+            {
+                "Name": "Console",
+                "Args": {
+                    "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
+                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}"
+                }
+            }
+        ]
     },
     "AllowedHosts": "*"
 }

--- a/Source/Kernel/Server/appsettings.json
+++ b/Source/Kernel/Server/appsettings.json
@@ -6,6 +6,7 @@
         "MinimumLevel": {
             "Default": "Verbose",
             "Override": {
+                "Aksio": "Information",
                 "Microsoft": "Warning",
                 "Microsoft.Hosting.Lifetime": "Information",
                 "System": "Warning",


### PR DESCRIPTION
### Fixed

- Fixing a bug when recursively applying compliance for events for complex structures. NJsonSchema has properties that are prefixed **Actual** which point to resolved versions for type references.
