### PR TITLE
Ignoring the IsPublic part of event type when filtering events we're interested in

### DIFF
--- a/Source/Kernel/Projections/Engine/Projection.cs
+++ b/Source/Kernel/Projections/Engine/Projection.cs
@@ -82,10 +82,10 @@ public class Projection : IProjection
     }
 
     /// <inheritdoc/>
-    public IObservable<ProjectionEventContext> FilterEventTypes(IObservable<ProjectionEventContext> observable) => observable.Where(_ => EventTypes.Any(et => et == _.Event.Metadata.Type));
+    public IObservable<ProjectionEventContext> FilterEventTypes(IObservable<ProjectionEventContext> observable) => observable.Where(_ => EventTypes.Any(et => et.Id == _.Event.Metadata.Type.Id));
 
     /// <inheritdoc/>
-    public IObservable<AppendedEvent> FilterEventTypes(IObservable<AppendedEvent> observable) => observable.Where(_ => EventTypes.Any(et => et == _.Metadata.Type));
+    public IObservable<AppendedEvent> FilterEventTypes(IObservable<AppendedEvent> observable) => observable.Where(_ => EventTypes.Any(et => et.Id == _.Metadata.Type.Id));
 
     /// <inheritdoc/>
     public void OnNext(ProjectionEventContext context)
@@ -109,7 +109,7 @@ public class Projection : IProjection
     public void SetEventTypesWithKeyResolvers(IEnumerable<EventTypeWithKeyResolver> eventTypesWithKeyResolver)
     {
         EventTypesWithKeyResolver = eventTypesWithKeyResolver;
-        EventTypes = eventTypesWithKeyResolver.Select(_ => _.EventType).ToArray();
+        EventTypes = eventTypesWithKeyResolver.Select(_ => new EventType(_.EventType.Id, _.EventType.Generation)).ToArray();
         _eventTypesToKeyResolver = eventTypesWithKeyResolver.ToDictionary(
             _ => new EventType(_.EventType.Id, _.EventType.Generation),
             _ => _.KeyResolver);

--- a/Source/Kernel/Projections/Engine/ProjectionExtensions.cs
+++ b/Source/Kernel/Projections/Engine/ProjectionExtensions.cs
@@ -23,7 +23,7 @@ public static class ProjectionExtensions
     /// <returns>Filtered <see cref="IObservable{T}"/>.</returns>
     public static IObservable<ProjectionEventContext> From(this IObservable<ProjectionEventContext> observable, EventType eventType)
     {
-        return observable.Where(_ => _.Event.Metadata.Type == eventType);
+        return observable.Where(_ => _.Event.Metadata.Type.Id == eventType.Id);
     }
 
     /// <summary>
@@ -72,7 +72,7 @@ public static class ProjectionExtensions
     /// <returns>The observable for continuation.</returns>
     public static IObservable<ProjectionEventContext> RemovedWith(this IObservable<ProjectionEventContext> observable, EventType eventType)
     {
-        observable.Where(_ => _.Event.Metadata.Type == eventType).Subscribe(_ => _.Changeset.Remove());
+        observable.Where(_ => _.Event.Metadata.Type.Id == eventType.Id).Subscribe(_ => _.Changeset.Remove());
         return observable;
     }
 
@@ -84,6 +84,6 @@ public static class ProjectionExtensions
     /// <returns>The observable for continuation.</returns>
     public static IObservable<ProjectionEventContext> Join(this IObservable<ProjectionEventContext> observable, EventType eventType)
     {
-        return observable.Where(_ => _.Event.Metadata.Type == eventType);
+        return observable.Where(_ => _.Event.Metadata.Type.Id == eventType.Id);
     }
 }

--- a/Specifications/Kernel/Projections/Engine/for_Projection/given/a_projection.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projection/given/a_projection.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NJsonSchema;
+
+namespace Aksio.Cratis.Events.Projections.for_Projection.given;
+
+public class a_projection : Specification
+{
+    protected Projection projection;
+
+    void Establish()
+    {
+        projection = new Projection(
+            "0b7325dd-7a25-4681-9ab7-c387a6073547",
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            new Model(string.Empty, new JsonSchema()),
+            true,
+            Array.Empty<IProjection>());
+    }
+}

--- a/Specifications/Kernel/Projections/Engine/for_Projection/when_getting_key_resolver_for_event_type.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projection/when_getting_key_resolver_for_event_type.cs
@@ -1,28 +1,17 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using NJsonSchema;
-
 namespace Aksio.Cratis.Events.Projections.for_Projection;
 
