### PR TITLE
Fixing empty to not be a method but a static field

### DIFF
--- a/Source/Kernel/Store/Shared/EventContext.cs
+++ b/Source/Kernel/Store/Shared/EventContext.cs
@@ -30,7 +30,7 @@ public record EventContext(
     /// Creates an 'empty' <see cref="EventContext"/> with the event source id set to empty and all properties default.
     /// </summary>
     /// <returns>A new <see cref="EventContext"/>.</returns>
-    public static EventContext Empty() => From(Guid.Empty);
+    public static readonly EventContext Empty = From(Guid.Empty);
 
     /// <summary>
     /// Creates a new <see cref="EventContext"/> from <see cref="EventSourceId"/> and other optional parameters.


### PR DESCRIPTION
### Fixed

- Messed up the API in 6.7.0 for `EventContext.Empty()` should've been `EventContext.Empty`.

