### PR TITLE
fix/sassLoaderNotWorking

### DIFF
--- a/Source/Node/WebPack/frontend/rules.js
+++ b/Source/Node/WebPack/frontend/rules.js
@@ -35,7 +35,7 @@ module.exports = [
             // Creates `style` nodes from JS strings
             'style-loader',
             // Adds typescript declarations to the css modules and allows importing and using strongly typed scss modules in react components.
-            '@teamsupercell/typings-for-css-modules-loader',
+            'css-modules-typescript-loader',
             // Translates CSS into CommonJS
             { loader: 'css-loader', options: { modules: true, importLoaders: 1, sourceMap: true } },
             // Compiles Sass to CSS

--- a/Source/Node/WebPack/package.json
+++ b/Source/Node/WebPack/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@aksio/cratis-typescript": "1.0.0",
-        "@teamsupercell/typings-for-css-modules-loader": "2.5.1",
+        "css-modules-typescript-loader": "4.0.1",
         "clean-webpack-plugin": "4.0.0",
         "css-loader": "6.7.1",
         "file-loader": "6.2.0",


### PR DESCRIPTION
### Fixed

- Reinstated css-modules-typescript-loader instead of `@teamsupercell/typings-for-css-modules-loader` because it broke at production build.

