### PR TITLE
Add support for Date type for proxy generated types

### DIFF
--- a/Source/ApplicationModel/Tooling/ProxyGenerator/Syntax/TypeSymbolExtensions.cs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/Syntax/TypeSymbolExtensions.cs
@@ -27,8 +27,8 @@ namespace Aksio.Cratis.Applications.ProxyGenerator.Syntax
             { typeof(ulong).FullName!, new("number") },
             { typeof(float).FullName!, new("number") },
             { typeof(double).FullName!, new("number") },
-            { typeof(DateTime).FullName!, new("string") },
-            { typeof(DateTimeOffset).FullName!, new("string") },
+            { typeof(DateTime).FullName!, new("Date") },
+            { typeof(DateTimeOffset).FullName!, new("Date") },
             { typeof(Guid).FullName!, new("string") },
             { "System.Text.Json.JsonDocument", new("string") }
         };


### PR DESCRIPTION
### Fixed

- Fixed type support in proxy generation. It was using `string` for C# types `DateTime`and `DateTimeOffset`, now it uses `Date`. 
