### PR TITLE
Event-spec-api-fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,7 @@
         "Expando",
         "fluentui",
         "Grpc",
+        "inheritdoc",
         "Insurtech",
         "IPII",
         "Namotion",
@@ -70,6 +71,7 @@
         "Proto",
         "protobuf",
         "tinycolor",
+        "typeparam",
         "upserted"
     ]
 }

--- a/Samples/Bank/GlobalUsings.Specs.cs
+++ b/Samples/Bank/GlobalUsings.Specs.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable CS8019
 
+global using Aksio.Cratis.Specifications;
 global using Aksio.Specifications;
 global using Moq;
 global using Xunit;

--- a/Samples/Bank/Integration.Specs/AccountHolders/for_AccountHolderDetailsAdapter/when_importing_for_the_second_time_without_changes.cs
+++ b/Samples/Bank/Integration.Specs/AccountHolders/for_AccountHolderDetailsAdapter/when_importing_for_the_second_time_without_changes.cs
@@ -15,5 +15,5 @@ public class when_importing_for_the_second_time_without_changes : given.object_r
 
     Task Because() => context.Import(object_to_import);
 
-    [Fact] void should_not_append_any_events() => context.ShouldNotAppendEvents();
+    [Fact] void should_not_append_any_events() => context.ShouldNotAppendEventsDuringImport();
 }

--- a/Source/Extensions/Specifications/AppendedEventForSpecifications.cs
+++ b/Source/Extensions/Specifications/AppendedEventForSpecifications.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Aksio.Cratis.Events.Store;
+
+namespace Aksio.Cratis.Specifications;
+
+/// <summary>
+/// Represents a specialized version of <see cref="AppendedEvent"/> used in specifications.
+/// </summary>
+/// <param name="Metadata">The <see cref="EventMetadata"/>.</param>
+/// <param name="Context">The <see cref="EventContext"/>.</param>
+/// <param name="Content">The content in the form of JSON.</param>
+/// <param name="ActualEvent">The actual original event committed.</param>
+public record AppendedEventForSpecifications(
+    EventMetadata Metadata,
+    EventContext Context,
+    JsonObject Content,
+    object ActualEvent) : AppendedEvent(Metadata, Context, Content);

--- a/Source/Extensions/Specifications/EventLogForSpecifications.cs
+++ b/Source/Extensions/Specifications/EventLogForSpecifications.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection;
 using Aksio.Cratis.Events;
-using Aksio.Cratis.Events.Store;
 using Aksio.Cratis.Execution;
 
 namespace Aksio.Cratis.Specifications;
@@ -14,20 +13,13 @@ namespace Aksio.Cratis.Specifications;
 public class EventLogForSpecifications : IEventLog
 {
     static readonly IEventSerializer _serializer = new EventSerializer();
-    readonly List<AppendedEvent> _appendedEvents = new();
-    readonly List<object> _actualEvents = new();
-
+    readonly List<AppendedEventForSpecifications> _appendedEvents = new();
     EventSequenceNumber _sequenceNumber = EventSequenceNumber.First;
 
     /// <summary>
     /// Gets the appended events.
     /// </summary>
-    public IEnumerable<AppendedEvent> AppendedEvents => _appendedEvents;
-
-    /// <summary>
-    /// Gets the actual events that was appended.
-    /// </summary>
-    public IEnumerable<object> ActualEvents => _actualEvents;
+    public IEnumerable<AppendedEventForSpecifications> AppendedEvents => _appendedEvents;
 
     /// <inheritdoc/>
     public Task Append(EventSourceId eventSourceId, object @event, DateTimeOffset? validFrom = null)
@@ -45,8 +37,8 @@ public class EventLogForSpecifications : IEventLog
                 CorrelationId.New(),
                 CausationId.System,
                 CausedBy.System),
-            json));
-        _actualEvents.Add(@event);
+            json,
+            @event));
         _sequenceNumber++;
         return Task.CompletedTask;
     }

--- a/Source/Extensions/Specifications/EventSequenceStorageProviderForSpecifications.cs
+++ b/Source/Extensions/Specifications/EventSequenceStorageProviderForSpecifications.cs
@@ -46,7 +46,7 @@ public class EventSequenceStorageProviderForSpecifications : IEventSequenceStora
     public Task<AppendedEvent> GetLastInstanceFor(EventTypeId eventTypeId, EventSourceId eventSourceId)
     {
         var lastInstance = _eventLog.AppendedEvents.Where(_ => _.Metadata.Type.Id == eventTypeId && _.Context.EventSourceId == eventSourceId).OrderByDescending(_ => _.Metadata.SequenceNumber).First();
-        return Task.FromResult(lastInstance);
+        return Task.FromResult(new AppendedEvent(lastInstance.Metadata, lastInstance.Context, lastInstance.Content));
     }
 
     /// <inheritdoc/>

