### PR TITLE
If not possible to parse JSON, return empty command result

### DIFF
--- a/Source/ApplicationModel/Frontend/commands/Command.ts
+++ b/Source/ApplicationModel/Frontend/commands/Command.ts
@@ -48,9 +48,12 @@ export abstract class Command<TCommandContent = {}> implements ICommand<TCommand
         });
         this.setInitialValuesFromCurrentValues();
 
-        const result = await response.json();
-
-        return new CommandResult(result);
+        try {
+            const result = await response.json();
+            return new CommandResult(result);
+        } catch (ex) {
+            return CommandResult.empty;
+        }
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
### Fixed

- Due to #359 the frontend does not get a valid JSON on 200 OK responses. This is now taken into account and it will return a valid command result if this happens.
