### PR TITLE
Fixing event type filtering

### DIFF
--- a/Source/Extensions/Specifications/EventSequenceStorageProviderForSpecifications.cs
+++ b/Source/Extensions/Specifications/EventSequenceStorageProviderForSpecifications.cs
@@ -32,7 +32,7 @@ public class EventSequenceStorageProviderForSpecifications : IEventSequenceStora
         }
         if (eventTypes is not null)
         {
-            query = query.Where(_ => eventTypes.Any(et => et == _.Metadata.Type));
+            query = query.Where(_ => eventTypes.Any(et => et.Id == _.Metadata.Type.Id));
         }
 
         var cursor = new EventCursorForSpecifications(query.ToArray());
@@ -49,7 +49,7 @@ public class EventSequenceStorageProviderForSpecifications : IEventSequenceStora
         }
         if (eventTypes is not null)
         {
-            query = query.Where(_ => eventTypes.Any(et => et == _.Metadata.Type));
+            query = query.Where(_ => eventTypes.Any(et => et.Id == _.Metadata.Type.Id));
         }
 
         var cursor = new EventCursorForSpecifications(query.ToArray());


### PR DESCRIPTION
### Fixed

- Fixing so that automated tests/specifications for projections just looks at the event type identifier and ignores the public flag when filtering. As the rest of the system does.
