### PR TITLE
Fix/enum-generation

### DIFF
--- a/Source/ApplicationModel/Tooling/ProxyGenerator/Diagnostics.cs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/Diagnostics.cs
@@ -19,7 +19,7 @@ public static class Diagnostics
             "Missing output path",
             "Missing output path for generating proxies to. Add <AksioProxyOutput/> to your .csproj file. Will not output proxies.",
             "Generation",
-            DiagnosticSeverity.Info,
+            DiagnosticSeverity.Warning,
             true),
         default);
 
@@ -35,4 +35,21 @@ public static class Diagnostics
             DiagnosticSeverity.Error,
             true),
         default);
+
+    /// <summary>
+    /// The <see cref="Diagnostic"/> to report when the output path is missing.
+    /// </summary>
+    /// <param name="exception">The exception that occurred.</param>
+    /// <returns><see cref="Diagnostics"/> for reporting.</returns>
+    public static Diagnostic UnknownError(Exception exception) => Diagnostic.Create(
+        new DiagnosticDescriptor(
+            "AKSIO0000",
+            "Error during proxy generation",
+            "Error '{0}' happened during proxy generation.",
+            "Generation",
+            DiagnosticSeverity.Warning,
+            true,
+            "Stack:\n{1}"),
+        default,
+        messageArgs: new object[] { exception.Message, exception.StackTrace });
 }

