### PR TITLE
Fixing so that the specs projects build in the template

### DIFF
--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Directory.Build.props
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Directory.Build.props
@@ -30,7 +30,7 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(SpecProject)' == 'true'">
-        <ProjectReference Include="Aksio.Cratis.Specifications" Version="5.0.3" />
+        <PackageReference Include="Aksio.Cratis.Specifications" Version="5.0.3" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(SpecProject)' == 'true'">
@@ -38,7 +38,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(SpecProject)' == 'true'">
-        <PackageReference Include="xunit" Version="$(xunit)" />
+        <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### Fixed

- FIxing Aksio Microservice template to build the specs projects. Missing XUnit reference and was using project reference instead of package reference for the specifications extensions.
