### PR TITLE
Azure-storage-options-fix

### DIFF
--- a/Documentation/fundamentals/configuration.md
+++ b/Documentation/fundamentals/configuration.md
@@ -185,8 +185,8 @@ public class ClusterOptionsValueResolver : IConfigurationValueResolver
         return configuration.GetValue<string>("type") switch
         {
             ClusterTypes.Static => new StaticClusterOptions(),
-            ClusterTypes.AdoNet => new AdoNetClusteringSiloOptions(),
-            ClusterTypes.AzureStorage => new AzureStorageClusteringOptions(),
+            ClusterTypes.AdoNet => new AdoNetClusterOptions(),
+            ClusterTypes.AzureStorage => new AzureStorageClusterOptions(),
             _ => null!
         };
     }

--- a/Source/Clients/DotNET/Orleans/ClusterConfigurationExtensions.cs
+++ b/Source/Clients/DotNET/Orleans/ClusterConfigurationExtensions.cs
@@ -51,7 +51,7 @@ public static class ClusterConfigurationExtensions
             case ClusterTypes.AdoNet:
                 {
                     logger?.UsingAdoNetClustering();
-                    var adoNetOptions = clusterConfig.GetAdoNetClusteringSiloOptions();
+                    var adoNetOptions = clusterConfig.GetAdoNetClusterOptions();
                     builder.UseAdoNetClustering(options =>
                     {
                         options.ConnectionString = adoNetOptions.ConnectionString;
@@ -63,7 +63,7 @@ public static class ClusterConfigurationExtensions
             case ClusterTypes.AzureStorage:
                 {
                     logger?.UsingAzureStorageClustering();
-                    var azureOptions = clusterConfig.GetAzureStorageClusteringOptions();
+                    var azureOptions = clusterConfig.GetAzureStorageClusterOptions();
                     builder.UseAzureStorageClustering(options =>
                     {
                         options.ConfigureTableServiceClient(azureOptions.ConnectionString);

--- a/Source/Extensions/Orleans/Configuration/AdoNetClusterOptions.cs
+++ b/Source/Extensions/Orleans/Configuration/AdoNetClusterOptions.cs
@@ -4,17 +4,17 @@
 namespace Aksio.Cratis.Extensions.Orleans.Configuration;
 
 /// <summary>
-/// Represents cluster configuration for azure storage.
+/// Represents the options for the Azure Storage clustering.
 /// </summary>
-public class AzureStorageClusteringConfiguration
+public class AdoNetClusterOptions
 {
     /// <summary>
-    /// Gets the connection string.
+    /// Gets the connection string to use.
     /// </summary>
-    public string ConnectionString { get; init; } = string.Empty;
+    public string ConnectionString { get; init; } = string.Empty;
 
     /// <summary>
-    /// Gets the table name.
+    /// Gets the invariant name of the connector to use.
     /// </summary>
-    public string TableName { get; init; } = string.Empty;
+    public string Invariant { get; init; } = string.Empty;
 }

--- a/Source/Extensions/Orleans/Configuration/AzureStorageClusterOptions.cs
+++ b/Source/Extensions/Orleans/Configuration/AzureStorageClusterOptions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Orleans.Clustering.AzureStorage;
+
+namespace Aksio.Cratis.Extensions.Orleans.Configuration;
+
+/// <summary>
+/// Represents the options for the Azure Storage clustering.
+/// </summary>
+public class AzureStorageClusterOptions
+{
+    /// <summary>
+    /// Gets the connection string to use.
+    /// </summary>
+    public string ConnectionString { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the table name to use.
+    /// </summary>
+    public string TableName { get; init; } = AzureStorageClusteringOptions.DEFAULT_TABLE_NAME;
+}

--- a/Source/Extensions/Orleans/Configuration/ClusterConfigurationExtensions.cs
+++ b/Source/Extensions/Orleans/Configuration/ClusterConfigurationExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.Configuration;
 
 namespace Aksio.Cratis.Extensions.Orleans.Configuration;
 
@@ -29,16 +28,16 @@ public static class ClusterConfigurationExtensions
     public static StaticClusterOptions GetStaticClusterOptions(this Cluster clusterConfig) => clusterConfig.Options as StaticClusterOptions ?? new StaticClusterOptions();
 
     /// <summary>
-    /// Get specific <see cref="AdoNetClusteringSiloOptions"/> from the options of <see cref="Cluster"/>.
+    /// Get specific <see cref="AdoNetClusterOptions"/> from the options of <see cref="Cluster"/>.
     /// </summary>
     /// <param name="clusterConfig"><see cref="Cluster"/> to get from.</param>
-    /// <returns><see cref="AdoNetClusteringSiloOptions"/> instance.</returns>
-    public static AdoNetClusteringSiloOptions GetAdoNetClusteringSiloOptions(this Cluster clusterConfig) => clusterConfig.Options as AdoNetClusteringSiloOptions ?? new AdoNetClusteringSiloOptions();
+    /// <returns><see cref="AdoNetClusterOptions"/> instance.</returns>
+    public static AdoNetClusterOptions GetAdoNetClusterOptions(this Cluster clusterConfig) => clusterConfig.Options as AdoNetClusterOptions ?? new AdoNetClusterOptions();
 
     /// <summary>
-    /// Get specific <see cref="AzureStorageClusteringConfiguration"/> from the options of <see cref="Cluster"/>.
+    /// Get specific <see cref="AzureStorageClusterOptions"/> from the options of <see cref="Cluster"/>.
     /// </summary>
     /// <param name="clusterConfig"><see cref="Cluster"/> to get from.</param>
-    /// <returns><see cref="AzureStorageClusteringConfiguration"/> instance.</returns>
-    public static AzureStorageClusteringConfiguration GetAzureStorageClusteringOptions(this Cluster clusterConfig) => clusterConfig.Options as AzureStorageClusteringConfiguration ?? new AzureStorageClusteringConfiguration();
+    /// <returns><see cref="AzureStorageClusterOptions"/> instance.</returns>
+    public static AzureStorageClusterOptions GetAzureStorageClusterOptions(this Cluster clusterConfig) => clusterConfig.Options as AzureStorageClusterOptions ?? new AzureStorageClusterOptions();
 }

--- a/Source/Extensions/Orleans/Configuration/ClusterOptionsValueResolver.cs
+++ b/Source/Extensions/Orleans/Configuration/ClusterOptionsValueResolver.cs
@@ -3,8 +3,6 @@
 
 using Aksio.Cratis.Configuration;
 using Microsoft.Extensions.Configuration;
-using Orleans.Clustering.AzureStorage;
-using Orleans.Configuration;
 
 namespace Aksio.Cratis.Extensions.Orleans.Configuration;
 
@@ -19,8 +17,8 @@ public class ClusterOptionsValueResolver : IConfigurationValueResolver
         return configuration.GetValue<string>("type") switch
         {
             ClusterTypes.Static => new StaticClusterOptions(),
-            ClusterTypes.AdoNet => new AdoNetClusteringSiloOptions(),
-            ClusterTypes.AzureStorage => new AzureStorageClusteringOptions(),
+            ClusterTypes.AdoNet => new AdoNetClusterOptions(),
+            ClusterTypes.AzureStorage => new AzureStorageClusterOptions(),
             _ => null!
         };
     }

--- a/Source/Fundamentals/Configuration/ConfigurationHostBuilderExtensions.cs
+++ b/Source/Fundamentals/Configuration/ConfigurationHostBuilderExtensions.cs
@@ -89,7 +89,7 @@ public static class ConfigurationHostBuilderExtensions
 
             foreach (var searchPath in allSearchPaths)
             {
-                logger?.AddingConfigurationFile(configurationObjectType, fileName);
+                logger?.AddingConfigurationFile(configurationObjectType, fileName, searchPath);
                 var actualFile = Path.Combine(searchPath, fileName);
                 configurationBuilder.AddJsonFile(actualFile, true);
             }

--- a/Source/Fundamentals/Configuration/ConfigurationHostBuilderExtensionsLogMessages.cs
+++ b/Source/Fundamentals/Configuration/ConfigurationHostBuilderExtensionsLogMessages.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// </summary>
 public static partial class ConfigurationHostBuilderExtensionsLogMessages
 {
-    [LoggerMessage(0, LogLevel.Information, "Adding optional configuration file '{File}' for type '{Type}'")]
-    internal static partial void AddingConfigurationFile(this ILogger logger, Type type, string file);
+    [LoggerMessage(0, LogLevel.Information, "Adding optional configuration file '{File}' for type '{Type}' in path '{Path}'")]
+    internal static partial void AddingConfigurationFile(this ILogger logger, Type type, string file, string path);
 }

--- a/Source/Kernel/Server/ClusterConfigurationExtensions.cs
+++ b/Source/Kernel/Server/ClusterConfigurationExtensions.cs
@@ -60,7 +60,7 @@ public static class ClusterConfigurationExtensions
 
                 case ClusterTypes.AdoNet:
                     {
-                        var adoNetOptions = clusterConfig.GetAdoNetClusteringSiloOptions();
+                        var adoNetOptions = clusterConfig.GetAdoNetClusterOptions();
                         builder.UseAdoNetClustering(options =>
                         {
                             options.ConnectionString = adoNetOptions.ConnectionString;
@@ -71,7 +71,7 @@ public static class ClusterConfigurationExtensions
 
                 case ClusterTypes.AzureStorage:
                     {
-                        var azureOptions = clusterConfig.GetAzureStorageClusteringOptions();
+                        var azureOptions = clusterConfig.GetAzureStorageClusterOptions();
                         builder.UseAzureStorageClustering(options =>
                         {
                             options.ConfigureTableServiceClient(azureOptions.ConnectionString);


### PR DESCRIPTION
### Fixed

- Switching from using Orleans options types for cluster configuration to our own (Azure Storage and Ado Net). (Fixes #303).
