### PR TITLE
403-add-cache-setup-to-webpack-config

### DIFF
--- a/Source/Node/WebPack/frontend/index.js
+++ b/Source/Node/WebPack/frontend/index.js
@@ -25,6 +25,7 @@ module.exports = (env, argv, basePath, callback, port, title) => {
         plugins: plugins(basePath, title),
         devtool: production ? false : 'inline-source-map',
         devServer: devServer(basePath, port),
+        cache: production ? false : {type: 'filesystem', allowCollectingMemory: true},
         watchOptions: {
             ignored: [
                 '**/for_*/**/*.ts'


### PR DESCRIPTION
### Fixed

- Added cache to development to decrease startup time. (#403)

