### PR TITLE
Setting default MS for now to Guid.Empty

### DIFF
--- a/Samples/Banking/Bank/Main/Program.cs
+++ b/Samples/Banking/Bank/Main/Program.cs
@@ -4,7 +4,7 @@
 using Sample;
 
 var builder = Host.CreateDefaultBuilder()
-                    .UseAksio(microserviceId: "0e1219ec-7136-40d8-a6e6-99c05ba22a30")
+                    .UseAksio(microserviceId: "00000000-0000-0000-0000-000000000000")
                     .ConfigureWebHostDefaults(_ => _.UseStartup<Startup>());
 
 var app = builder.Build();

--- a/Samples/Banking/Bank/cratis.json
+++ b/Samples/Banking/Bank/cratis.json
@@ -5,7 +5,7 @@
         }
     },
     "microservices": {
-        "0e1219ec-7136-40d8-a6e6-99c05ba22a30": {
+        "00000000-0000-0000-0000-000000000000": {
             "name": "Bank"
         }
     },
@@ -23,7 +23,7 @@
             "connectionDetails": "mongodb://localhost:27017/cratis-shared"
         },
         "microservices": {
-            "0e1219ec-7136-40d8-a6e6-99c05ba22a30": {
+            "00000000-0000-0000-0000-000000000000": {
                 "shared": {
                     "eventStore": {
                         "type": "MongoDB",

--- a/Samples/Banking/cratis.json
+++ b/Samples/Banking/cratis.json
@@ -11,7 +11,7 @@
         }
     },
     "microservices": {
-        "0e1219ec-7136-40d8-a6e6-99c05ba22a30": {
+        "00000000-0000-0000-0000-000000000000": {
             "name": "Bank"
         },
         "40dda9cf-38cc-4bf5-a249-ba3ce4f8861f": {
@@ -19,7 +19,7 @@
             "inbox": {
                 "fromOutboxes": [
                     {
-                        "microservice": "0e1219ec-7136-40d8-a6e6-99c05ba22a30"
+                        "microservice": "00000000-0000-0000-0000-000000000000"
                     }
                 ]
             }
@@ -39,7 +39,7 @@
             "connectionDetails": "mongodb://localhost:27017/cratis-shared"
         },
         "microservices": {
-            "0e1219ec-7136-40d8-a6e6-99c05ba22a30": {
+            "00000000-0000-0000-0000-000000000000": {
                 "shared": {
                     "eventStore": {
                         "type": "MongoDB",

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Main/Program.cs
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Main/Program.cs
@@ -4,7 +4,7 @@
 using Sample;
 
 var builder = Host.CreateDefaultBuilder()
-                    .UseAksio(microserviceId: "0e1219ec-7136-40d8-a6e6-99c05ba22a30")
+                    .UseAksio(microserviceId: "00000000-0000-0000-0000-000000000000")
                     .ConfigureWebHostDefaults(_ => _.UseStartup<Startup>());
 
 var app = builder.Build();

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/cratis.json
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/cratis.json
@@ -5,7 +5,7 @@
         }
     },
     "microservices": {
-        "0e1219ec-7136-40d8-a6e6-99c05ba22a30": {
+        "00000000-0000-0000-0000-000000000000": {
             "name": "Bank"
         }
     },
@@ -23,7 +23,7 @@
             "connectionDetails": "mongodb://localhost:27017/cratis-shared"
         },
         "microservices": {
-            "0e1219ec-7136-40d8-a6e6-99c05ba22a30": {
+            "00000000-0000-0000-0000-000000000000": {
                 "shared": {
                     "eventStore": {
                         "type": "MongoDB",

--- a/Source/Kernel/Server/cratis.json
+++ b/Source/Kernel/Server/cratis.json
@@ -5,7 +5,7 @@
         }
     },
     "microservices": {
-        "0e1219ec-7136-40d8-a6e6-99c05ba22a30": {
+        "00000000-0000-0000-0000-000000000000": {
             "name": "Bank"
         }
     },
@@ -23,7 +23,7 @@
             "connectionDetails": "mongodb://localhost:27017/cratis-shared"
         },
         "microservices": {
-            "0e1219ec-7136-40d8-a6e6-99c05ba22a30": {
+            "00000000-0000-0000-0000-000000000000": {
                 "shared": {
                     "eventStore": {
                         "type": "MongoDB",


### PR DESCRIPTION
### Fixed

- Changing to Bank microservice having the `Guid.Empty()` identifier. Since this is the default identifier if none is specified, the Kernel will work for all that has this not set. In a future version we will don't care about this type of configuration and let the connecting client tell which Microservice it is.
