### PR TITLE
Fix-adhoc-projection

### DIFF
--- a/Source/Fundamentals/Dynamic/ExpandoObjectExtensions.cs
+++ b/Source/Fundamentals/Dynamic/ExpandoObjectExtensions.cs
@@ -65,6 +65,8 @@ namespace Aksio.Cratis.Dynamic
         /// <returns>A new <see cref="ExpandoObject"/> representing the given object.</returns>
         public static ExpandoObject AsExpandoObject(this object original)
         {
+            if (original is ExpandoObject) return (original as ExpandoObject)!;
+
             var expando = new ExpandoObject();
             var expandoAsDictionary = expando as IDictionary<string, object>;
 

--- a/Source/Kernel/Projections/Engine/Projection.cs
+++ b/Source/Kernel/Projections/Engine/Projection.cs
@@ -113,7 +113,7 @@ namespace Aksio.Cratis.Events.Projections
         public void SetEventTypesWithKeyResolvers(IEnumerable<EventTypeWithKeyResolver> eventTypesWithKeyResolver)
         {
             EventTypesWithKeyResolver = eventTypesWithKeyResolver;
-            EventTypes = eventTypesWithKeyResolver.Select(_ => _.EventType);
+            EventTypes = eventTypesWithKeyResolver.Select(_ => _.EventType).ToArray();
             _eventTypesToKeyResolver = eventTypesWithKeyResolver.ToDictionary(_ => _.EventType, _ => _.KeyResolver);
         }
 

--- a/Source/Kernel/Projections/Engine/ProjectionFactory.cs
+++ b/Source/Kernel/Projections/Engine/ProjectionFactory.cs
@@ -78,7 +78,7 @@ namespace Aksio.Cratis.Events.Projections
                 child.SetParent(projection);
                 eventsForProjection.AddRange(child.EventTypesWithKeyResolver);
             }
-            projection.SetEventTypesWithKeyResolvers(eventsForProjection.DistinctBy(_ => _.EventType));
+            projection.SetEventTypesWithKeyResolvers(eventsForProjection.DistinctBy(_ => _.EventType).ToArray());
 
             foreach (var (eventType, fromDefinition) in projectionDefinition.From)
             {

--- a/Source/Kernel/Projections/Grains/Projection.cs
+++ b/Source/Kernel/Projections/Grains/Projection.cs
@@ -8,7 +8,6 @@ using Aksio.Cratis.Changes;
 using Aksio.Cratis.Dynamic;
 using Aksio.Cratis.Events.Projections.Definitions;
 using Aksio.Cratis.Events.Store;
-using Aksio.Cratis.Properties;
 using Orleans;
 using EngineProjection = Aksio.Cratis.Events.Projections.IProjection;
 
@@ -22,25 +21,30 @@ namespace Aksio.Cratis.Events.Projections.Grains
         readonly IProjectionDefinitions _projectionDefinitions;
         readonly IProjectionFactory _projectionFactory;
         readonly IObjectsComparer _objectsComparer;
+        readonly IProjectionEventProviders _projectionEventProviders;
         readonly IEventLogStorageProvider _eventLogStorageProvider;
         EngineProjection? _projection;
+        IProjectionEventProvider? _projectionEventProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Projection"/> class.
         /// </summary>
         /// <param name="projectionDefinitions"><see cref="IProjectionDefinitions"/>.</param>
         /// <param name="projectionFactory"><see cref="IProjectionFactory"/> for creating engine projections.</param>
+        /// <param name="projectionEventProviders"><see cref="IProjectionEventProviders"/> in the system.</param>
         /// <param name="objectsComparer"><see cref="IObjectsComparer"/> to compare objects with.</param>
         /// <param name="eventLogStorageProvider"><see cref="IEventLogStorageProvider"/> for getting events from storage.</param>
         public Projection(
             IProjectionDefinitions projectionDefinitions,
             IProjectionFactory projectionFactory,
+            IProjectionEventProviders projectionEventProviders,
             IObjectsComparer objectsComparer,
             IEventLogStorageProvider eventLogStorageProvider)
         {
             _projectionDefinitions = projectionDefinitions;
             _projectionFactory = projectionFactory;
             _objectsComparer = objectsComparer;
+            _projectionEventProviders = projectionEventProviders;
             _eventLogStorageProvider = eventLogStorageProvider;
         }
 
@@ -50,6 +54,7 @@ namespace Aksio.Cratis.Events.Projections.Grains
             var projectionId = this.GetPrimaryKey();
             var definition = await _projectionDefinitions.GetFor(projectionId);
             _projection = await _projectionFactory.CreateFrom(definition);
+            _projectionEventProvider = _projectionEventProviders.GetForType("c0c0196f-57e3-4860-9e3b-9823cf45df30");
         }
 
         /// <inheritdoc/>
