### PR TITLE
Making sure we set Id by default for the return of immediate projections

### DIFF
--- a/Source/Kernel/Projections/Grains/ImmediateProjection.cs
+++ b/Source/Kernel/Projections/Grains/ImmediateProjection.cs
@@ -116,6 +116,7 @@ public class ImmediateProjection : Grain, IImmediateProjection
         }
 
         // TODO: Conversion from ExpandoObject to JsonObject can be improved - they're effectively both just Dictionary<string, object>
+        (state as IDictionary<string, object>)!["id"] = modelKey.Value;
         var json = JsonSerializer.Serialize(state);
         var jsonObject = JsonNode.Parse(json)!;
         return new((jsonObject as JsonObject)!, affectedProperties, projectedEventsCount);


### PR DESCRIPTION
### Fixed

- Immediate projections now set the `Id` property to the `modelKey` being  asked for. A future expansion on this will be to allow defininig which property is the `Id` property (#455)
