### PR TITLE
Adding telemetry config to the Cratis Kernel config

### DIFF
--- a/Source/Kernel/Configuration/Shared/KernelConfiguration.cs
+++ b/Source/Kernel/Configuration/Shared/KernelConfiguration.cs
@@ -27,6 +27,11 @@ public class KernelConfiguration : IPerformPostBindOperations
     public Cluster Cluster { get; init; } = new();
 
     /// <summary>
+    /// Gets the <see cref="Telemetry"/> configuration.
+    /// </summary>
+    public Telemetry Telemetry { get; init; } = new ();
+
+    /// <summary>
     /// Gets the <see cref="Storage"/> configuration.
     /// </summary>
     public Storage Storage { get; init; } = new();


### PR DESCRIPTION
### Fixed

- Adding the `Telemetry` configration object to the Cratis Kernel configuration object.
