### PR TITLE
Adding explicit version dependency to fix downgrade errors

### DIFF
--- a/Source/Extensions/Orleans/Orleans.csproj
+++ b/Source/Extensions/Orleans/Orleans.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="$(Orleans)" />
         <PackageReference Include="Microsoft.Orleans.Clustering.AdoNet" Version="$(Orleans)" />
         <PackageReference Include="System.Data.SqlClient" Version="$(SqlDataClient)" />
+        <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Added

- Configuration of cluster options supporting local, Azure Storage and ADO.NET for now. All done through a new `cluster.json` file. If the file is missing, localhost clustering is assumed for development purposes.
- Adding a way to resolve configuration values that differ in type / implementation. See the docs for more details.