@@ -71,12 +76,25 @@ namespace Aksio.Cratis.Events.Projections.Grains
                 foreach (var @event in cursor.Current)
                 {
                     var changeset = new Changeset<AppendedEvent, ExpandoObject>(_objectsComparer, @event, state);
-                    var context = new ProjectionEventContext(new Key(@event.Context.EventSourceId, ArrayIndexers.NoIndexers), @event, changeset);
-                    _projection.OnNext(context);
+                    var keyResolver = _projection.GetKeyResolverFor(@event.Metadata.Type);
+                    var key = await keyResolver(_projectionEventProvider!, @event);
+                    var context = new ProjectionEventContext(key, @event, changeset);
+
+                    await HandleEventFor(_projection!, context);
 
                     foreach (var change in changeset.Changes)
                     {
-                        state = state.OverwriteWith((change.State as ExpandoObject)!);
+                        switch (change)
+                        {
+                            case PropertiesChanged<ExpandoObject> propertiesChanged:
+                                state = state.OverwriteWith((change.State as ExpandoObject)!);
+                                break;
+
+                            case ChildAdded childAdded:
+                                var items = state.EnsureCollection<ExpandoObject>(childAdded.ChildrenProperty, key.ArrayIndexers);
+                                items.Add(childAdded.Child.AsExpandoObject());
+                                break;
+                        }
                     }
                 }
             }
@@ -85,6 +103,19 @@ namespace Aksio.Cratis.Events.Projections.Grains
             var json = JsonSerializer.Serialize(state);
             var jsonObject = JsonNode.Parse(json)!;
             return (jsonObject as JsonObject)!;
+        }
+
+        async Task HandleEventFor(EngineProjection projection, ProjectionEventContext context)
+        {
+            if (projection.Accepts(context.Event.Metadata.Type))
+            {
+                projection.OnNext(context);
+            }
+
+            foreach (var child in projection.ChildProjections)
+            {
+                await HandleEventFor(child, context);
+            }
         }
     }
 }

--- a/Source/Node/FluentUI/package.json
+++ b/Source/Node/FluentUI/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@aksio/cratis-typescript": "1.0.0",
         "@fluentui/font-icons-mdl2": "8.1.20",
-        "@fluentui/react": "8.51.1",
+        "@fluentui/react": "8.49.5",
         "@fluentui/react-charting": "5.7.5",
         "@fluentui/react-hooks": "8.3.9",
         "@fluentui/react-icons": "1.1.145"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,28 @@
         "edit-json-file": "1.6.0",
         "glob": "7.2.0"
     },
+    "resolutions": {
+        "@fluentui/react": "8.49.5",
+        "@fluentui/foundation-legacy": "8.1.19",
+        "@fluentui/date-time-utilities": "8.2.3",
+        "@fluentui/theme": "2.4.6",
+        "@fluentui/style-utilities": "8.5.2",
+        "@fluentui/utilities": "8.3.9",
+        "@fluentui/react-charting": "5.7.5",
+        "@fluentui/react-focus": "8.3.15",
+        "@fluentui/react-hooks": "8.3.9"
+    },
+    "overrides": {
+        "@fluentui/react": "8.49.5",
+        "@fluentui/foundation-legacy": "8.1.19",
+        "@fluentui/date-time-utilities": "8.2.3",
+        "@fluentui/theme": "2.4.6",
+        "@fluentui/style-utilities": "8.5.2",
+        "@fluentui/utilities": "8.3.9",
+        "@fluentui/react-charting": "5.7.5",
+        "@fluentui/react-focus": "8.3.15",
+        "@fluentui/react-hooks": "8.3.9"
+    },
     "license": "MIT",
     "version": "0.0.0"
 }


### PR DESCRIPTION
### Fixed

- Fixing order of precedence for config files (#201).
- Fixing `GetModelInstanceById()`of the Projection Grain to be in line with how the `ProjectionPipelineHandler`handles events. This rises technical debt for later; #205.