### PR TITLE
Fix/272-eventcursor-continuation

### DIFF
--- a/Source/Kernel/Store/MongoDB/EventCursor.cs
+++ b/Source/Kernel/Store/MongoDB/EventCursor.cs
@@ -10,6 +10,8 @@ namespace Aksio.Cratis.Events.Store.MongoDB;
 /// </summary>
 public class EventCursor : IEventCursor
 {
+    readonly EventSequenceNumber _sequenceNumber;
+    readonly IEnumerable<EventType> _eventTypes;
     readonly IEventConverter _converter;
     readonly IAsyncCursor<Event>? _innerCursor;
 
@@ -19,12 +21,18 @@ public class EventCursor : IEventCursor
     /// <summary>
     /// Initializes a new instance of the <see cref="EventCursor"/> class.
     /// </summary>
+    /// <param name="sequenceNumber">Blah.</param>
+    /// <param name="eventTypes">Blasdah.</param>
     /// <param name="converter"><see cref="IEventConverter"/> to convert event types.</param>
     /// <param name="innerCursor">The underlying MongoDB cursor.</param>
     public EventCursor(
+        EventSequenceNumber sequenceNumber,
+        IEnumerable<EventType> eventTypes,
         IEventConverter converter,
         IAsyncCursor<Event>? innerCursor)
     {
+        _sequenceNumber = sequenceNumber;
+        _eventTypes = eventTypes;
         _converter = converter;
         _innerCursor = innerCursor;
     }
@@ -32,16 +40,20 @@ public class EventCursor : IEventCursor
     /// <inheritdoc/>
     public async Task<bool> MoveNext()
     {
+        Console.WriteLine($"MoveNext: {_sequenceNumber}:{string.Join(", ", _eventTypes.Select(_ => _.ToString()))}");
         if (_innerCursor is null) return false;
         var result = await _innerCursor.MoveNextAsync();
         if (_innerCursor.Current is not null)
         {
+            Console.WriteLine($"{_sequenceNumber}:{string.Join(", ", _eventTypes.Select(_ => _.ToString()))} - {_innerCursor.Current.Count()} - {_innerCursor.Current.First().SequenceNumber}");
             Current = await Task.WhenAll(_innerCursor.Current.Select(@event => _converter.ToAppendedEvent(@event)));
         }
         else
         {
+            Console.WriteLine($"MoveNext: {_sequenceNumber}:{string.Join(", ", _eventTypes.Select(_ => _.ToString()))} - nothing");
             Current = Array.Empty<AppendedEvent>();
         }
+        Console.WriteLine($"MoveNext: {_sequenceNumber}:{string.Join(", ", _eventTypes.Select(_ => _.ToString()))} - result: {result}");
         return result;
     }
 

--- a/Source/Kernel/Store/MongoDB/EventCursor.cs
+++ b/Source/Kernel/Store/MongoDB/EventCursor.cs
@@ -5,13 +5,13 @@ using MongoDB.Driver;
 
 namespace Aksio.Cratis.Events.Store.MongoDB;
 
+#pragma warning disable CA1849, MA0042 // Allow this blocking call - we get deadlocks when using MongoDB MoveNextAsync()
+
 /// <summary>
 /// Represents an implementation of <see cref="IEventCursor"/> for handling events from event sequence.
 /// </summary>
 public class EventCursor : IEventCursor
 {
-    readonly EventSequenceNumber _sequenceNumber;
-    readonly IEnumerable<EventType> _eventTypes;
     readonly IEventConverter _converter;
     readonly IAsyncCursor<Event>? _innerCursor;
 
@@ -21,18 +21,12 @@ public class EventCursor : IEventCursor
     /// <summary>
     /// Initializes a new instance of the <see cref="EventCursor"/> class.
     /// </summary>
-    /// <param name="sequenceNumber">Blah.</param>
-    /// <param name="eventTypes">Blasdah.</param>
     /// <param name="converter"><see cref="IEventConverter"/> to convert event types.</param>
     /// <param name="innerCursor">The underlying MongoDB cursor.</param>
     public EventCursor(
-        EventSequenceNumber sequenceNumber,
-        IEnumerable<EventType> eventTypes,
         IEventConverter converter,
         IAsyncCursor<Event>? innerCursor)
     {
-        _sequenceNumber = sequenceNumber;
-        _eventTypes = eventTypes;
         _converter = converter;
         _innerCursor = innerCursor;
     }
@@ -40,20 +34,17 @@ public class EventCursor : IEventCursor
     /// <inheritdoc/>
     public async Task<bool> MoveNext()
     {
-        Console.WriteLine($"MoveNext: {_sequenceNumber}:{string.Join(", ", _eventTypes.Select(_ => _.ToString()))}");
         if (_innerCursor is null) return false;
-        var result = await _innerCursor.MoveNextAsync();
+
+        var result = _innerCursor.MoveNext();
         if (_innerCursor.Current is not null)
         {
-            Console.WriteLine($"{_sequenceNumber}:{string.Join(", ", _eventTypes.Select(_ => _.ToString()))} - {_innerCursor.Current.Count()} - {_innerCursor.Current.First().SequenceNumber}");
             Current = await Task.WhenAll(_innerCursor.Current.Select(@event => _converter.ToAppendedEvent(@event)));
         }
         else
         {
-            Console.WriteLine($"MoveNext: {_sequenceNumber}:{string.Join(", ", _eventTypes.Select(_ => _.ToString()))} - nothing");
             Current = Array.Empty<AppendedEvent>();
         }
-        Console.WriteLine($"MoveNext: {_sequenceNumber}:{string.Join(", ", _eventTypes.Select(_ => _.ToString()))} - result: {result}");
         return result;
     }
 

--- a/Source/Kernel/Store/MongoDB/MongoDBEventSequenceStorageProvider.cs
+++ b/Source/Kernel/Store/MongoDB/MongoDBEventSequenceStorageProvider.cs
@@ -117,6 +117,6 @@ public class MongoDBEventSequenceStorageProvider : IEventSequenceStorageProvider
 
         var filter = Builders<Event>.Filter.And(filters.ToArray());
         var cursor = collection.Find(filter).ToCursor();
-        return Task.FromResult<IEventCursor>(new EventCursor(_converter(), cursor));
+        return Task.FromResult<IEventCursor>(new EventCursor(sequenceNumber, eventTypes ?? Array.Empty<EventType>(), _converter(), cursor));
     }
 }

