### PR TITLE
Setting folder for yarn cache for publishing packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,6 +175,10 @@ jobs:
             ./Source/Workbench/API
           key: dotnet-cache
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - uses: actions/cache@v2
         id: yarn-cache
         with:


### PR DESCRIPTION
### Fixed

- Fixing publish-packages job of CI/CD with regards to the cache folder for node_modules++
