### PR TITLE
Assembly-exclusion

### DIFF
--- a/Documentation/fundamentals/types.md
+++ b/Documentation/fundamentals/types.md
@@ -14,9 +14,15 @@ the class called `Types` in the `Aksio.Cratis.Types` namespace. This implements 
 
 ## Assembly prefixes
 
-The constructor for `Types` supports taking an 'opt-in' filter for including assemblies in type discovery.
-This will make it possible to include more assemblies in addition to the default project referenced
-assemblies only. The strings you pass to it are considered prefixes, meaning that if you want to include
+By default the `Types` system will load all referenced project and package assemblies.
+You can exclude assemblies by using the static method called `Types.AddAssemblyPrefixesToExclude()`.
+This takes a `params` of strings of prefixes to assemblies to exclude.
+Out of the box, it will ignore things like `System`, `Microsoft`, `Newtonsoft`.
+
+On the flip side of this, the constructor for `Types` supports taking an explicit 'opt-in' filter for including assemblies
+in type discovery. This will make it possible to include more assemblies in addition.
+
+For both filters the strings you pass to it are considered prefixes, meaning that if you want to include
 a set of assemblies all starting with the same string, you simply put the common start.
 
 ```csharp
@@ -24,6 +30,8 @@ using Aksio.Cratis.Types;
 
 var types = new Types("Microsoft","SomeOther");
 ```
+
+> Note: When using the application model, it will exclude even more 3rd parties.
 
 ## Type Discovery
 

--- a/Source/Fundamentals/Types/Types.cs
+++ b/Source/Fundamentals/Types/Types.cs
@@ -16,7 +16,11 @@ public class Types : ITypes
         "System",
         "Microsoft",
         "Newtonsoft",
-        "runtimepack"
+        "runtimepack",
+        "mscorlib",
+        "netstandard",
+        "WindowsBase",
+        "Namotion"
     };
 
     readonly List<string> _assemblyPrefixesToInclude = new()

--- a/Source/Fundamentals/Types/Types.cs
+++ b/Source/Fundamentals/Types/Types.cs
@@ -15,7 +15,8 @@ public class Types : ITypes
     {
         "System",
         "Microsoft",
-        "Newtonsoft"
+        "Newtonsoft",
+        "runtimepack"
     };
 
     readonly List<string> _assemblyPrefixesToInclude = new()

--- a/Source/Fundamentals/Types/Types.cs
+++ b/Source/Fundamentals/Types/Types.cs
@@ -114,7 +114,18 @@ public class Types : ITypes
                             .Where(_ => _.RuntimeAssemblyGroups.Count > 0 &&
                                         (_assemblyPrefixesToInclude.Any(asm => _.Name.StartsWith(asm)) ||
                                         !_assemblyPrefixesToExclude.Any(asm => _.Name.StartsWith(asm))))
-                            .Select(_ => Assembly.Load(_.Name))
+                            .Select(_ =>
+                            {
+                                try
+                                {
+                                    return Assembly.Load(_.Name);
+                                }
+                                catch
+                                {
+                                    return null!;
+                                }
+                            })
+                            .Where(_ => _ is not null)
                             .Distinct()
                             .ToArray();
         _assemblies.AddRange(assemblies.Where(_ => !projectReferencedAssemblies.Any(p => p == _)).Select(_ => _));


### PR DESCRIPTION
### Fixed

- Kernel didn't start in docker due to it trying to explicitly load assemblies starting with `runtimepack`.
