### PR TITLE
Adding checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -160,6 +160,9 @@ jobs:
     needs: [release]
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
### Fixed

- Fixing publish pipeline after breaking into NuGet and NPM package jobs. Adding the needed checkout for the NPM job.
