### PR TITLE
Removing explicit css loader as the sass loader seems to work fine

### DIFF
--- a/Source/Node/WebPack/frontend/rules.js
+++ b/Source/Node/WebPack/frontend/rules.js
@@ -54,15 +54,5 @@ module.exports = [
             loader: 'svg-url-loader',
             options: {}
         }
-    },
-    {
-        test: /\.css$/i,
-        issuer: { not: [/\.html$/i] },
-        use: [
-            // Creates `style` nodes from JS strings
-            'style-loader',
-            // Translates CSS into CommonJS
-            'css-loader',
-        ]
     }
 ];


### PR DESCRIPTION
### Fixed

- Removing CSS rule from WebPack setup, with the SASS rule we seem to be picking up CSS as well.
