### PR TITLE
Making projections accept event types based on identifier

### DIFF
--- a/Source/Kernel/Projections/Engine/Projection.cs
+++ b/Source/Kernel/Projections/Engine/Projection.cs
@@ -94,7 +94,7 @@ public class Projection : IProjection
     }
 
     /// <inheritdoc/>
-    public bool Accepts(EventType eventType) => _eventTypesToKeyResolver.ContainsKey(eventType);
+    public bool Accepts(EventType eventType) => _eventTypesToKeyResolver.Keys.Any(_ => _.Id == eventType.Id);
 
     /// <inheritdoc/>
     public KeyResolver GetKeyResolverFor(EventType eventType)

--- a/Specifications/Kernel/Projections/Engine/for_Projection/when_asking_if_private_event_type_is_accepted_and_it_is_registered_as_private.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projection/when_asking_if_private_event_type_is_accepted_and_it_is_registered_as_private.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Events.Projections.for_Projection;
+
+public class when_asking_if_private_event_type_is_accepted_and_it_is_registered_as_private : given.a_projection
+{
+    static EventType event_type = new("993888cc-a9c5-4d56-ae21-f732159feec7", 1);
+    bool result;
+
+    void Establish()
+    {
+        projection.SetEventTypesWithKeyResolvers(new EventTypeWithKeyResolver[]
+        {
+                new EventTypeWithKeyResolver(event_type, KeyResolvers.FromEventSourceId)
+        });
+    }
+
+    void Because() => result = projection.Accepts(new EventType(event_type.Id, event_type.Generation));
+
+    [Fact] void should_accept_it() => result.ShouldBeTrue();
+}

--- a/Specifications/Kernel/Projections/Engine/for_Projection/when_asking_if_public_event_type_is_accepted_and_it_is_registered_as_private.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projection/when_asking_if_public_event_type_is_accepted_and_it_is_registered_as_private.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Events.Projections.for_Projection;
+
+public class when_asking_if_public_event_type_is_accepted_and_it_is_registered_as_private : given.a_projection
+{
+    static EventType event_type = new("993888cc-a9c5-4d56-ae21-f732159feec7", 1);
+    bool result;
+
+    void Establish()
+    {
+        projection.SetEventTypesWithKeyResolvers(new EventTypeWithKeyResolver[]
+        {
+                new EventTypeWithKeyResolver(event_type, KeyResolvers.FromEventSourceId)
+        });
+    }
+
+    void Because() => result = projection.Accepts(new EventType(event_type.Id, event_type.Generation, true));
+
+    [Fact] void should_accept_it() => result.ShouldBeTrue();
+}

--- a/Specifications/Kernel/Projections/Engine/for_Projection/when_asking_if_unknown_event_type_is_accepted.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projection/when_asking_if_unknown_event_type_is_accepted.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Events.Projections.for_Projection;
+
+public class when_asking_if_unknown_event_type_is_accepted : given.a_projection
+{
+    static EventType event_type = new("993888cc-a9c5-4d56-ae21-f732159feec7", 1);
+    bool result;
+
+    void Establish()
+    {
+        projection.SetEventTypesWithKeyResolvers(new EventTypeWithKeyResolver[]
+        {
+                new EventTypeWithKeyResolver(event_type, KeyResolvers.FromEventSourceId)
+        });
+    }
+
+    void Because() => result = projection.Accepts(new EventType("5f6e10c6-f687-4e1c-b9a9-4007810c48da", 1));
+
+    [Fact] void should_not_accept_it() => result.ShouldBeFalse();
+}


### PR DESCRIPTION
### Fixed

- Making projections accept event types based only on their identifier, ignoring generation and whether or not it is marked public.
