### PR TITLE
Up and running with API and definition for All expressions

### DIFF
--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Domain/Customers/Customers.cs
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Domain/Customers/Customers.cs
@@ -10,7 +10,7 @@ public class Customers : Controller
 {
     readonly IEventLog _eventLog;
 
-    public  Customers(IEventLog eventLog) => _eventLog = eventLog;
+    public Customers(IEventLog eventLog) => _eventLog = eventLog;
 
     [HttpPost]
     public Task RegisterCustomer(RegisterCustomer command) => _eventLog.Append(command.CustomerId, new CustomerRegistered(command.FirstName, command.LastName, command.SocialSecurityNumber));

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Read.Specs/Accounts/Debit/for_DebitAccountProjection/when_opening_account.cs
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Read.Specs/Accounts/Debit/for_DebitAccountProjection/when_opening_account.cs
@@ -23,6 +23,6 @@ public class when_opening_account : ProjectionSpecificationFor<DebitAccount>
     }
 
     [Fact] void should_set_account_name() => result.Model.Name.Value.ShouldEqual(account_name);
-    [Fact] void should_set_owner() => result.Model.Owner.Value.ShouldEqual(Guid.Parse(owner_id));
+    [Fact] void should_set_owner_id() => result.Model.OwnerId.Value.ShouldEqual(Guid.Parse(owner_id));
     [Fact] void should_set_has_card() => ((bool)result.Model.HasCard).ShouldEqual(true);
 }

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Read/AccountHolders/AccountHolderWithAccountsObserver.cs
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Read/AccountHolders/AccountHolderWithAccountsObserver.cs
@@ -25,29 +25,29 @@ public class AccountHolderWithAccountsObserver
 
     public Task AccountHolderRegistered(AccountHolderRegistered @event, EventContext context)
     {
-        var CustomerId = GetCustomerIdFromString(context.EventSourceId);
-        var model = new AccountHolderWithAccounts(CustomerId, @event.FirstName, @event.LastName, new());
-        return _collection.ReplaceOneAsync(_ => _.Id == CustomerId, model, new ReplaceOptions { IsUpsert = true });
+        var customerId = GetCustomerIdFromString(context.EventSourceId);
+        var model = new AccountHolderWithAccounts(customerId, @event.FirstName, @event.LastName, new());
+        return _collection.ReplaceOneAsync(_ => _.Id == customerId, model, new ReplaceOptions { IsUpsert = true });
     }
 
     public async Task CreditAccountOpened(CreditAccountOpened @event, EventContext context)
     {
-        var CustomerId = @event.Owner;
-        var personalInformation = await _immediateProjections.GetInstanceById<AccountHolderPersonalInformation>(CustomerId.Value);
+        var customerId = @event.Owner;
+        var personalInformation = await _immediateProjections.GetInstanceById<AccountHolderPersonalInformation>(customerId.Value);
         var result = await _collection.FindAsync(_ => _.Id == @event.Owner);
-        var model = result.FirstOrDefault() ?? new(CustomerId, personalInformation.FirstName, personalInformation.LastName, new Collection<IAccount>());
+        var model = result.FirstOrDefault() ?? new(customerId, personalInformation.FirstName, personalInformation.LastName, new Collection<IAccount>());
         model.Accounts.Add(new CreditAccount(@context.EventSourceId, @event.Name, AccountType.Credit));
-        await _collection.ReplaceOneAsync(_ => _.Id == CustomerId, model, new ReplaceOptions { IsUpsert = true });
+        await _collection.ReplaceOneAsync(_ => _.Id == customerId, model, new ReplaceOptions { IsUpsert = true });
     }
 
     public async Task DebitAccountOpened(DebitAccountOpened @event, EventContext context)
     {
-        var CustomerId = @event.Owner;
-        var personalInformation = await _immediateProjections.GetInstanceById<AccountHolderPersonalInformation>(CustomerId.Value);
+        var customerId = @event.Owner;
+        var personalInformation = await _immediateProjections.GetInstanceById<AccountHolderPersonalInformation>(customerId.Value);
         var result = await _collection.FindAsync(_ => _.Id == @event.Owner);
-        var model = result.FirstOrDefault() ?? new(CustomerId, personalInformation.FirstName, personalInformation.LastName, new Collection<IAccount>());
+        var model = result.FirstOrDefault() ?? new(customerId, personalInformation.FirstName, personalInformation.LastName, new Collection<IAccount>());
         model.Accounts.Add(new DebitAccount(@context.EventSourceId, @event.Name, AccountType.Debit));
-        await _collection.ReplaceOneAsync(_ => _.Id == CustomerId, model, new ReplaceOptions { IsUpsert = true });
+        await _collection.ReplaceOneAsync(_ => _.Id == customerId, model, new ReplaceOptions { IsUpsert = true });
     }
 
 #pragma warning disable CA5351

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/Owner.ts
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/Owner.ts
@@ -4,28 +4,12 @@
 
 import { field } from '@aksio/cratis-fundamentals';
 
