### PR TITLE
Using latest Aksio.Defaults

### DIFF
--- a/Versions.props
+++ b/Versions.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <AksioDefaults>1.6.5</AksioDefaults>
+        <AksioDefaults>1.6.6</AksioDefaults>
         <AksioSpecifications>2.0.1</AksioSpecifications>
         <NewtonsoftJson>13.0.1</NewtonsoftJson>
         <Autofac>6.4.0</Autofac>


### PR DESCRIPTION
### Fixed

- Reverting the inclusion of PDB files. Relying on source link and .snupkg. 
