### PR TITLE
Adding debug info to packages + source link

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,9 +12,11 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/aksio-insurtech/Cratis</RepositoryUrl>
         <PackageProjectUrl>https://github.com/aksio-insurtech/Cratis</PackageProjectUrl>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Aksio.Defaults" Version="$(AksioDefaults)" PrivateAssets="All" Condition="'$(PublishReadyToRun)' != 'true'" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     </ItemGroup>
 </Project>

--- a/Versions.props
+++ b/Versions.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <AksioDefaults>1.6.4</AksioDefaults>
+        <AksioDefaults>1.6.5</AksioDefaults>
         <AksioSpecifications>2.0.1</AksioSpecifications>
         <NewtonsoftJson>13.0.1</NewtonsoftJson>
         <Autofac>6.4.0</Autofac>


### PR DESCRIPTION
### Fixed

- Including PDB debug symbols and source in packages. Also adding source link. This to be able to debug broadly in different tooling. Downside is of course that the packages will become much larger. We'll keep an eye on this and change if necessary. Our complete setup now includes generation of `.snupkg`, include PDB files, include source in packages and source link.