-import { Owner } from './Owner';
 
-export class DebitAccount {
-
-    @field(String)
-    id!: string;
+export class Owner {
 
     @field(String)
-    name!: string;
+    firstName!: string;
 
     @field(String)
-    ownerId!: string;
-
-    @field(Owner)
-    owner!: Owner;
-
-    @field(Number)
-    balance?: number;
-
-    @field(Boolean)
-    hasCard!: boolean;
-
-    @field(Date)
-    lastUpdated!: Date;
+    lastName!: string;
 }

--- a/Source/Clients/DotNET/Events/Projections/AllBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/AllBuilder.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq.Expressions;
+using Aksio.Cratis.Events.Projections.Definitions;
+using Aksio.Cratis.Reflection;
+
+namespace Aksio.Cratis.Events.Projections;
+
+/// <summary>
+/// Represents an implementation of <see cref="IAllBuilder{TModel}"/>.
+/// </summary>
+/// <typeparam name="TModel">Type of model to build for.</typeparam>
+public class AllBuilder<TModel> : IAllBuilder<TModel>
+{
+    readonly List<IPropertyExpressionBuilder> _propertyExpressions = new();
+
+    /// <inheritdoc/>
+    public IAllSetBuilder<TModel, IAllBuilder<TModel>> Set<TProperty>(Expression<Func<TModel, TProperty>> modelPropertyAccessor)
+    {
+        var setBuilder = new AllSetBuilder<TModel, IAllBuilder<TModel>>(this, modelPropertyAccessor.GetPropertyPath());
+        _propertyExpressions.Add(setBuilder);
+        return setBuilder;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="AllDefinition"/> from expressions.
+    /// </summary>
+    /// <returns>A new <see cref="AllDefinition"/> instance.</returns>
+    public AllDefinition Build() => new(_propertyExpressions.ToDictionary(_ => _.TargetProperty, _ => _.Build()));
+}

--- a/Source/Clients/DotNET/Events/Projections/AllBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/AllBuilder.cs
@@ -14,6 +14,7 @@ namespace Aksio.Cratis.Events.Projections;
 public class AllBuilder<TModel> : IAllBuilder<TModel>
 {
     readonly List<IPropertyExpressionBuilder> _propertyExpressions = new();
+    bool _includeChildren;
 
     /// <inheritdoc/>
     public IAllSetBuilder<TModel, IAllBuilder<TModel>> Set<TProperty>(Expression<Func<TModel, TProperty>> modelPropertyAccessor)
@@ -23,9 +24,16 @@ public class AllBuilder<TModel> : IAllBuilder<TModel>
         return setBuilder;
     }
 
+    /// <inheritdoc/>
+    public IAllBuilder<TModel> IncludeChildProjections()
+    {
+        _includeChildren = true;
+        return this;
+    }
+
     /// <summary>
     /// Builds a <see cref="AllDefinition"/> from expressions.
     /// </summary>
     /// <returns>A new <see cref="AllDefinition"/> instance.</returns>
-    public AllDefinition Build() => new(_propertyExpressions.ToDictionary(_ => _.TargetProperty, _ => _.Build()));
+    public AllDefinition Build() => new(_propertyExpressions.ToDictionary(_ => _.TargetProperty, _ => _.Build()), _includeChildren);
 }

--- a/Source/Clients/DotNET/Events/Projections/AllSetBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/AllSetBuilder.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq.Expressions;
+using Aksio.Cratis.Events.Projections.Expressions;
+using Aksio.Cratis.Events.Store;
+using Aksio.Cratis.Properties;
+using Aksio.Cratis.Reflection;
+
+namespace Aksio.Cratis.Events.Projections;
+
+/// <summary>
+/// Represents an implementation of <see cref="IAllSetBuilder{TModel, TParentBuilder}"/>.
+/// </summary>
+/// <typeparam name="TModel">Model to build for.</typeparam>
+/// <typeparam name="TParentBuilder">Type of the parent builder.</typeparam>
+public class AllSetBuilder<TModel, TParentBuilder> : IAllSetBuilder<TModel, TParentBuilder>
+{
+    readonly TParentBuilder _parent;
+    IEventValueExpression? _expression;
+
+    /// <inheritdoc/>
+    public PropertyPath TargetProperty { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SetBuilder{TModel, TEvent, TProperty, TParentBuilder}"/> class.
+    /// </summary>
+    /// <param name="parent">Parent builder.</param>
+    /// <param name="targetProperty">Target property we're building for.</param>
+    public AllSetBuilder(TParentBuilder parent, PropertyPath targetProperty)
+    {
+        _parent = parent;
+        TargetProperty = targetProperty;
+    }
+
+    /// <inheritdoc/>
+    public TParentBuilder ToEventSourceId()
+    {
+        _expression = new EventSourceIdExpression();
+        return _parent;
+    }
+
+    /// <inheritdoc/>
+    public TParentBuilder ToEventContextProperty(Expression<Func<EventContext, object>> eventContextPropertyAccessor)
+    {
+        _expression = new EventContextPropertyExpression(eventContextPropertyAccessor.GetPropertyPath());
+        return _parent;
+    }
+
+    /// <inheritdoc/>
+    public string Build()
+    {
+        ThrowIfMissingToExpression();
+
+        return _expression!.Build();
+    }
+
+    void ThrowIfMissingToExpression()
+    {
+        if (_expression is null)
+        {
+            throw new MissingToExpressionForAllSet(typeof(TModel), TargetProperty);
+        }
+    }
+}

--- a/Source/Clients/DotNET/Events/Projections/ChildrenBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/ChildrenBuilder.cs
@@ -25,9 +25,9 @@ public class ChildrenBuilder<TParentModel, TChildModel> : IChildrenBuilder<TPare
     readonly JsonSerializerOptions _jsonSerializerOptions;
     readonly Dictionary<EventType, FromDefinition> _fromDefinitions = new();
     readonly Dictionary<EventType, JoinDefinition> _joinDefinitions = new();
-    AllDefinition _allDefinition = new(new Dictionary<PropertyPath, string>(), false);
     readonly Dictionary<PropertyPath, ChildrenDefinition> _childrenDefinitions = new();
     readonly string _modelName;
+    AllDefinition _allDefinition = new(new Dictionary<PropertyPath, string>(), false);
     string _identifiedBy = string.Empty;
     EventType? _removedWithEvent;
     JsonObject _initialValues = (JsonObject)JsonNode.Parse("{}")!;
@@ -83,8 +83,9 @@ public class ChildrenBuilder<TParentModel, TChildModel> : IChildrenBuilder<TPare
         var builder = new AllBuilder<TChildModel>();
         builderCallback(builder);
         var allDefinition = builder.Build();
-        allDefinition.Properties.Concat(_allDefinition.Properties);
-        _allDefinition = allDefinition;
+        _allDefinition = new AllDefinition(
+            new Dictionary<PropertyPath, string>(_allDefinition.Properties.Concat(allDefinition.Properties)),
+            allDefinition.IncludeChildren);
         return this;
     }
 

--- a/Source/Clients/DotNET/Events/Projections/ChildrenBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/ChildrenBuilder.cs
@@ -25,7 +25,7 @@ public class ChildrenBuilder<TParentModel, TChildModel> : IChildrenBuilder<TPare
     readonly JsonSerializerOptions _jsonSerializerOptions;
     readonly Dictionary<EventType, FromDefinition> _fromDefinitions = new();
     readonly Dictionary<EventType, JoinDefinition> _joinDefinitions = new();
-    AllDefinition _allDefinition = new(new Dictionary<PropertyPath, string>());
+    AllDefinition _allDefinition = new(new Dictionary<PropertyPath, string>(), false);
     readonly Dictionary<PropertyPath, ChildrenDefinition> _childrenDefinitions = new();
     readonly string _modelName;
     string _identifiedBy = string.Empty;
@@ -83,7 +83,8 @@ public class ChildrenBuilder<TParentModel, TChildModel> : IChildrenBuilder<TPare
         var builder = new AllBuilder<TChildModel>();
         builderCallback(builder);
         var allDefinition = builder.Build();
-        _allDefinition.Properties.Concat(allDefinition.Properties);
+        allDefinition.Properties.Concat(_allDefinition.Properties);
+        _allDefinition = allDefinition;
         return this;
     }
 

