### PR TITLE
Fixing typo in hostName - should be hostname

### DIFF
--- a/Source/Kernel/Server/ClusterConfigurationExtensions.cs
+++ b/Source/Kernel/Server/ClusterConfigurationExtensions.cs
@@ -41,7 +41,7 @@ public static class ClusterConfigurationExtensions
             else
             {
                 builder.ConfigureEndpoints(
-                    hostName: clusterConfig.SiloHostName,
+                    hostname: clusterConfig.SiloHostName,
                     siloPort: clusterConfig.SiloPort,
                     gatewayPort: clusterConfig.GatewayPort,
                     listenOnAnyHostAddress: true);


### PR DESCRIPTION
### Added

- Added support for specifying the silos hostname in the cluster configuration. When this is specified, it ignore the `AdvertisedIP` configuration.
