### PR TITLE
Change to ASPNET as base image

### DIFF
--- a/Docker/BaseDevelopment/Dockerfile
+++ b/Docker/BaseDevelopment/Dockerfile
@@ -5,7 +5,7 @@
 # Build runtime image
 ####################################
 ARG VERSION
-FROM mcr.microsoft.com/dotnet/runtime:6.0.1-focal
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-focal
 
 RUN echo Version = ${VERSION}
 


### PR DESCRIPTION
### Fixed

- Changing the base image to the ASP.NET Core runtime for the base development image.