--- a/Source/Extensions/Specifications/IHaveEventLog.cs
+++ b/Source/Extensions/Specifications/IHaveEventLog.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Events;
+
+namespace Aksio.Cratis.Specifications;
+
+/// <summary>
+/// Defines a system for specifications that has an event log.
+/// </summary>
+public interface IHaveEventLog
+{
+    /// <summary>
+    /// Gets the <see cref="IEventLog"/>.
+    /// </summary>
+    IEventLog EventLog { get; }
+
+    /// <summary>
+    /// Gets the collection of <see cref="AppendedEventForSpecifications"/>.
+    /// </summary>
+    IEnumerable<AppendedEventForSpecifications> AppendedEvents { get; }
+}

--- a/Source/Extensions/Specifications/Integration/ShouldEventLogExtensions.cs
+++ b/Source/Extensions/Specifications/Integration/ShouldEventLogExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Specifications;
+
+namespace Aksio.Cratis.Specifications.Integration;
+
+/// <summary>
+/// Holds extension methods for fluent "Should*" assertions related to <see cref="IHaveEventLog"/>.
+/// </summary>
+public static class ShouldEventLogExtensions
+{
+    /// <summary>
+    /// Assert that a set events are appended.
+    /// </summary>
+    /// <param name="eventLog">The <see cref="IHaveEventLog"/> the assertion is for.</param>
+    /// <param name="events">Events to verify.</param>
+    public static void ShouldAppendEvents(this IHaveEventLog eventLog, params object[] events) => eventLog.AppendedEvents.Select(_ => _.ActualEvent).ShouldContain(events);
+
+    /// <summary>
+    /// Assert that a set events are the only ones being appended.
+    /// </summary>
+    /// <param name="eventLog">The <see cref="IHaveEventLog"/> the assertion is for.</param>
+    /// <param name="events">Events to verify.</param>
+    public static void ShouldOnlyAppendEvents(this IHaveEventLog eventLog, params object[] events) => eventLog.AppendedEvents.Select(_ => _.ActualEvent).ShouldContainOnly(events);
+
+    /// <summary>
+    /// Assert that there has not been appended any events.
+    /// </summary>
+    /// <param name="eventLog">The <see cref="IHaveEventLog"/> the assertion is for.</param>
+    public static void ShouldNotAppendEvents(this IHaveEventLog eventLog) => eventLog.AppendedEvents.ShouldBeEmpty();
+}

--- a/Source/Extensions/Specifications/Integration/ShouldEventLogExtensions.cs
+++ b/Source/Extensions/Specifications/Integration/ShouldEventLogExtensions.cs
@@ -3,7 +3,7 @@
 
 using Aksio.Specifications;
 
-namespace Aksio.Cratis.Specifications.Integration;
+namespace Aksio.Cratis.Specifications;
 
 /// <summary>
 /// Holds extension methods for fluent "Should*" assertions related to <see cref="IHaveEventLog"/>.

--- a/Source/Extensions/Specifications/Projections/ProjectionSpecificationContext.cs
+++ b/Source/Extensions/Specifications/Projections/ProjectionSpecificationContext.cs
@@ -22,7 +22,7 @@ namespace Aksio.Cratis.Specifications.Integration;
 /// Represents the context for specifications for a projection.
 /// </summary>
 /// <typeparam name="TModel">Type of target model the projection is for.</typeparam>
-public class ProjectionSpecificationContext<TModel> : IDisposable
+public class ProjectionSpecificationContext<TModel> : IHaveEventLog, IDisposable
 {
     internal readonly EventLogForSpecifications _eventLog = new();
     readonly JsonSerializerOptions _serializerOptions = new()
@@ -34,10 +34,11 @@ public class ProjectionSpecificationContext<TModel> : IDisposable
                 }
     };
 
-    /// <summary>
-    /// Gets the <see cref="IEventLog"/>.
-    /// </summary>
+    /// <inheritdoc/>
     public IEventLog EventLog => _eventLog;
+
+    /// <inheritdoc/>
+    public IEnumerable<AppendedEventForSpecifications> AppendedEvents => _eventLog.AppendedEvents;
 
     readonly IProjection _projection;
     readonly IEventSequenceStorageProvider _eventSequenceStorageProvider;


### PR DESCRIPTION
### Changed

- For asserting if that events are not added during import one should now use `ShouldNotAppendEventsDuringImport()`.

### Fixed

- More flexibility around how to write custom assertions. `IHaveEventLog` is an interface implemented by `AdpaterSpecificationContext<,>` and `ProjectionSpecificationContext<>` holding the actual appended events. (Fixes #297)
- Moved assertions into general extension methods that can be used for anything implementing `IHaveEventLog`.