### PR TITLE
Setting Time component to mid-day to avoid date sliding during serialization

### DIFF
--- a/Source/Extensions/MongoDB/DateOnlySerializer.cs
+++ b/Source/Extensions/MongoDB/DateOnlySerializer.cs
@@ -15,7 +15,7 @@ public class DateOnlySerializer : StructSerializerBase<DateOnly>
     /// <inheritdoc/>
     public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, DateOnly value)
     {
-        var dateTime = value.ToDateTime(TimeOnly.MinValue);
+        var dateTime = value.ToDateTime(new TimeOnly(12, 0));
         var ticks = BsonUtils.ToMillisecondsSinceEpoch(dateTime);
         context.Writer.WriteDateTime(ticks);
     }


### PR DESCRIPTION
### Fixed

- Fixing `DateOnlySerializer` to use mid-day point for time component when serializing to Bson Date. Without it, the date will slide a day per serialization due to timezones.