--- a/Source/Kernel/Store/MongoDB/MongoDBEventSequenceStorageProvider.cs
+++ b/Source/Kernel/Store/MongoDB/MongoDBEventSequenceStorageProvider.cs
@@ -117,6 +117,6 @@ public class MongoDBEventSequenceStorageProvider : IEventSequenceStorageProvider
 
         var filter = Builders<Event>.Filter.And(filters.ToArray());
         var cursor = collection.Find(filter).ToCursor();
-        return Task.FromResult<IEventCursor>(new EventCursor(sequenceNumber, eventTypes ?? Array.Empty<EventType>(), _converter(), cursor));
+        return Task.FromResult<IEventCursor>(new EventCursor(_converter(), cursor));
     }
 }

--- a/Source/Kernel/TestData/Program.cs
+++ b/Source/Kernel/TestData/Program.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Text.Json;
+using Aksio.Cratis.Events;
+using Aksio.Cratis.Events.Store;
+using Aksio.Cratis.Events.Store.MongoDB;
+using Aksio.Cratis.Execution;
+using Aksio.Cratis.Extensions.MongoDB;
+using Aksio.Cratis.Json;
+using Events.Accounts.Debit;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Aksio.Cratis.TestData;
+
+static class Program
+{
+    static readonly string[] _owners = new string[]
+    {
+        "aae77be6-21ce-4dc6-bf33-e97014c2ba3b",
+        "6a48dc85-086b-4ab3-ba4f-44259eb574ca",
+        "acd5cbb4-09c4-4a69-bafb-7e784d7de8bd",
+        "a9ade696-9958-4f24-9a9d-099405c93b28",
+        "b676372f-297b-4f3b-8f4e-94555512ba31"
+    };
+
+    static readonly Dictionary<string, List<string>> _accountsPerPerson = new();
+    static JsonSerializerOptions? _serializerOptions;
+
+    static IMongoCollection<Event>? _eventLog;
+    static IMongoCollection<EventSequenceState>? _eventSequenceState;
+
+    public static async Task Main()
+    {
+        _serializerOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters =
+                {
+                    new ConceptAsJsonConverterFactory()
+                }
+        };
+
+        var types = new Types.Types();
+        var defaults = new MongoDBDefaults(types);
+        defaults.Initialize();
+
+        var settings = MongoClientSettings.FromConnectionString("mongodb://localhost:27017");
+        var client = new MongoClient(settings);
+        var database = client.GetDatabase("bank-dev-event-store");
+        _eventLog = database.GetCollection<Event>("event-log");
+        _eventSequenceState = database.GetCollection<EventSequenceState>("event-sequences");
+
+        var rnd = new Random();
+
+        var sequenceNumber = (await GetSequence()).SequenceNumber;
+
+        Console.WriteLine($"Start generating test data at sequence number: {sequenceNumber}");
+        var occurred = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(30));
+
+        foreach (var owner in _owners)
+        {
+            var accounts = new List<string>();
+
+            for (var i = 0; i < rnd.Next() % 10; i++)
+            {
+                var account = Guid.NewGuid().ToString();
+                accounts.Add(account);
+                await Append(
+                    sequenceNumber,
+                    account,
+                    occurred,
+                    new DebitAccountOpened($"account-{i}", owner));
+
+                sequenceNumber++;
+
+                occurred = occurred.Add(TimeSpan.FromSeconds(rnd.NextDouble() * 100));
+
+                Console.WriteLine($"Added account {account} for {owner}");
+            }
+
+            _accountsPerPerson[owner] = accounts;
+        }
+
+        Console.WriteLine("Add operations on accounts for owners");
+        for (var i = 0; i < 200; i++)
+        {
+            var owner = _owners[rnd.Next() % _owners.Length];
+            if (!_accountsPerPerson.ContainsKey(owner) || _accountsPerPerson[owner].Count == 0)
+            {
+                continue;
+            }
+            var account = _accountsPerPerson[owner][rnd.Next() % _accountsPerPerson[owner].Count];
+            var deposit = rnd.Next() % 2;
+
+            object @event;
+
+            if (deposit == 0)
+            {
+                @event = new DepositToDebitAccountPerformed(rnd.NextDouble() * 500);
+            }
+            else
+            {
+                @event = new WithdrawalFromDebitAccountPerformed(rnd.NextDouble() * 500);
+            }
+
+            await Append(
+                sequenceNumber,
+                account,
+                occurred,
+                @event);
+
+            sequenceNumber++;
+            await WriteSequence(sequenceNumber);
+
+            Console.Write(".");
+
+            occurred = occurred.Add(TimeSpan.FromSeconds(rnd.NextDouble() * 100));
+        }
+    }
+
+    static async Task Append(EventSequenceNumber sequenceNumber, EventSourceId eventSourceId, DateTimeOffset occurred, object content)
+    {
+        var eventTypeAttribute = content.GetType().GetCustomAttribute<EventTypeAttribute>();
+        var eventType = eventTypeAttribute!.Type;
+
+        var contentAsJson = JsonSerializer.Serialize(content, _serializerOptions!);
+        var contentAsBson = BsonDocument.Parse(contentAsJson);
+        contentAsBson.Remove("_t");
+
+        var @event = new Event(
+            sequenceNumber,
+            CorrelationId.New(),
+            CausationId.System,
+            CausedBy.System,
+            eventType.Id,
+            occurred,
+            DateTimeOffset.MinValue,
+            eventSourceId,
+            new Dictionary<string, BsonDocument>
+            {
+                { "1", contentAsBson }
+            },
+            Array.Empty<EventCompensation>());
+
+        await _eventLog!.InsertOneAsync(@event);
+    }
+
+    static async Task<EventSequenceState> GetSequence()
+    {
+        var filter = Builders<EventSequenceState>.Filter.Eq(new StringFieldDefinition<EventSequenceState, Guid>("_id"), Guid.Empty);
+        var cursor = await _eventSequenceState.FindAsync(filter);
+        return await cursor.FirstOrDefaultAsync() ?? new EventSequenceState();
+    }
+
+    static Task WriteSequence(EventSequenceNumber sequenceNumber)
+    {
+        var filter = Builders<EventSequenceState>.Filter.Eq(new StringFieldDefinition<EventSequenceState, Guid>("_id"), Guid.Empty);
+        return _eventSequenceState!.UpdateOneAsync(
+            filter,
+            Builders<EventSequenceState>.Update.Set(_ => _.SequenceNumber, sequenceNumber),
+            new() { IsUpsert = true });
+    }
+}

--- a/Source/Kernel/TestData/TestData.csproj
+++ b/Source/Kernel/TestData/TestData.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Aksio.Cratis.TestData</AssemblyName>
+        <RootNamespace>Aksio.Cratis.TestData</RootNamespace>
+        <InvariantGlobalization>true</InvariantGlobalization>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+
+    <ItemGroup>
+        <ProjectReference Include="../Store/MongoDB/MongoDB.csproj"/>
+        <ProjectReference Include="../../Fundamentals/Fundamentals.csproj"/>
+        <ProjectReference Include="../../Clients/DotNET/DotNET.csproj"/>
+        <ProjectReference Include="../../../Samples/Banking/Bank/Events/Events.csproj"/>
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
### Fixed

- Fixes a problem where we got into deadlock when getting events when using `MoveNextAsync()` on MongoDB cursors. The consequence was that you only got the first 100 events of a selection. Fixes #272.
