### PR TITLE
Putting back all .deps.json files and just leaving cratis.json out

### DIFF
--- a/Docker/Production/Dockerfile
+++ b/Docker/Production/Dockerfile
@@ -16,9 +16,11 @@ RUN echo Version = ${VERSION}
 EXPOSE 80 11111 30000
 
 COPY ./Source/Kernel/Server/out/x64/*.dll .
-COPY ./Source/Kernel/Server/out/x64/appsettings.json .
+COPY ./Source/Kernel/Server/out/x64/*.json .
 COPY ./Source/Kernel/Server/out/x64/*.so .
 COPY ./Source/Kernel/Server/out/x64/Aksio.Cratis.Server .
 COPY ./Source/Workbench/wwwroot wwwroot
+
+RUN rm ./cratis.json
 
 ENTRYPOINT ["./Aksio.Cratis.Server"]


### PR DESCRIPTION
### Fixed

- Production image in 6.1.9 is broken due to missing `.deps.json` files. These are now braught back and `cratis.json` which was the file we intended to remove is now explicitly removed from the image.
