### PR TITLE
Returning correct type for nullables

### DIFF
--- a/Source/ApplicationModel/Tooling/ProxyGenerator/Syntax/TypeSymbolExtensions.cs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/Syntax/TypeSymbolExtensions.cs
@@ -176,6 +176,11 @@ namespace Aksio.Cratis.Applications.ProxyGenerator.Syntax
                 symbol = arrayTypeSymbol.ElementType;
             }
 
+            if (symbol.Name.Equals("Nullable", StringComparison.InvariantCulture) && symbol is INamedTypeSymbol namedTypeSymbol)
+            {
+                symbol = namedTypeSymbol.TypeArguments[0];
+            }
+
             return $"{symbol.ContainingNamespace.ToDisplayString()}.{symbol.Name}";
         }
     }


### PR DESCRIPTION
### Fixed

- Proxy generator now returns the correct underlying type for nullables and not `Nullable`.