--- a/Source/Clients/DotNET/Events/Projections/ChildrenBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/ChildrenBuilder.cs
@@ -25,6 +25,7 @@ public class ChildrenBuilder<TParentModel, TChildModel> : IChildrenBuilder<TPare
     readonly JsonSerializerOptions _jsonSerializerOptions;
     readonly Dictionary<EventType, FromDefinition> _fromDefinitions = new();
     readonly Dictionary<EventType, JoinDefinition> _joinDefinitions = new();
+    AllDefinition _allDefinition = new(new Dictionary<PropertyPath, string>());
     readonly Dictionary<PropertyPath, ChildrenDefinition> _childrenDefinitions = new();
     readonly string _modelName;
     string _identifiedBy = string.Empty;
@@ -77,6 +78,16 @@ public class ChildrenBuilder<TParentModel, TChildModel> : IChildrenBuilder<TPare
     }
 
     /// <inheritdoc/>
+    public IChildrenBuilder<TParentModel, TChildModel> All(Action<IAllBuilder<TChildModel>> builderCallback)
+    {
+        var builder = new AllBuilder<TChildModel>();
+        builderCallback(builder);
+        var allDefinition = builder.Build();
+        _allDefinition.Properties.Concat(allDefinition.Properties);
+        return this;
+    }
+
+    /// <inheritdoc/>
     public IChildrenBuilder<TParentModel, TChildModel> IdentifiedBy<TProperty>(Expression<Func<TChildModel, TProperty>> propertyExpression)
     {
         _identifiedBy = propertyExpression.GetPropertyPath();
@@ -109,6 +120,7 @@ public class ChildrenBuilder<TParentModel, TChildModel> : IChildrenBuilder<TPare
             _fromDefinitions,
             _joinDefinitions,
             _childrenDefinitions,
+            _allDefinition,
             _removedWithEvent == default ? default : new RemovedWithDefinition(_removedWithEvent));
     }
 }

