### PR TITLE
Fixing type conversion for query args

### DIFF
--- a/Source/ApplicationModel/Frontend/queries/useObservableQuery.ts
+++ b/Source/ApplicationModel/Frontend/queries/useObservableQuery.ts
@@ -22,7 +22,7 @@ export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor
     useEffect(() => {
         const subscription = queryInstance.subscribe(_ => {
             setResult(_ as unknown as QueryResult<TDataType>);
-        }, args);
+        }, args as any);
 
         return () => subscription.unsubscribe();
     }, argumentsDependency);

--- a/Source/ApplicationModel/Frontend/queries/useQuery.ts
+++ b/Source/ApplicationModel/Frontend/queries/useQuery.ts
@@ -23,7 +23,7 @@ export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArgume
     const queryInstance = new query() as TQuery;
     const [result, setResult] = useState<QueryResult<TDataType>>(new QueryResult(queryInstance.defaultValue, true));
     const queryExecutor = (async (args?: TArguments) => {
-        const response = await queryInstance.perform(args);
+        const response = await queryInstance.perform(args as any);
         setResult(response);
     });
 


### PR DESCRIPTION
### Fixed

- Converting to `any` for query arguments when passed down to base type for `useQuery()` and `useObservableQuery()` hooks.
