### PR TITLE
Fixing a problem regarding parsing of DateTimeOffset

### DIFF
--- a/Documentation/fundamentals/concepts.md
+++ b/Documentation/fundamentals/concepts.md
@@ -40,6 +40,10 @@ public interface IPersons
 }
 ```
 
+> Note: It is important to note that anything that implements `ConceptAs<>` is assumed to be a wrapper for a primitive type only.
+> All serialization converters assume this and will fail if one puts more properties on it.
+> If one needs to represent complex types, you can do so without inheriting from `ConceptAs<>` and then have all its values be concepts instead.
+
 ## Implicit operators
 
 The `ConceptAs<>` base record has an implicit operator overload for converting from the formalized type to the underlying primitive type.

--- a/Source/Fundamentals/Concepts/ConceptFactory.cs
+++ b/Source/Fundamentals/Concepts/ConceptFactory.cs
@@ -53,7 +53,18 @@ public static class ConceptFactory
         }
         else if (genericArgumentType.IsDateTimeOffset())
         {
-            val = value ?? default(DateTimeOffset);
+            if (value is DateTimeOffset)
+            {
+                val = value;
+            }
+            else if (DateTimeOffset.TryParse(value.ToString(), out var dateTimeOffsetValue))
+            {
+                val = dateTimeOffsetValue;
+            }
+            else
+            {
+                val = default(DateTimeOffset);
+            }
         }
         else if (genericArgumentType.IsAPrimitiveType())
         {

--- a/Specifications/Fundamentals/Concepts/for_ConceptFactory/DateTimeOffsetConcept.cs
+++ b/Specifications/Fundamentals/Concepts/for_ConceptFactory/DateTimeOffsetConcept.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Concepts.for_ConceptFactory;
+
+public record DateTimeOffsetConcept(DateTimeOffset Value) : ConceptAs<DateTimeOffset>(Value);

--- a/Specifications/Fundamentals/Concepts/for_ConceptFactory/when_creating_instance_of_datetime_concept_with_value_as_string.cs
+++ b/Specifications/Fundamentals/Concepts/for_ConceptFactory/when_creating_instance_of_datetime_concept_with_value_as_string.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Concepts.for_ConceptFactory;
+
+public class when_creating_instance_of_datetime_concept_with_value_as_string : Specification
+{
+    DateTimeConcept result;
+    string now;
+
+    void Establish() => now = DateTime.Now.ToString();
+
+    void Because() => result = ConceptFactory.CreateConceptInstance(typeof(DateTimeConcept), now) as DateTimeConcept;
+
+    [Fact] void should_be_the_value_of_the_datetime() => result.Value.ToString().ShouldEqual(now);
+}

--- a/Specifications/Fundamentals/Concepts/for_ConceptFactory/when_creating_instance_of_datetimeoffset_concept_with_value_as_datetime.cs
+++ b/Specifications/Fundamentals/Concepts/for_ConceptFactory/when_creating_instance_of_datetimeoffset_concept_with_value_as_datetime.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Concepts.for_ConceptFactory;
+
+public class when_creating_instance_of_datetimeoffset_concept_with_value_as_datetime : Specification
+{
+    DateTimeOffsetConcept result;
+    DateTimeOffset now;
+
+    void Establish() => now = DateTimeOffset.Now;
+
+    void Because() => result = ConceptFactory.CreateConceptInstance(typeof(DateTimeOffsetConcept), now) as DateTimeOffsetConcept;
+
+    [Fact] void should_be_the_value_of_the_datetime() => result.Value.ShouldEqual(now);
+}

--- a/Specifications/Fundamentals/Concepts/for_ConceptFactory/when_creating_instance_of_datetimeoffset_concept_with_value_as_string.cs
+++ b/Specifications/Fundamentals/Concepts/for_ConceptFactory/when_creating_instance_of_datetimeoffset_concept_with_value_as_string.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Concepts.for_ConceptFactory;
+
+public class when_creating_instance_of_datetimeoffset_concept_with_value_as_string : Specification
+{
+    DateTimeOffsetConcept result;
+    string now;
+
+    void Establish() => now = DateTimeOffset.Now.ToString();
+
+    void Because() => result = ConceptFactory.CreateConceptInstance(typeof(DateTimeOffsetConcept), now) as DateTimeOffsetConcept;
+
+    [Fact] void should_be_the_value_of_the_datetime() => result.Value.ToString().ShouldEqual(now);
+}


### PR DESCRIPTION
### Fixed

- `ConceptFactory` now supports conversion from a string representation to `DateTimeOffset`. .NET does not support type conversion of this when using `Convert.ChangeType()`.
- Updated [documentation for concepts](./Documentation/fundamentals/concepts.md) regarding them representing a single value.