--- a/Source/Clients/DotNET/Events/Projections/IAllBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/IAllBuilder.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq.Expressions;
+
+namespace Aksio.Cratis.Events.Projections;
+
+/// <summary>
+/// Defines the builder for building properties that can be set by all events.
+/// </summary>
+/// <typeparam name="TModel">Type of model to build for.</typeparam>
+public interface IAllBuilder<TModel>
+{
+    /// <summary>
+    /// Start building the set operation to a target property on the model.
+    /// </summary>
+    /// <typeparam name="TProperty">Type of the property.</typeparam>
+    /// <param name="modelPropertyAccessor">Model property accessor for defining the target property.</param>
+    /// <returns>The <see cref="IAllSetBuilder{TModel, TBuilder}"/> to build up the property expressions.</returns>
+    IAllSetBuilder<TModel, IAllBuilder<TModel>> Set<TProperty>(Expression<Func<TModel, TProperty>> modelPropertyAccessor);
+}

--- a/Source/Clients/DotNET/Events/Projections/IAllBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/IAllBuilder.cs
@@ -18,4 +18,10 @@ public interface IAllBuilder<TModel>
     /// <param name="modelPropertyAccessor">Model property accessor for defining the target property.</param>
     /// <returns>The <see cref="IAllSetBuilder{TModel, TBuilder}"/> to build up the property expressions.</returns>
     IAllSetBuilder<TModel, IAllBuilder<TModel>> Set<TProperty>(Expression<Func<TModel, TProperty>> modelPropertyAccessor);
