### PR TITLE
Workbench-fixes

### DIFF
--- a/Source/Kernel/Store/Api/EventSequence.cs
+++ b/Source/Kernel/Store/Api/EventSequence.cs
@@ -85,7 +85,7 @@ public class EventSequence : Controller
     {
         var result = new List<AppendedEvent>();
         _executionContextManager.Establish(tenantId, CorrelationId.New(), microserviceId);
-        var cursor = await _eventSequenceStorageProviderProvider().GetFromSequenceNumber(EventSequenceId.Log, EventSequenceNumber.First);
+        var cursor = await _eventSequenceStorageProviderProvider().GetFromSequenceNumber(eventSequenceId, EventSequenceNumber.First);
         while (await cursor.MoveNext())
         {
             result.AddRange(cursor.Current);

--- a/Source/Workbench/events/store/EventSequences.tsx
+++ b/Source/Workbench/events/store/EventSequences.tsx
@@ -134,6 +134,14 @@ export const EventSequences = () => {
         }
     }, [selectedEventSequence, selectedMicroservice, selectedTenant]);
 
+    useEffect(() => {
+        if (selectedMicroservice) {
+            refreshEventTypes({
+                microserviceId: selectedMicroservice.id
+            });
+        }
+    }, [selectedMicroservice]);
+
     commandBarItems = [...commandBarItems, ...[
         // {
         //     key: 'timeline',

--- a/Source/Workbench/events/store/Observers.tsx
+++ b/Source/Workbench/events/store/Observers.tsx
@@ -43,7 +43,8 @@ const observerRunningStates: { [key: number]: string; } = {
 const observerTypes: { [key: number]: string; } = {
     0: 'Unknown',
     1: 'Client',
-    2: 'Projection'
+    2: 'Projection',
+    3: 'Inbox'
 };
 
 const columns: IColumn[] = [


### PR DESCRIPTION
### Fixed

- The Kernel REST API now honors the EventSequenceId in the `FindFor` query.
- Event sequence view in Workbench now refreshes the event types when selecting a microservice.
- Showing correct type for Inbox observer type in observer view.
