### PR TITLE
Fixing child relations to use property paths

### DIFF
--- a/Source/Clients/DotNET/Events/Projections/ChildrenBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/ChildrenBuilder.cs
@@ -53,7 +53,7 @@ namespace Aksio.Cratis.Events.Projections
         /// <inheritdoc/>
         public IChildrenBuilder<TParentModel, TChildModel> IdentifiedBy<TProperty>(Expression<Func<TChildModel, TProperty>> propertyExpression)
         {
-            _identifiedBy = propertyExpression.GetPropertyInfo().Name.ToCamelCase();
+            _identifiedBy = propertyExpression.GetPropertyPath();
             return this;
         }
 
@@ -69,7 +69,7 @@ namespace Aksio.Cratis.Events.Projections
         {
             var builder = new ChildrenBuilder<TChildModel, TNestedChildModel>(_eventTypes, _schemaGenerator);
             builderCallback(builder);
-            _childrenDefinitions[targetProperty.GetPropertyInfo().Name.ToCamelCase()] = builder.Build();
+            _childrenDefinitions[targetProperty.GetPropertyPath()] = builder.Build();
             return this;
         }
 

--- a/Source/Clients/DotNET/Events/Projections/ProjectionBuilderFor.cs
+++ b/Source/Clients/DotNET/Events/Projections/ProjectionBuilderFor.cs
@@ -100,7 +100,7 @@ namespace Aksio.Cratis.Events.Projections
         {
             var builder = new ChildrenBuilder<TModel, TChildModel>(_eventTypes, _schemaGenerator);
             builderCallback(builder);
-            _childrenDefinitions[targetProperty.GetPropertyInfo().Name.ToCamelCase()] = builder.Build();
+            _childrenDefinitions[targetProperty.GetPropertyPath()] = builder.Build();
             return this;
         }
 


### PR DESCRIPTION
### Fixed

- Child relationships are now using PropertyPath for nested objects in the Client definition, not just the name of the last property in the chain.