+
+    /// <summary>
+    /// Instruct the all definition to include all child projections.
+    /// </summary>
+    /// <returns>Builder continuation.</returns>
+    IAllBuilder<TModel> IncludeChildProjections();
 }

--- a/Source/Clients/DotNET/Events/Projections/IAllSetBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/IAllSetBuilder.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq.Expressions;
+using Aksio.Cratis.Events.Store;
+
+namespace Aksio.Cratis.Events.Projections;
+
+/// <summary>
+/// Defines a builder for building set operations for properties that will be applied for all events the projection is projecting from - represented as expressions.
+/// </summary>
+/// <typeparam name="TModel">Model to build for.</typeparam>
+/// <typeparam name="TParentBuilder">Type of the parent builder.</typeparam>
+public interface IAllSetBuilder<TModel, TParentBuilder> : IPropertyExpressionBuilder
+{
+    /// <summary>
+    /// Map to the event source id on the metadata of the event.
+    /// </summary>
+    /// <returns>Builder continuation.</returns>
+    TParentBuilder ToEventSourceId();
+
+    /// <summary>
+    /// Map to a property on the <see cref="EventContext"/>.
+    /// </summary>
+    /// <param name="eventContextPropertyAccessor">Property accessor for specifying which property to map to.</param>
+    /// <returns>Builder continuation.</returns>
+    TParentBuilder ToEventContextProperty(Expression<Func<EventContext, object>> eventContextPropertyAccessor);
+}

--- a/Source/Clients/DotNET/Events/Projections/IChildrenBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/IChildrenBuilder.cs
@@ -42,6 +42,13 @@ public interface IChildrenBuilder<TParentModel, TChildModel>
     IChildrenBuilder<TParentModel, TChildModel> Join<TEvent>(Action<IJoinBuilder<TChildModel, TEvent>> builderCallback);
 
     /// <summary>
+    /// Start building property expressions that applies for all events being projected from.
+    /// </summary>
+    /// <param name="builderCallback">Callback for building.</param>
+    /// <returns>Builder continuation.</returns>
+    IChildrenBuilder<TParentModel, TChildModel> All(Action<IAllBuilder<TChildModel>> builderCallback);
+
+    /// <summary>
     /// Sets the property that identifies the child model in the collection within the parent.
     /// </summary>
     /// <param name="propertyExpression">The expression that represents the property used to identify.</param>

--- a/Source/Clients/DotNET/Events/Projections/IModelPropertiesBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/IModelPropertiesBuilder.cs
@@ -76,6 +76,6 @@ public interface IModelPropertiesBuilder<TModel, TEvent, TBuilder>
     /// </summary>
     /// <typeparam name="TProperty">Type of the property.</typeparam>
     /// <param name="modelPropertyAccessor">Model property accessor for defining the target property.</param>
