### PR TITLE
Taking ProxyGenerator out as a cross cutting thing and adding it explicitly into the projects that need it

### DIFF
--- a/Source/Kernel/Compliance/Domain/Domain.csproj
+++ b/Source/Kernel/Compliance/Domain/Domain.csproj
@@ -4,6 +4,8 @@
         <RootNamespace>Aksio.Cratis.Compliance.Domain</RootNamespace>
     </PropertyGroup>
 
+    <Import Project="../../ProxyGeneration.props"/>
+
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/Source/Kernel/Compliance/Read/Read.csproj
+++ b/Source/Kernel/Compliance/Read/Read.csproj
@@ -4,6 +4,8 @@
         <RootNamespace>Aksio.Cratis.Compliance.Read</RootNamespace>
     </PropertyGroup>
 
+    <Import Project="../../ProxyGeneration.props"/>
+
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/Source/Kernel/Configuration/Api/Api.csproj
+++ b/Source/Kernel/Configuration/Api/Api.csproj
@@ -4,6 +4,8 @@
         <RootNamespace>Aksio.Cratis.Configuration.Api</RootNamespace>
     </PropertyGroup>
 
+    <Import Project="../../ProxyGeneration.props"/>
+
     <ItemGroup>
         <ProjectReference Include="../Shared/Shared.csproj" />
         <ProjectReference Include="../Grains.Interfaces/Grains.Interfaces.csproj" />

--- a/Source/Kernel/Directory.Build.props
+++ b/Source/Kernel/Directory.Build.props
@@ -1,15 +1,5 @@
 <Project>
     <Import Project="$(MSBuildThisFileDirectory)../../Directory.Build.props"/>
-    <PropertyGroup>
-        <AksioProxyOutput>$(MSBuildThisFileDirectory)../Workbench/API</AksioProxyOutput>
-        <AksioUseRouteAsPath>true</AksioUseRouteAsPath>
-    </PropertyGroup>
-
-    <Import Project="$(MSBuildThisFileDirectory)../ApplicationModel/Tooling/ProxyGenerator/build/Aksio.Cratis.Applications.ProxyGenerator.props"/>
-
-    <ItemGroup>
-        <ProjectReference Include="$(MSBuildThisFileDirectory)../ApplicationModel/Tooling/ProxyGenerator/ProxyGenerator.csproj" OutputItemType="Analyzer" Private="true"/>
-    </ItemGroup>
 
     <ItemGroup>
         <Compile Include="$(MSBuildThisFileDirectory)/GlobalUsings.cs"/>

--- a/Source/Kernel/Projections/Api/Api.csproj
+++ b/Source/Kernel/Projections/Api/Api.csproj
@@ -4,6 +4,8 @@
         <RootNamespace>Aksio.Cratis.Events.Projections.Api</RootNamespace>
     </PropertyGroup>
 
+    <Import Project="../../ProxyGeneration.props"/>
+
     <ItemGroup>
         <ProjectReference Include="../Engine/Engine.csproj" />
         <ProjectReference Include="../../../ApplicationModel/CQRS.MongoDB/CQRS.MongoDB.csproj"/>

--- a/Source/Kernel/ProxyGeneration.props
+++ b/Source/Kernel/ProxyGeneration.props
@@ -1,0 +1,12 @@
+<Project>
+    <PropertyGroup>
+        <AksioProxyOutput>$(MSBuildThisFileDirectory)../Workbench/API</AksioProxyOutput>
+        <AksioUseRouteAsPath>true</AksioUseRouteAsPath>
+    </PropertyGroup>
+
+    <Import Project="$(MSBuildThisFileDirectory)../ApplicationModel/Tooling/ProxyGenerator/build/Aksio.Cratis.Applications.ProxyGenerator.props"/>
+
+    <ItemGroup>
+        <ProjectReference Include="$(MSBuildThisFileDirectory)../ApplicationModel/Tooling/ProxyGenerator/ProxyGenerator.csproj" OutputItemType="Analyzer" Private="true"/>
+    </ItemGroup>
+</Project>

--- a/Source/Kernel/Schemas/Api/Api.csproj
+++ b/Source/Kernel/Schemas/Api/Api.csproj
@@ -4,6 +4,8 @@
         <RootNamespace>Aksio.Cratis.Events.Schemas.Api</RootNamespace>
     </PropertyGroup>
 
+    <Import Project="../../ProxyGeneration.props"/>
+
     <ItemGroup>
         <ProjectReference Include="../Shared/Shared.csproj" />
     </ItemGroup>

--- a/Source/Kernel/Store/Api/Api.csproj
+++ b/Source/Kernel/Store/Api/Api.csproj
@@ -4,6 +4,8 @@
         <RootNamespace>Aksio.Cratis.Events.Store.Api</RootNamespace>
     </PropertyGroup>
 
+    <Import Project="../../ProxyGeneration.props"/>
+
     <ItemGroup>
         <ProjectReference Include="../../Events/Events.csproj" />
         <ProjectReference Include="../Shared/Shared.csproj" />


### PR DESCRIPTION
### Fixed

- Removing reference to the proxy generator for all assemblies related to Kernel and just add it to the API projects. This way we're not pulling the proxy generator implicitly into everything when referencing the C# SDK. (Plus added benefit of faster Cratis compile times :))