-public class when_getting_key_resolver_for_event_type : Specification
+public class when_getting_key_resolver_for_event_type : given.a_projection
 {
     static EventType event_type = new("993888cc-a9c5-4d56-ae21-f732159feec7", 1);
-    Projection projection;
     KeyResolver expected;
     KeyResolver result;
 
     void Establish()
     {
         expected = KeyResolvers.FromEventSourceId;
-        projection = new Projection(
-            "0b7325dd-7a25-4681-9ab7-c387a6073547",
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            new Model(string.Empty, new JsonSchema()),
-            true,
-            Array.Empty<IProjection>());
         projection.SetEventTypesWithKeyResolvers(new EventTypeWithKeyResolver[]
         {
                 new EventTypeWithKeyResolver(event_type, expected)

--- a/Specifications/Kernel/Projections/Engine/for_Projection/when_getting_key_resolver_for_event_type_registered_as_public.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projection/when_getting_key_resolver_for_event_type_registered_as_public.cs
@@ -1,28 +1,17 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using NJsonSchema;
-
 namespace Aksio.Cratis.Events.Projections.for_Projection;
 
-public class when_getting_key_resolver_for_event_type_registered_as_public : Specification
+public class when_getting_key_resolver_for_event_type_registered_as_public : given.a_projection
 {
     static EventType event_type = new("993888cc-a9c5-4d56-ae21-f732159feec7", 1, IsPublic: true);
-    Projection projection;
     KeyResolver expected;
     KeyResolver result;
 
     void Establish()
     {
         expected = KeyResolvers.FromEventSourceId;
-        projection = new Projection(
-            "0b7325dd-7a25-4681-9ab7-c387a6073547",
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            new Model(string.Empty, new JsonSchema()),
-            true,
-            Array.Empty<IProjection>());
         projection.SetEventTypesWithKeyResolvers(new EventTypeWithKeyResolver[]
         {
                 new EventTypeWithKeyResolver(event_type, expected)

--- a/Specifications/Kernel/Projections/Engine/for_Projection/when_getting_key_resolver_for_unknown_event_type.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projection/when_getting_key_resolver_for_unknown_event_type.cs
@@ -1,26 +1,11 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using NJsonSchema;
-
 namespace Aksio.Cratis.Events.Projections.for_Projection;
 
-public class when_getting_key_resolver_for_unknown_event_type : Specification
+public class when_getting_key_resolver_for_unknown_event_type : given.a_projection
 {
-    Projection projection;
     Exception result;
-
-    void Establish()
-    {
-        projection = new Projection(
-            "0b7325dd-7a25-4681-9ab7-c387a6073547",
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            new Model(string.Empty, new JsonSchema()),
-            true,
-            Array.Empty<IProjection>());
-    }
 
     void Because() => result = Catch.Exception(() => projection.GetKeyResolverFor(new("6ffcf259-2069-4e7b-bf60-006edbffaf8b", 1)));
 

--- a/Specifications/Kernel/Projections/Engine/for_Projection/when_next_event_is_a_public_event.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projection/when_next_event_is_a_public_event.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Aksio.Cratis.Changes;
+using Aksio.Cratis.Events.Store;
+using Aksio.Cratis.Properties;
+
+namespace Aksio.Cratis.Events.Projections.for_Projection;
+
+public class when_next_event_is_a_public_event : given.a_projection
+{
+    static EventType public_event_type = new("05c2799e-e3ad-43b6-87bb-9fecb0b4e147", 1);
+    AppendedEvent public_event;
+    Mock<IChangeset<AppendedEvent, ExpandoObject>> changeset;
+    List<ProjectionEventContext> observed_events;
+
+    void Establish()
+    {
+        changeset = new();
+        projection.SetEventTypesWithKeyResolvers(new EventTypeWithKeyResolver[]
+        {
+                new EventTypeWithKeyResolver(public_event_type, KeyResolvers.FromEventSourceId)
+        });
+
+        public_event = new(
+            new(0, public_event_type),
+            new("2f005aaf-2f4e-4a47-92ea-63687ef74bd4", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "123b8935-a1a4-410d-aace-e340d48f0aa0", "41f18595-4748-4b01-88f7-4c0d0907aa90", "50308963-d8b5-4b6e-97c7-e2486e8237e1", "bfb7fd4a-1822-4937-a6d1-52464a173f84"),
+            new JsonObject());
+
+        observed_events = new();
+        projection.Event.Subscribe(_ => observed_events.Add(_));
+    }
+
+    void Because() => projection.OnNext(new(new(public_event.Context.EventSourceId, ArrayIndexers.NoIndexers), public_event, changeset.Object));
+
+    [Fact] void should_only_observe_one_event() => observed_events.Count.ShouldEqual(1);
+    [Fact] void should_observe_the_public_event() => observed_events[0].Event.Metadata.Type.Id.ShouldEqual(public_event_type.Id);
+}

--- a/Specifications/Kernel/Projections/Engine/for_Projection/when_next_event_is_not_of_interest.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projection/when_next_event_is_not_of_interest.cs
@@ -6,13 +6,11 @@ using System.Text.Json.Nodes;
 using Aksio.Cratis.Changes;
 using Aksio.Cratis.Events.Store;
 using Aksio.Cratis.Properties;
-using NJsonSchema;
 
 namespace Aksio.Cratis.Events.Projections.for_Projection;
 
-public class when_next_event_is_not_of_interest : Specification
+public class when_next_event_is_not_of_interest : given.a_projection
 {
-    Projection projection;
     bool observed;
     AppendedEvent @event;
     Changeset<AppendedEvent, ExpandoObject> changeset;
@@ -20,15 +18,6 @@ public class when_next_event_is_not_of_interest : Specification
 
     void Establish()
     {
-        projection = new Projection(
-            "0b7325dd-7a25-4681-9ab7-c387a6073547",
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            new Model(string.Empty, new JsonSchema()),
-            true,
-            Array.Empty<IProjection>());
-
         projection.SetEventTypesWithKeyResolvers(new EventTypeWithKeyResolver[]
         {
                 new EventTypeWithKeyResolver(new  EventType("aac3d310-ff2f-4809-a326-afe14dd9a3d6", 1), KeyResolvers.FromEventSourceId)

--- a/Specifications/Kernel/Projections/Engine/for_Projection/when_next_event_is_of_interest.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projection/when_next_event_is_of_interest.cs
@@ -6,15 +6,13 @@ using System.Text.Json.Nodes;
 using Aksio.Cratis.Changes;
 using Aksio.Cratis.Events.Store;
 using Aksio.Cratis.Properties;
-using NJsonSchema;
 
 namespace Aksio.Cratis.Events.Projections.for_Projection;
 
-public class when_next_event_is_of_interest : Specification
+public class when_next_event_is_of_interest : given.a_projection
 {
     static EventType event_a = new("05c2799e-e3ad-43b6-87bb-9fecb0b4e147", 1);
     static EventType event_b = new("4212376e-dd74-44f4-8ed4-1b7fe314d208", 1);
-    Projection projection;
     List<ProjectionEventContext> observed_events;
     ExpandoObject initial_state;
 
@@ -27,14 +25,6 @@ public class when_next_event_is_of_interest : Specification
 
     void Establish()
     {
-        projection = new Projection(
-            "0b7325dd-7a25-4681-9ab7-c387a6073547",
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            new Model(string.Empty, new JsonSchema()),
-            true,
-            Array.Empty<IProjection>());
         projection.SetEventTypesWithKeyResolvers(new EventTypeWithKeyResolver[]
         {
                 new EventTypeWithKeyResolver(event_b, KeyResolvers.FromEventSourceId)

--- a/Specifications/Kernel/Projections/Engine/for_ProjectionExtensions/when_applying_from_filter/and_issuing_public_event_with_type_that_is_included.cs
+++ b/Specifications/Kernel/Projections/Engine/for_ProjectionExtensions/when_applying_from_filter/and_issuing_public_event_with_type_that_is_included.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Events.Projections.for_ProjectionExtensions.when_applying_from_filter;
+
+public class and_issuing_public_event_with_type_that_is_included : given.an_observable_and_event_setup
+{
+    IObservable<ProjectionEventContext> filtered;
+
+    void Establish()
+    {
+        filtered = observable.From(new EventType(@event.Metadata.Type.Id, 1, true));
+        filtered.Subscribe(_ => received.Add(_));
+    }
+
+    void Because() => observable.OnNext(event_context);
+
+    [Fact] void should_receive_event() => received.ShouldContainOnly(event_context);
+}

--- a/Specifications/Kernel/Projections/Engine/for_ProjectionExtensions/when_handling_remove_with_public_event.cs
+++ b/Specifications/Kernel/Projections/Engine/for_ProjectionExtensions/when_handling_remove_with_public_event.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Events.Store;
+using Aksio.Cratis.Properties;
+
+namespace Aksio.Cratis.Events.Projections.for_ProjectionExtensions.when_applying_from_filter;
+
+public class when_handling_remove_with_public_event : given.an_observable_and_event_setup
+{
+    AppendedEvent public_event;
+    ProjectionEventContext public_event_context;
+
+    void Establish()
+    {
+        observable.RemovedWith(new(@event.Metadata.Type.Id, 1, true));
+
+        public_event = new(
+            new(1,
+            new(@event.Metadata.Type.Id, 1, true)),
+            @event.Context,
+            @event.Content);
+
+        public_event_context = new(new(@event.Context.EventSourceId, ArrayIndexers.NoIndexers), @event, changeset.Object);
+    }
+
+    void Because() => observable.OnNext(public_event_context);
+
+    [Fact] void should_remove_on_changeset() => changeset.Verify(_ => _.Remove(), Once());
+}


### PR DESCRIPTION
### Fixed

- Projections are now only looking at the event type identifier and ignoring generation and whether or not it is public when filtering event types it is interested in.
