### PR TITLE
Adding support for post bind operations

### DIFF
--- a/Documentation/fundamentals/configuration.md
+++ b/Documentation/fundamentals/configuration.md
@@ -234,3 +234,25 @@ public class MyController : Controller
     }
 }
 ```
+
+## Perform operations after values bound
+
+After the values are bound to a configuration object one might want to be notified to be able to perform operations / preparations
+for the object to be used. By implementing `IPerformPostBindOperations` the system will call the `Perform()` method when values have
+been bound.
+
+```csharp
+[Configuration("cratis")]
+public class KernelConfiguration : IPerformPostBindOperations
+{
+    public Tenants Tenants { get; init; } = new();
+    public Cluster Cluster { get; init; } = new();
+    public Storage Storage { get; init; } = new();
+
+    public void Perform()
+    {
+        // Perform post configuration
+        Storage.ConfigureKernelMicroservice(Tenants.Select(_ => _.Key));
+    }
+}
+```

--- a/Source/Fundamentals/Configuration/ConfigurationHostBuilderExtensions.cs
+++ b/Source/Fundamentals/Configuration/ConfigurationHostBuilderExtensions.cs
@@ -101,6 +101,12 @@ public static class ConfigurationHostBuilderExtensions
             if (configuration.Providers.Any(_ => _.GetChildKeys(Array.Empty<string>(), null!).Any()))
             {
                 configuration.Bind(configurationObject);
+
+                if (configurationObject is IPerformPostBindOperations postPerformer)
+                {
+                    postPerformer.Perform();
+                }
+
                 services.AddSingleton(configurationObjectType, configurationObject);
 
                 services.AddChildConfigurationObjects(configurationObjectType, configurationObject);

--- a/Source/Fundamentals/Configuration/IPerformPostBindOperations.cs
+++ b/Source/Fundamentals/Configuration/IPerformPostBindOperations.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Configuration;
+
+/// <summary>
+/// Defines an interface for configuration objects to implement to be called when the configuration object is initialized.
+/// </summary>
+public interface IPerformPostBindOperations
+{
+    /// <summary>
+    /// The method thats gets called after the object is initialized.
+    /// </summary>
+    void Perform();
+}

--- a/Source/Kernel/Configuration/Shared/KernelConfiguration.cs
+++ b/Source/Kernel/Configuration/Shared/KernelConfiguration.cs
@@ -9,7 +9,7 @@ namespace Aksio.Cratis.Configuration;
 /// Represents the configuration for the Kernel.
 /// </summary>
 [Configuration("cratis")]
-public class KernelConfiguration
+public class KernelConfiguration : IPerformPostBindOperations
 {
     /// <summary>
     /// Gets the <see cref="Tenants"/> configuration.
@@ -19,15 +19,21 @@ public class KernelConfiguration
     /// <summary>
     /// Gets the <see cref="Microservice"/> configuration.
     /// </summary>
-    public Microservices Microservices { get; init; } = new();
+    public Microservices Microservices { get; init; } = new();
 
     /// <summary>
     /// Gets the <see cref="Cluster"/> configuration.
     /// </summary>
-    public Cluster Cluster { get; init; } = new();
+    public Cluster Cluster { get; init; } = new();
 
     /// <summary>
     /// Gets the <see cref="Storage"/> configuration.
     /// </summary>
-    public Storage Storage { get; init; } = new();
+    public Storage Storage { get; init; } = new();
+
+    /// <inheritdoc/>
+    public void Perform()
+    {
+        Storage.ConfigureKernelMicroservice(Tenants.Select(_ => _.Key));
+    }
 }

--- a/Source/Kernel/Configuration/Shared/Storage.cs
+++ b/Source/Kernel/Configuration/Shared/Storage.cs
@@ -11,59 +11,38 @@ namespace Aksio.Cratis.Configuration;
 [Configuration]
 public class Storage
 {
-    bool _addedKernelMicroservice;
-    StorageType? _cluster;
-    StorageForMicroservices? _storageForMicroservices;
-
     /// <summary>
     /// The storage configuration for the cluster.
     /// </summary>
-    public StorageType Cluster
-    {
-        get => _cluster ?? new();
-        init
-        {
-            _cluster = value;
-            AddKernelMicroserviceIfNotAdded();
-        }
-    }
+    public StorageType Cluster { get; set; } = new();
 
     /// <summary>
     /// The storage configuration for all microservices.
     /// </summary>
-    public StorageForMicroservices Microservices
-    {
-        get => _storageForMicroservices ?? new();
-        init
-        {
-            _storageForMicroservices = value;
-            AddKernelMicroserviceIfNotAdded();
-        }
-    }
+    public StorageForMicroservices Microservices { get; set; } = new();
 
-    void AddKernelMicroserviceIfNotAdded()
+    /// <summary>
+    /// Configure the Kernel as a Microservice.
+    /// </summary>
+    /// <param name="tenants">Tenants the Kernel needs to support.</param>
+    public void ConfigureKernelMicroservice(IEnumerable<string> tenants)
     {
-        if (_addedKernelMicroservice || _storageForMicroservices is null || _cluster is null) return;
-
-        var tenants = _storageForMicroservices!.First().Value.Tenants.Select(_ => _.Key);
-        _storageForMicroservices[MicroserviceId.Kernel] = new()
+        Microservices[MicroserviceId.Kernel] = new()
         {
             Shared = new StorageTypes
             {
-                ["eventStore"] = _cluster,
+                ["eventStore"] = Cluster,
             },
             Tenants = new()
         };
 
         foreach (var tenant in tenants)
         {
-            _storageForMicroservices[MicroserviceId.Kernel].Tenants[tenant] = new StorageTypes
+            Microservices[MicroserviceId.Kernel].Tenants[tenant] = new StorageTypes
             {
-                ["readModels"] = _cluster,
-                ["eventStore"] = _cluster
+                ["readModels"] = Cluster,
+                ["eventStore"] = Cluster
             };
         }
-
-        _addedKernelMicroservice = true;
     }
 }


### PR DESCRIPTION
## Summary

Adding support for performing operations after the config objects values has been bound up.
Automatically recognized. Below is a sample, read more in the documentation:

```csharp
[Configuration("MyConfig")]
public class ConfigObject : IPerformPostBindOperations
{
    public void Perform()
    {
        // Perform a post bind operation
    }
}
```

### Added

- Configuration objects can now implement `IPerformPostBindOperations` to be called after values have been bound to it.
