### PR TITLE
Removing debugger statement left in while debugging

### DIFF
--- a/Source/ApplicationModel/Tooling/ProxyGenerator/SourceGenerator.cs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/SourceGenerator.cs
@@ -317,11 +317,6 @@ public class SourceGenerator : ISourceGenerator
 
         foreach (var property in properties)
         {
-            if (property.Name == "SatsKap19" && property.ContainingType.Name == "VedtakAP19441953")
-            {
-                while (!System.Diagnostics.Debugger.IsAttached) Thread.Sleep(10);
-            }
-
             var propertyType = property.Type;
             var isNullable = false;
             if (property.NullableAnnotation == NullableAnnotation.Annotated && property.Type is INamedTypeSymbol namedTypeSymbol)


### PR DESCRIPTION
### Fixed

- Removing debugger statement in proxy generator that was left in while hunting down a problem.
