### PR TITLE
Ignore app settings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ package-json.lock
 dist
 for_*
 Dockerfile
+appsettings.json


### PR DESCRIPTION
### Fixed

- Taking out `appsettings.json` from the built Docker images. One needs now to configure this and mount it in for logging and other things.
