### PR TITLE
Making DocFX private

### DIFF
--- a/DocFX/package.json
+++ b/DocFX/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.0",
     "description": "",
     "main": "index.js",
+    "private": true,
     "scripts": {
         "watch": "rm -rf ./_site && rm -rf ./obj && dotnet clean && dotnet restore && concurrently 'yarn serve' 'npm-watch build'",
         "build": "dotnet msbuild -t:docfx",


### PR DESCRIPTION
### Fixed

- React upgraded to version 18.0
- Upgraded all NuGet dependencies to latest
- Latest version of .NET for build actions
