### PR TITLE
Fix/has-data

### DIFF
--- a/Source/ApplicationModel/Frontend/queries/QueryResult.ts
+++ b/Source/ApplicationModel/Frontend/queries/QueryResult.ts
@@ -20,7 +20,6 @@ export class QueryResult<TDataType> {
      * @param {boolean} isSuccess Whether or not the query was successful.
      */
     constructor(readonly data: TDataType, readonly isSuccess: boolean) {
-        console.log('hello');
     }
 
     /**
@@ -46,9 +45,10 @@ export class QueryResult<TDataType> {
      * Gets whether or not the query has data.
      */
     get hasData(): boolean {
-        if (this.data) {
-            if (this.data.constructor === Array) {
-                if ((this.data as any).length || 0 > 0) {
+        const data = this.data as any;
+        if (data) {
+            if (data.constructor && data.constructor === Array) {
+                if (data.length || 0 > 0) {
                     return true;
                 }
             } else {

--- a/Source/ApplicationModel/Frontend/queries/QueryResult.ts
+++ b/Source/ApplicationModel/Frontend/queries/QueryResult.ts
@@ -20,6 +20,7 @@ export class QueryResult<TDataType> {
      * @param {boolean} isSuccess Whether or not the query was successful.
      */
     constructor(readonly data: TDataType, readonly isSuccess: boolean) {
+        console.log('hello');
     }
 
     /**
@@ -32,12 +33,29 @@ export class QueryResult<TDataType> {
         const jsonResponse = await response.json() as QueryResultFromServer<TModel>;
 
         let data: any = jsonResponse.data;
-        if( enumerable ) {
+        if (enumerable) {
             data = JsonSerializer.deserializeArrayFromInstance(instanceType, data);
         } else {
             data = JsonSerializer.deserializeFromInstance(instanceType, data);
         }
 
         return new QueryResult(data, jsonResponse.isSuccess && response.ok);
+    }
+
+    /**
+     * Gets whether or not the query has data.
+     */
+    get hasData(): boolean {
+        if (this.data) {
+            if (this.data.constructor === Array) {
+                if ((this.data as any).length || 0 > 0) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Source/ApplicationModel/Frontend/queries/QueryResultWithState.ts
+++ b/Source/ApplicationModel/Frontend/queries/QueryResultWithState.ts
@@ -14,9 +14,8 @@ export class QueryResultWithState<TDataType> extends QueryResult<TDataType> {
      * @param {TDataType} data The items returned, if any - can be empty.
      * @param {boolean} isSuccess Whether or not the query was successful.
      * @param {boolean} isPerforming Whether or not the query is being performed. True if its performing, false if it is done.
-     * @param {boolean} hasData Whether or not there is data in the result.
      */
-    constructor(readonly data: TDataType, readonly isSuccess: boolean, readonly isPerforming: boolean, readonly hasData: boolean) {
+    constructor(readonly data: TDataType, readonly isSuccess: boolean, readonly isPerforming: boolean) {
         super(data, isSuccess);
     }
 }

--- a/Source/ApplicationModel/Frontend/queries/for_QueryResult/when_asking_has_data/and_it_an_array_with_items.ts
+++ b/Source/ApplicationModel/Frontend/queries/for_QueryResult/when_asking_has_data/and_it_an_array_with_items.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { QueryResult } from '../../QueryResult';
+
+describe("when asking has data and it is an array with items", () => {
+    const queryResult = new QueryResult<any>([{}, {}], true);
+
+    it('should consider having data', () => queryResult.hasData.should.be.true);
+});

--- a/Source/ApplicationModel/Frontend/queries/for_QueryResult/when_asking_has_data/and_it_is_empty_array.ts
+++ b/Source/ApplicationModel/Frontend/queries/for_QueryResult/when_asking_has_data/and_it_is_empty_array.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { QueryResult } from '../../QueryResult';
+
+describe("when asking has data and it is empty array", () => {
+    const queryResult = new QueryResult<any>([], true);
+
+    it('should consider to not having data', () => queryResult.hasData.should.be.false);
+});

--- a/Source/ApplicationModel/Frontend/queries/for_QueryResult/when_asking_has_data/and_it_is_undefined copy.ts
+++ b/Source/ApplicationModel/Frontend/queries/for_QueryResult/when_asking_has_data/and_it_is_undefined copy.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { QueryResult } from '../../QueryResult';
+
+describe("when asking has data and it is defined instance", () => {
+    const queryResult = new QueryResult<any>({}, true);
+
+    it('should considered to have data', () => queryResult.hasData.should.be.true);
+});

--- a/Source/ApplicationModel/Frontend/queries/for_QueryResult/when_asking_has_data/and_it_is_undefined.ts
+++ b/Source/ApplicationModel/Frontend/queries/for_QueryResult/when_asking_has_data/and_it_is_undefined.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { QueryResult } from '../../QueryResult';
+
+describe("when asking has data and it is undefined", () => {
+    const queryResult = new QueryResult<any>(undefined, true);
+
+    it('should considered to not having data', () => queryResult.hasData.should.be.false);
+});

--- a/Source/ApplicationModel/Frontend/queries/useObservableQuery.ts
+++ b/Source/ApplicationModel/Frontend/queries/useObservableQuery.ts
@@ -23,7 +23,7 @@ export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor
     useEffect(() => {
         const subscription = queryInstance.subscribe(_ => {
             const response = _ as unknown as QueryResult<TDataType>;
-            setResult(new QueryResultWithState(response.data, response.isSuccess, false, response.isSuccess));
+            setResult(new QueryResultWithState(response.data, response.isSuccess, false, response.hasData));
         }, args as any);
 
         return () => subscription.unsubscribe();

--- a/Source/ApplicationModel/Frontend/queries/useObservableQuery.ts
+++ b/Source/ApplicationModel/Frontend/queries/useObservableQuery.ts
@@ -17,13 +17,13 @@ import { QueryResult } from './QueryResult';
  */
 export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, args?: TArguments): [QueryResultWithState<TDataType>] {
     const queryInstance = new query() as TQuery;
-    const [result, setResult] = useState<QueryResultWithState<TDataType>>(new QueryResultWithState(queryInstance.defaultValue, true, true, false));
+    const [result, setResult] = useState<QueryResultWithState<TDataType>>(new QueryResultWithState(queryInstance.defaultValue, true, true));
     const argumentsDependency = queryInstance.requestArguments.map(_ => args?.[_]);
 
     useEffect(() => {
         const subscription = queryInstance.subscribe(_ => {
             const response = _ as unknown as QueryResult<TDataType>;
-            setResult(new QueryResultWithState(response.data, response.isSuccess, false, response.hasData));
+            setResult(new QueryResultWithState(response.data, response.isSuccess, false));
         }, args as any);
 
         return () => subscription.unsubscribe();

--- a/Source/ApplicationModel/Frontend/queries/useQuery.ts
+++ b/Source/ApplicationModel/Frontend/queries/useQuery.ts
@@ -5,6 +5,7 @@ import { IQueryFor } from './IQueryFor';
 import { Constructor } from '@aksio/cratis-fundamentals';
 import { useState, useEffect } from 'react';
 import { QueryResultWithState } from './QueryResultWithState';
+import { QueryResult } from './QueryResult';
 
 /**
  * Delegate type for performing a {@link IQueryFor} in the context of the {@link useQuery} hook.
@@ -24,7 +25,7 @@ export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArgume
     const [result, setResult] = useState<QueryResultWithState<TDataType>>(new QueryResultWithState(queryInstance.defaultValue, true, true, false));
     const queryExecutor = (async (args?: TArguments) => {
         const response = await queryInstance.perform(args as any);
-        setResult(new QueryResultWithState(response.data, response.isSuccess, false, response.isSuccess));
+        setResult(new QueryResultWithState(response.data, response.isSuccess, false, response.hasData));
     });
 
     useEffect(() => {
@@ -32,7 +33,7 @@ export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArgume
     }, []);
 
     return [result, async (args?: TArguments) => {
-        setResult(new QueryResultWithState(result.data, result.isSuccess, true, result.isSuccess));
+        setResult(new QueryResultWithState(result.data, result.isSuccess, true, false));
         await queryExecutor(args);
     }];
 }

--- a/Source/ApplicationModel/Frontend/queries/useQuery.ts
+++ b/Source/ApplicationModel/Frontend/queries/useQuery.ts
@@ -22,10 +22,10 @@ export type PerformQuery<TArguments = {}> = (args?: TArguments) => Promise<void>
  */
 export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, args?: TArguments): [QueryResultWithState<TDataType>, PerformQuery<TArguments>] {
     const queryInstance = new query() as TQuery;
-    const [result, setResult] = useState<QueryResultWithState<TDataType>>(new QueryResultWithState(queryInstance.defaultValue, true, true, false));
+    const [result, setResult] = useState<QueryResultWithState<TDataType>>(new QueryResultWithState(queryInstance.defaultValue, true, true));
     const queryExecutor = (async (args?: TArguments) => {
         const response = await queryInstance.perform(args as any);
-        setResult(new QueryResultWithState(response.data, response.isSuccess, false, response.hasData));
+        setResult(new QueryResultWithState(response.data, response.isSuccess, false));
     });
 
     useEffect(() => {
@@ -33,7 +33,7 @@ export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArgume
     }, []);
 
     return [result, async (args?: TArguments) => {
-        setResult(new QueryResultWithState(result.data, result.isSuccess, true, false));
+        setResult(new QueryResultWithState(result.data, result.isSuccess, true));
         await queryExecutor(args);
     }];
 }

--- a/wallaby.js
+++ b/wallaby.js
@@ -5,12 +5,14 @@ module.exports = function (wallaby) {
             { pattern: 'Source/**/package.json', instrument: false },
             '!Source/**/*.d.ts*',
             '!Source/**/for_*/**/when_*.ts*',
+            '!Source/**/for_*/**/and_*.ts*',
             'Source/**/*.ts*'
         ],
 
         tests: [
             '!Source/**/*.d.ts*',
-            'Source/**/for_*/**/when_*.ts*'
+            'Source/**/for_*/**/when_*.ts*',
+            'Source/**/for_*/**/and_*.ts*'
         ],
 
         testFramework: 'mocha',


### PR DESCRIPTION
### Fixed

- Frontend queries based now has a `hasData` property which reflects correctly whether or not there actually is data. This gets used in the `QueryResultWithState` and can be used inside the frontend to check if there actually is data and make decisions based on it.
