### PR TITLE
Forcing forward slash for import statements

### DIFF
--- a/Source/ApplicationModel/Tooling/ProxyGenerator/Templates/ImportStatement.cs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/Templates/ImportStatement.cs
@@ -6,6 +6,26 @@ namespace Aksio.Cratis.Applications.ProxyGenerator.Templates;
 /// <summary>
 /// Describes an import statement.
 /// </summary>
-/// <param name="Type">Type to use.</param>
-/// <param name="Module">Source module in which the type is from.</param>
-public record ImportStatement(string Type, string Module);
+public record ImportStatement
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImportStatement"/> class.
+    /// </summary>
+    /// <param name="type">Type to use.</param>
+    /// <param name="module">Source module the type is originating from.</param>
+    public ImportStatement(string type, string module)
+    {
+        Type = type;
+        Module = module.Replace('\\', '/');
+    }
+
+    /// <summary>
+    /// Gets the type to use.
+    /// </summary>
+    public string Type { get; }
+
+    /// <summary>
+    /// Gets the source module in which the type is from.
+    /// </summary>
+    public string Module { get; }
+}

--- a/Source/Kernel/Store/Shared/EventContext.cs
+++ b/Source/Kernel/Store/Shared/EventContext.cs
@@ -27,6 +27,31 @@ public record EventContext(
     EventObservationState ObservationState = EventObservationState.Initial)
 {
     /// <summary>
+    /// Creates an 'empty' <see cref="EventContext"/> with the event source id set to empty and all properties default.
+    /// </summary>
+    /// <returns>A new <see cref="EventContext"/>.</returns>
+    public static EventContext Empty() => From(Guid.Empty);
+
+    /// <summary>
+    /// Creates a new <see cref="EventContext"/> from <see cref="EventSourceId"/> and other optional parameters.
+    /// </summary>
+    /// <param name="eventSourceId"><see cref="EventSourceId"/> to create from.</param>
+    /// <param name="occurred">Optional occurred.</param>
+    /// <param name="validFrom">Optional valid from.</param>
+    /// <returns>A new <see cref="EventContext"/>.</returns>
+    public static EventContext From(EventSourceId eventSourceId, DateTimeOffset? occurred = default, DateTimeOffset? validFrom = default)
+    {
+        return new(
+            eventSourceId,
+            occurred ?? DateTimeOffset.Now,
+            validFrom ?? DateTimeOffset.MinValue,
+            TenantId.Development,
+            CorrelationId.New(),
+            CausationId.System,
+            CausedBy.System);
+    }
+
+    /// <summary>
     /// Creates a copy of the context object with the new desired state.
     /// </summary>
     /// <param name="desiredState">The desired state.</param>


### PR DESCRIPTION
### Added

- Adding convenience methods for `EventContext`. (#398)

### Fixed

- Fixes import paths to be correct across platforms. (#395)