-    /// <returns>Builder continuation.</returns>
+    /// <returns>The <see cref="ISetBuilder{TModel, Tevent, TProperty, TBuilder}"/> to continue building on.</returns>
     ISetBuilder<TModel, TEvent, TProperty, TBuilder> Set<TProperty>(Expression<Func<TModel, TProperty>> modelPropertyAccessor);
 }

--- a/Source/Clients/DotNET/Events/Projections/IProjectionBuilderFor.cs
+++ b/Source/Clients/DotNET/Events/Projections/IProjectionBuilderFor.cs
@@ -61,6 +61,13 @@ public interface IProjectionBuilderFor<TModel>
     IProjectionBuilderFor<TModel> Join<TEvent>(Action<IJoinBuilder<TModel, TEvent>> builderCallback);
 
     /// <summary>
+    /// Start building property expressions that applies for all events being projected from.
+    /// </summary>
+    /// <param name="builderCallback">Callback for building.</param>
+    /// <returns>Builder continuation.</returns>
+    IProjectionBuilderFor<TModel> All(Action<IAllBuilder<TModel>> builderCallback);
+
+    /// <summary>
     /// Define an event type that causes a delete in the projected result.
     /// </summary>
     /// <typeparam name="TEvent">Type of event.</typeparam>

--- a/Source/Clients/DotNET/Events/Projections/MissingToExpressionForAllSet.cs
+++ b/Source/Clients/DotNET/Events/Projections/MissingToExpressionForAllSet.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Properties;
+
+namespace Aksio.Cratis.Events.Projections;
+
+/// <summary>
+/// Exception that gets thrown when a to expression is missing in a mapping.
+/// </summary>
+public class MissingToExpressionForAllSet : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingToExpressionForAllSet"/> class.
+    /// </summary>
+    /// <param name="modelType">Type of model the expression is missing for.</param>
+    /// <param name="propertyPath">Path within the model the expression is missing for.</param>
+    public MissingToExpressionForAllSet(Type modelType, PropertyPath propertyPath)
+        : base($"Property '{propertyPath}' on '{modelType.FullName}' is missing a `.To...()` expression when mapping in an all expression")
+    {
+    }
+}

--- a/Source/Clients/DotNET/Events/Projections/ProjectionBuilderFor.cs
+++ b/Source/Clients/DotNET/Events/Projections/ProjectionBuilderFor.cs
@@ -29,6 +29,7 @@ public class ProjectionBuilderFor<TModel> : IProjectionBuilderFor<TModel>
     readonly Dictionary<EventType, FromDefinition> _fromDefinitions = new();
     readonly Dictionary<PropertyPath, ChildrenDefinition> _childrenDefinitions = new();
     readonly Dictionary<EventType, JoinDefinition> _joinDefinitions = new();
+    AllDefinition _allDefinition = new(new Dictionary<PropertyPath, string>());
     bool _isRewindable = true;
     string _modelName;
     string? _name;
@@ -112,6 +113,16 @@ public class ProjectionBuilderFor<TModel> : IProjectionBuilderFor<TModel>
     }
 
     /// <inheritdoc/>
+    public IProjectionBuilderFor<TModel> All(Action<IAllBuilder<TModel>> builderCallback)
+    {
+        var builder = new AllBuilder<TModel>();
+        builderCallback(builder);
+        var allDefinition = builder.Build();
+        _allDefinition.Properties.Concat(allDefinition.Properties);
+        return this;
+    }
+
+    /// <inheritdoc/>
     public IProjectionBuilderFor<TModel> RemovedWith<TEvent>()
     {
         if (_removedWithEvent != default)
@@ -151,6 +162,7 @@ public class ProjectionBuilderFor<TModel> : IProjectionBuilderFor<TModel>
             _fromDefinitions,
             _joinDefinitions,
             _childrenDefinitions,
+            _allDefinition,
             _removedWithEvent == default ? default : new RemovedWithDefinition(_removedWithEvent));
     }
 }

