### PR TITLE
Fixing so that we resolve the entire property path for all projection property operations

### DIFF
--- a/Source/Clients/DotNET/Events/Projections/FromBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/FromBuilder.cs
@@ -35,7 +35,7 @@ namespace Aksio.Cratis.Events.Projections
         /// <inheritdoc/>
         public IAddBuilder<TModel, TEvent, TProperty> Add<TProperty>(Expression<Func<TModel, TProperty>> modelPropertyAccessor)
         {
-            var addBuilder = new AddBuilder<TModel, TEvent, TProperty>(this, modelPropertyAccessor.GetPropertyInfo().Name);
+            var addBuilder = new AddBuilder<TModel, TEvent, TProperty>(this, modelPropertyAccessor.GetPropertyPath());
             _propertyExpressions.Add(addBuilder);
             return addBuilder;
         }
@@ -43,7 +43,7 @@ namespace Aksio.Cratis.Events.Projections
         /// <inheritdoc/>
         public ISubtractBuilder<TModel, TEvent, TProperty> Subtract<TProperty>(Expression<Func<TModel, TProperty>> modelPropertyAccessor)
         {
-            var subtractBuilder = new SubtractBuilder<TModel, TEvent, TProperty>(this, modelPropertyAccessor.GetPropertyInfo().Name);
+            var subtractBuilder = new SubtractBuilder<TModel, TEvent, TProperty>(this, modelPropertyAccessor.GetPropertyPath());
             _propertyExpressions.Add(subtractBuilder);
             return subtractBuilder;
         }
@@ -51,7 +51,7 @@ namespace Aksio.Cratis.Events.Projections
         /// <inheritdoc/>
         public ISetBuilder<TModel, TEvent, TProperty> Set<TProperty>(Expression<Func<TModel, TProperty>> modelPropertyAccessor)
         {
-            var setBuilder = new SetBuilder<TModel, TEvent, TProperty>(this, modelPropertyAccessor.GetPropertyInfo().Name);
+            var setBuilder = new SetBuilder<TModel, TEvent, TProperty>(this, modelPropertyAccessor.GetPropertyPath());
             _propertyExpressions.Add(setBuilder);
             return setBuilder;
         }

--- a/Source/Clients/DotNET/Events/Projections/SetBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/SetBuilder.cs
@@ -35,7 +35,7 @@ namespace Aksio.Cratis.Events.Projections
         /// <inheritdoc/>
         public IFromBuilder<TModel, TEvent> To(Expression<Func<TEvent, TProperty>> eventPropertyAccessor)
         {
-            _expression = eventPropertyAccessor.GetPropertyInfo().Name;
+            _expression = eventPropertyAccessor.GetPropertyPath();
             return _parent;
         }
 


### PR DESCRIPTION
### Fixed

- Client was using the last name of the property when setting up properties for projection causing nested structures in both read models and events to be wrong. This is now fixed and it creates a fully qualified `PropertyPath`.
