### PR TITLE
Add an explicit exception when an event type is missing from schema store

### DIFF
--- a/Source/Kernel/Schemas/MongoDB/MissingEventSchemaForEventType.cs
+++ b/Source/Kernel/Schemas/MongoDB/MissingEventSchemaForEventType.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Events.Schemas.MongoDB;
+
+/// <summary>
+/// Exception that gets thrown when an event type is missing from the schema store.
+/// </summary>
+public class MissingEventSchemaForEventType : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingEventSchemaForEventType"/>.
+    /// </summary>
+    /// <param name="type">The <see cref="EventTypeId"/> missing.</param>
+    /// <param name="generation">The <see cref="EventGeneration"/> that is missing.</param>
+    public MissingEventSchemaForEventType(EventTypeId type, EventGeneration generation) : base($"Event type '{type}' with generation '{generation}' is missing from the event schema store")
+    {
+    }
+}

--- a/Source/Kernel/Schemas/MongoDB/MongoDBSchemaStore.cs
+++ b/Source/Kernel/Schemas/MongoDB/MongoDBSchemaStore.cs
@@ -101,6 +101,11 @@ public class MongoDBSchemaStore : ISchemaStore
         var schemas = await result.ToListAsync();
         _schemasByTypeAndGeneration[type] = schemas.ToDictionary(_ => (EventGeneration)_.Generation, _ => _.ToEventSchema());
 
+        if (schemas.Count == 0)
+        {
+            throw new MissingEventSchemaForEventType(type, generation);
+        }
+
         return schemas[0].ToEventSchema();
     }
 


### PR DESCRIPTION
### Fixed

- Making it clearer when an event type is missing from the event schema store by throwing an explicit exception.