--- a/Source/Clients/DotNET/Events/Projections/ProjectionBuilderFor.cs
+++ b/Source/Clients/DotNET/Events/Projections/ProjectionBuilderFor.cs
@@ -29,7 +29,7 @@ public class ProjectionBuilderFor<TModel> : IProjectionBuilderFor<TModel>
     readonly Dictionary<EventType, FromDefinition> _fromDefinitions = new();
     readonly Dictionary<PropertyPath, ChildrenDefinition> _childrenDefinitions = new();
     readonly Dictionary<EventType, JoinDefinition> _joinDefinitions = new();
-    AllDefinition _allDefinition = new(new Dictionary<PropertyPath, string>());
+    AllDefinition _allDefinition = new(new Dictionary<PropertyPath, string>(), false);
     bool _isRewindable = true;
     string _modelName;
     string? _name;
@@ -118,7 +118,8 @@ public class ProjectionBuilderFor<TModel> : IProjectionBuilderFor<TModel>
         var builder = new AllBuilder<TModel>();
         builderCallback(builder);
         var allDefinition = builder.Build();
-        _allDefinition.Properties.Concat(allDefinition.Properties);
+        allDefinition.Properties.Concat(_allDefinition.Properties);
+        _allDefinition = allDefinition;
         return this;
     }
 

--- a/Source/Clients/DotNET/Events/Projections/ProjectionBuilderFor.cs
+++ b/Source/Clients/DotNET/Events/Projections/ProjectionBuilderFor.cs
@@ -118,8 +118,9 @@ public class ProjectionBuilderFor<TModel> : IProjectionBuilderFor<TModel>
         var builder = new AllBuilder<TModel>();
         builderCallback(builder);
         var allDefinition = builder.Build();
-        allDefinition.Properties.Concat(_allDefinition.Properties);
-        _allDefinition = allDefinition;
+        _allDefinition = new AllDefinition(
+            new Dictionary<PropertyPath, string>(_allDefinition.Properties.Concat(allDefinition.Properties)),
+            allDefinition.IncludeChildren);
         return this;
     }
 

--- a/Source/Kernel/Projections/Shared/Definitions/AllDefinition.cs
+++ b/Source/Kernel/Projections/Shared/Definitions/AllDefinition.cs
@@ -9,4 +9,5 @@ namespace Aksio.Cratis.Events.Projections.Definitions;
 /// Represents the definition for a collection of property actions to perform for all events in the projection.
 /// </summary>
 /// <param name="Properties">Properties and expressions for each property.</param>
-public record AllDefinition(IDictionary<PropertyPath, string> Properties);
+/// <param name="IncludeChildren">Include event types from child projections.</param>
+public record AllDefinition(IDictionary<PropertyPath, string> Properties, bool IncludeChildren);

--- a/Source/Kernel/Projections/Shared/Definitions/AllDefinition.cs
+++ b/Source/Kernel/Projections/Shared/Definitions/AllDefinition.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Properties;
+
+namespace Aksio.Cratis.Events.Projections.Definitions;
+
+/// <summary>
+/// Represents the definition for a collection of property actions to perform for all events in the projection.
+/// </summary>
+/// <param name="Properties">Properties and expressions for each property.</param>
+public record AllDefinition(IDictionary<PropertyPath, string> Properties);

--- a/Source/Kernel/Projections/Shared/Definitions/ChildrenDefinition.cs
+++ b/Source/Kernel/Projections/Shared/Definitions/ChildrenDefinition.cs
@@ -15,6 +15,7 @@ namespace Aksio.Cratis.Events.Projections.Definitions;
 /// <param name="From">All the <see cref="FromDefinition"/> for <see cref="EventType">event types</see>.</param>
 /// <param name="Join">All the <see cref="JoinDefinition"/> for <see cref="EventType">event types</see>.</param>
 /// <param name="Children">All the <see cref="ChildrenDefinition"/> for properties on model.</param>