--- a/Source/ApplicationModel/Tooling/ProxyGenerator/Diagnostics.cs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/Diagnostics.cs
@@ -44,7 +44,7 @@ public static class Diagnostics
     public static Diagnostic UnknownError(Exception exception) => Diagnostic.Create(
         new DiagnosticDescriptor(
             "AKSIO0000",
-            "Error during proxy generation",
+            "Error during proxy generation.",
             "Error '{0}' happened during proxy generation.",
             "Generation",
             DiagnosticSeverity.Warning,

--- a/Source/ApplicationModel/Tooling/ProxyGenerator/Syntax/TypeSymbolExtensions.cs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/Syntax/TypeSymbolExtensions.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reflection;
 using Aksio.Cratis.Applications.ProxyGenerator.Templates;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Aksio.Cratis.Applications.ProxyGenerator.Syntax;
 
@@ -154,51 +152,13 @@ public static class TypeSymbolExtensions
     /// Gets an <see cref="EnumDescriptor"/> from a type symbol which is an enum.
     /// </summary>
     /// <param name="type"><see cref="ITypeSymbol"/> to get for.</param>
-    /// <param name="context">The current <see cref="GeneratorExecutionContext"/>.</param>
     /// <returns><see cref="EnumDescriptor"/>.</returns>
-    public static EnumDescriptor GetEnumDescriptor(this ITypeSymbol type, GeneratorExecutionContext context)
+    public static EnumDescriptor GetEnumDescriptor(this ITypeSymbol type)
     {
-        var currentEnumValue = 0;
-        List<EnumValueDescriptor> enumValues = null!;
-
-        while (!System.Diagnostics.Debugger.IsAttached) Thread.Sleep(10);
-
-        if (type.DeclaringSyntaxReferences.Length == 0)
-        {
-            var reference = context.Compilation.ExternalReferences.FirstOrDefault(_ => _.Display?.Contains(type.ContainingAssembly.MetadataName) ?? false);
-            if (reference is not null)
-            {
-                var assembly = Assembly.LoadFile(reference.Display);
-                var enumType = $"{type.ContainingNamespace}.{type.Name}";
-                var actualType = assembly.GetType(enumType);
-                if (actualType is not null)
-                {
-                    var names = Enum.GetNames(actualType);
-                    var values = Enum.GetValues(actualType).Cast<int>().ToList();
-                    enumValues = names
-                        .Select((name, index) => new EnumValueDescriptor(name, values[index]))
-                        .ToList();
-                }
-            }
-        }
-        else
-        {
-            enumValues = new List<EnumValueDescriptor>();
-            var syntax = (type.DeclaringSyntaxReferences[0].GetSyntax() as EnumDeclarationSyntax)!;
-            foreach (var member in syntax.Members)
-            {
-                if (member.EqualsValue is not null)
-                {
-                    currentEnumValue = int.Parse(member.EqualsValue.Value.ToString());
-                }
-                else
-                {
-                    currentEnumValue++;
-                }
-                enumValues.Add(new(member.Identifier.Text, currentEnumValue));
-            }
-        }
-
+        var enumValues = type
+                            .GetMembers()
+                            .Where(_ => _ is IFieldSymbol).Cast<IFieldSymbol>()
+                            .Select(_ => new EnumValueDescriptor(_.Name, int.Parse(_.ConstantValue?.ToString() ?? "0")));
         return new EnumDescriptor(type.Name, enumValues);
     }
 

--- a/Source/Fundamentals/Concepts/ConceptAs.cs
+++ b/Source/Fundamentals/Concepts/ConceptAs.cs
@@ -34,6 +34,6 @@ public record ConceptAs<T>
     /// <inheritdoc/>
     public sealed override string ToString()
     {
-        return Value?.ToString() ?? "[n/a]";
+        return Value!.ToString() ?? "[n/a]";
     }
 }

--- a/Source/Workbench/API/events/store/observers/FailedObserverPartition.ts
+++ b/Source/Workbench/API/events/store/observers/FailedObserverPartition.ts
@@ -6,18 +6,25 @@ import { field } from '@aksio/cratis-fundamentals';
 
 
 export class FailedObserverPartition {
+
     @field(String)
     eventSourceId!: string;
+
     @field(Number)
     sequenceNumber!: number;
+
     @field(Date)
     occurred!: Date;
+
     @field(Date)
     lastAttempt!: Date;
+
     @field(Number)
     attempts!: number;
+
     @field(String, true)
     messages!: string[];
+
     @field(String)
     stackTrace!: string;
 }

--- a/Source/Workbench/API/events/store/observers/ObserverRunningState.ts
+++ b/Source/Workbench/API/events/store/observers/ObserverRunningState.ts
@@ -2,8 +2,17 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { field } from '@aksio/cratis-fundamentals';
-
-
-export class ObserverRunningState {
+export enum ObserverRunningState {
+    new = 0,
+    subscribing = 1,
+    rewinding = 2,
+    replaying = 3,
+    catchingUp = 4,
+    active = 5,
+    paused = 6,
+    stopped = 7,
+    suspended = 8,
+    failed = 9,
+    tailOfReplay = 10,
+    disconnected = 11,
 }

--- a/Source/Workbench/API/events/store/observers/ObserverState.ts
+++ b/Source/Workbench/API/events/store/observers/ObserverState.ts
@@ -11,32 +11,46 @@ import { FailedObserverPartition } from './FailedObserverPartition';
 import { RecoveringFailedObserverPartition } from './RecoveringFailedObserverPartition';
 
 export class ObserverState {
+
     @field(String)
     id!: string;
+
     @field(EventType, true)
     eventTypes!: EventType[];
+
     @field(String)
     eventSequenceId!: string;
+
     @field(String)
     observerId!: string;
+
     @field(String)
     name!: string;
-    @field(ObserverType)
+
+    @field(Number)
     type!: ObserverType;
+
     @field(Number)
     nextEventSequenceNumber!: number;
+
     @field(Number)
     lastHandled!: number;
-    @field(ObserverRunningState)
+
+    @field(Number)
     runningState!: ObserverRunningState;
+
     @field(String)
     currentNamespace!: string;
+
     @field(FailedObserverPartition, true)
     failedPartitions!: FailedObserverPartition[];
+
     @field(RecoveringFailedObserverPartition, true)
     recoveringPartitions!: RecoveringFailedObserverPartition[];
+
     @field(Boolean)
     hasFailedPartitions!: boolean;
+
     @field(Boolean)
     isRecoveringAnyPartition!: boolean;
 }

--- a/Source/Workbench/API/events/store/observers/ObserverType.ts
+++ b/Source/Workbench/API/events/store/observers/ObserverType.ts
@@ -2,8 +2,9 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { field } from '@aksio/cratis-fundamentals';
-
-
-export class ObserverType {
+export enum ObserverType {
+    unknown = 0,
+    client = 1,
+    projection = 2,
+    inbox = 3,
 }

--- a/Source/Workbench/API/events/store/observers/RecoveringFailedObserverPartition.ts
+++ b/Source/Workbench/API/events/store/observers/RecoveringFailedObserverPartition.ts
@@ -6,10 +6,13 @@ import { field } from '@aksio/cratis-fundamentals';
 
 
 export class RecoveringFailedObserverPartition {
+
     @field(String)
     eventSourceId!: string;
+
     @field(Number)
     sequenceNumber!: number;
+
     @field(Date)
     startedRecoveryAt!: Date;
 }

--- a/Source/Workbench/API/events/store/sequence/AppendedEvent.ts
+++ b/Source/Workbench/API/events/store/sequence/AppendedEvent.ts
@@ -9,10 +9,13 @@ import { EventContext } from './EventContext';
 import { JsonObject } from './JsonObject';
 
 export class AppendedEvent {
+
     @field(EventMetadata)
     metadata!: EventMetadata;
+
     @field(EventContext)
     context!: EventContext;
+
     @field(JsonObject, true)
     content!: JsonObject[];
 }

--- a/Source/Workbench/API/events/store/sequence/EventContext.ts
+++ b/Source/Workbench/API/events/store/sequence/EventContext.ts
@@ -7,22 +7,31 @@ import { field } from '@aksio/cratis-fundamentals';
 import { EventObservationState } from './EventObservationState';
 
 export class EventContext {
+
     @field(String)
     eventSourceId!: string;
+
     @field(Number)
     sequenceNumber!: number;
+
     @field(Date)
     occurred!: Date;
+
     @field(Date)
     validFrom!: Date;
+
     @field(String)
     tenantId!: string;
+
     @field(String)
     correlationId!: string;
+
     @field(String)
     causationId!: string;
+
     @field(String)
     causedBy!: string;
-    @field(EventObservationState)
+
+    @field(Number)
     observationState!: EventObservationState;
 }

--- a/Source/Workbench/API/events/store/sequence/EventObservationState.ts
+++ b/Source/Workbench/API/events/store/sequence/EventObservationState.ts
@@ -2,8 +2,10 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { field } from '@aksio/cratis-fundamentals';
-
-
-export class EventObservationState {
+export enum EventObservationState {
+    none = 0,
+    initial = 1,
+    headOfReplay = 2,
+    replay = 4,
+    tailOfReplay = 8,
 }

--- a/Source/Workbench/API/events/store/sequence/JsonObject.ts
+++ b/Source/Workbench/API/events/store/sequence/JsonObject.ts
@@ -6,6 +6,7 @@ import { field } from '@aksio/cratis-fundamentals';
 
 
 export class JsonObject {
+
     @field(Number)
     count!: number;
 }


### PR DESCRIPTION
### Fixed

- Fixing a problem with enum proxy generators that were too complex and looking for the wrong syntax element during compilation, causing them to crash when enum was in a 3rd party referenced assembly.