+/// <param name="All">The full <see cref="AllDefinition"/>.</param>
 /// <param name="RemovedWith">The definition of what removes a child, if any.</param>
 public record ChildrenDefinition(
     PropertyPath IdentifiedBy,
@@ -23,4 +24,5 @@ public record ChildrenDefinition(
     IDictionary<EventType, FromDefinition> From,
     IDictionary<EventType, JoinDefinition> Join,
     IDictionary<PropertyPath, ChildrenDefinition> Children,
-    RemovedWithDefinition? RemovedWith) : ProjectionDefinition(Guid.Empty, string.Empty, Model, true, InitialModelState, From, Join, Children, RemovedWith);
+    AllDefinition All,
+    RemovedWithDefinition? RemovedWith) : ProjectionDefinition(Guid.Empty, string.Empty, Model, true, InitialModelState, From, Join, Children, All, RemovedWith);

--- a/Source/Kernel/Projections/Shared/Definitions/ProjectionDefinition.cs
+++ b/Source/Kernel/Projections/Shared/Definitions/ProjectionDefinition.cs
@@ -17,6 +17,7 @@ namespace Aksio.Cratis.Events.Projections.Definitions;
 /// <param name="From">All the <see cref="FromDefinition"/> for <see cref="EventType">event types</see>.</param>
 /// <param name="Join">All the <see cref="JoinDefinition"/> for <see cref="EventType">event types</see>.</param>
 /// <param name="Children">All the <see cref="ChildrenDefinition"/> for properties on model.</param>
+/// <param name="All">The full <see cref="AllDefinition"/>.</param>
 /// <param name="RemovedWith">The definition of what removes a child, if any.</param>
 public record ProjectionDefinition(
     ProjectionId Identifier,
@@ -27,4 +28,5 @@ public record ProjectionDefinition(
     IDictionary<EventType, FromDefinition> From,
     IDictionary<EventType, JoinDefinition> Join,
     IDictionary<PropertyPath, ChildrenDefinition> Children,
+    AllDefinition All,
     RemovedWithDefinition? RemovedWith = default);


### PR DESCRIPTION
### Added

- Adding the ability to project to model properties from properties from the event context from all events in a projection. Useful when one wants to set something like `LastUpdated` date time and base it on the `Occurred`.

```csharp
public class DebitAccountProjection : IProjectionFor<DebitAccount>
{
    public ProjectionId Identifier => "d1bb5522-5512-42ce-938a-d176536bb01d";

    public void Define(IProjectionBuilderFor<DebitAccount> builder) =>
        builder
            .WithInitialModelState(() => new(Guid.Empty, string.Empty, Guid.Empty, new(string.Empty, string.Empty), 0, false, DateTimeOffset.MinValue))

            // Set LastUpdated to Occurred for all events, and include any child projections
            .All(_ => _
                .Set(model => model.LastUpdated).ToEventContextProperty(ContextBoundObject => ContextBoundObject.Occurred)
                .IncludeChildProjections())

            .From<DebitAccountOpened>(_ => _
                .Set(model => model.Name).To(@event => @event.Name)
                .Set(model => model.OwnerId).To(@event => @event.Owner)
                .Set(model => model.HasCard).To(@event => @event.IncludeCard))
            .From<DebitAccountNameChanged>(_ => _
                .Set(model => model.Name).To(@event => @event.Name))
            .From<DepositToDebitAccountPerformed>(_ => _
                .Add(model => model.Balance).With(@event => @event.Amount))
            .From<WithdrawalFromDebitAccountPerformed>(_ => _
                .Subtract(model => model.Balance).With(@event => @event.Amount))
            .RemovedWith<DebitAccountClosed>();
}

```
