### PR TITLE
Making the MongoDB sink strict on target type conversion for properties and keys

### DIFF
--- a/Source/Extensions/MongoDB/BsonValueExtensions.cs
+++ b/Source/Extensions/MongoDB/BsonValueExtensions.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
 using Aksio.Cratis.Concepts;
+using Aksio.Cratis.Types;
 using MongoDB.Bson;
+using NJsonSchema;
 
 namespace Aksio.Cratis.Extensions.MongoDB;
 
@@ -15,8 +18,9 @@ public static class BsonValueExtensions
     /// Convert a CLR value to the correct <see cref="BsonValue"/>.
     /// </summary>
     /// <param name="input">Input value to convert from.</param>
+    /// <param name="targetType">Optional target type.</param>
     /// <returns>Converted <see cref="BsonValue"/>.</returns>
-    public static BsonValue ToBsonValue(this object? input)
+    public static BsonValue ToBsonValue(this object? input, Type? targetType = default)
     {
         if (input is null)
         {
@@ -26,6 +30,11 @@ public static class BsonValueExtensions
         if (input.IsConcept())
         {
             input = input.GetConceptValue();
+        }
+
+        if (targetType is not null)
+        {
+            input = TypeConversion.Convert(targetType, input);
         }
 
         switch (input)
@@ -61,10 +70,11 @@ public static class BsonValueExtensions
                 return new BsonBoolean(actualValue);
 
             case string actualValue:
-                if (Guid.TryParse(actualValue, out var actualValueAsGuid))
-                {
-                    return new BsonBinaryData(actualValueAsGuid, GuidRepresentation.Standard);
-                }
+
+                // if (Guid.TryParse(actualValue, out var actualValueAsGuid))
+                // {
+                //     return new BsonBinaryData(actualValueAsGuid, GuidRepresentation.Standard);
+                // }
                 return new BsonString(actualValue);
 
             case DateTime actualValue:
@@ -81,6 +91,122 @@ public static class BsonValueExtensions
 
             case Guid actualValue:
                 return new BsonBinaryData(actualValue, GuidRepresentation.Standard);
+        }
+
+        return BsonNull.Value;
+    }
+
+    /// <summary>
+    /// Convert a <see cref="BsonValue"/> to a specific target type.
+    /// </summary>
+    /// <param name="value"><see cref="BsonValue"/> to convert.</param>
+    /// <param name="targetType">The target type to convert to.</param>
+    /// <returns>Converted value.</returns>
+    public static object? ToTargetType(this BsonValue value, Type targetType)
+    {
+        switch (Type.GetTypeCode(targetType))
+        {
+            case TypeCode.Int16:
+                return (short)value.ToInt32();
+
+            case TypeCode.UInt16:
+                return (ushort)value.ToInt32();
+
+            case TypeCode.Int32:
+                return value.ToInt32();
+
+            case TypeCode.UInt32:
+                return (uint)value.ToInt32();
+
+            case TypeCode.Int64:
+                return value.ToInt64();
+
+            case TypeCode.UInt64:
+                return (ulong)value.ToInt64();
+
+            case TypeCode.Single:
+                return (float)value.ToDouble();
+
+            case TypeCode.Double:
+                return value.ToDouble();
+
+            case TypeCode.Decimal:
+                return value.ToDecimal();
+
+            case TypeCode.DateTime:
+                return value.ToUniversalTime();
+
+            case TypeCode.Byte:
+                return (byte)value.ToInt32();
+        }
+
+        if (targetType == typeof(Guid))
+        {
+            if (value is BsonString bsonString)
+            {
+                return Guid.Parse(bsonString.ToString()!);
+            }
+
+            if (value is BsonBinaryData bsonBinaryData)
+            {
+                return bsonBinaryData.ToGuid(GuidRepresentation.Standard);
+            }
+        }
+
+        if (targetType == typeof(DateTimeOffset))
+        {
+            if (value is BsonDateTime bsonDateTime)
+            {
+                return DateTimeOffset.FromUnixTimeMilliseconds(bsonDateTime.MillisecondsSinceEpoch);
+            }
+
+            if (value is BsonString bsonString)
+            {
+                return DateTimeOffset.ParseExact(bsonString.ToString()!, DateTimeOffsetSupportingBsonDateTimeSerializer.StringSerializationFormat, DateTimeFormatInfo.InvariantInfo);
+            }
+        }
+
+        if (targetType == typeof(DateOnly) && value is BsonDateTime bsonDateOnly)
+        {
+            var dateTime = bsonDateOnly.ToUniversalTime();
+            return new DateOnly(dateTime.Year, dateTime.Month, dateTime.Day);
+        }
+
+        if (targetType == typeof(TimeOnly) && value is BsonDateTime bsonTimeOnly)
+        {
+            var dateTime = bsonTimeOnly.ToUniversalTime();
+            return new TimeOnly(dateTime.Hour, dateTime.Minute, dateTime.Second, dateTime.Millisecond);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Convert to a <see cref="BsonValue"/> based on the type information in <see cref="JsonSchemaProperty"/>.
+    /// </summary>
+    /// <param name="value">Value to convert from.</param>
+    /// <param name="schemaProperty"><see cref="JsonSchemaProperty"/> with type info.</param>
+    /// <returns>Converted value.</returns>
+    public static BsonValue ToBsonValueBasedOnSchemaPropertyType(this object? value, JsonSchemaProperty schemaProperty)
+    {
+        if (value is null)
+        {
+            return BsonNull.Value;
+        }
+
+        switch (schemaProperty.Type)
+        {
+            case JsonObjectType.String:
+                return new BsonString(value is string actualString ? actualString : value.ToString()!);
+
+            case JsonObjectType.Boolean:
+                return new BsonBoolean(value is bool actualBool ? actualBool : bool.Parse(value.ToString()!));
+
+            case JsonObjectType.Integer:
+                return new BsonInt32(value is int actualInt ? actualInt : int.Parse(value.ToString()!));
+
+            case JsonObjectType.Number:
+                return new BsonDouble(value is double actualDouble ? actualDouble : double.Parse(value.ToString()!));
         }
 
         return BsonNull.Value;

--- a/Source/Fundamentals/Json/JsonSchemaExtensions.cs
+++ b/Source/Fundamentals/Json/JsonSchemaExtensions.cs
@@ -50,6 +50,41 @@ public static class JsonSchemaExtensions
         return schema;
     }
 
+    /// <summary>
+    /// Gets the <see cref="JsonSchemaProperty"/> within the schema hierarchy based on a <see cref="PropertyPath"/>.
+    /// </summary>
+    /// <param name="schema"><see cref="JsonSchema"/> to get from.</param>
+    /// <param name="propertyPath"><see cref="PropertyPath"/> to get for.</param>
+    /// <returns>The actual <see cref="JsonSchemaProperty"/>.</returns>
+    public static JsonSchemaProperty? GetSchemaPropertyForPropertyPath(this JsonSchema schema, PropertyPath propertyPath)
+    {
+        var segments = propertyPath.Segments.ToArray();
+        for (var segmentIndex = 0; segmentIndex < segments.Length; segmentIndex++)
+        {
+            var segment = segments[segmentIndex];
+
+            if (schema.ActualProperties.ContainsKey(segment.Value))
+            {
+                if (segmentIndex == segments.Length - 1)
+                {
+                    return schema.ActualProperties[segment.Value];
+                }
+
+                var schemaProperty = schema.ActualProperties[segment.Value];
+                if (schemaProperty.IsArray)
+                {
+                    schema = schema.ActualProperties[segment.Value].Item.Reference;
+                }
+                else
+                {
+                    schema = schemaProperty.ActualTypeSchema;
+                }
+            }
+        }
+
+        return null;
+    }
+
     static void CollectPropertiesFrom(JsonSchema schema, List<JsonSchemaProperty> properties)
     {
         properties.AddRange(schema.ActualProperties.Select(_ => _.Value));

--- a/Source/Kernel/Projections/MongoDB/MongoDBProjectionSinkFactory.cs
+++ b/Source/Kernel/Projections/MongoDB/MongoDBProjectionSinkFactory.cs
@@ -5,6 +5,7 @@ using System.Dynamic;
 using Aksio.Cratis.Configuration;
 using Aksio.Cratis.Execution;
 using Aksio.Cratis.Extensions.MongoDB;
+using Aksio.Cratis.Schemas;
 
 namespace Aksio.Cratis.Events.Projections.MongoDB;
 
@@ -15,6 +16,7 @@ public class MongoDBProjectionSinkFactory : IProjectionSinkFactory
 {
     readonly IMongoDBClientFactory _clientFactory;
     readonly IExpandoObjectConverter _expandoObjectConverter;
+    readonly ITypeFormats _typeFormats;
     readonly IExecutionContextManager _executionContextManager;
     readonly Storage _configuration;
 
@@ -27,16 +29,19 @@ public class MongoDBProjectionSinkFactory : IProjectionSinkFactory
     /// <param name="executionContextManager"><see cref="IExecutionContextManager"/> for working with execution context.</param>
     /// <param name="clientFactory"><see cref="IMongoDBClientFactory"/> to use.</param>
     /// <param name="expandoObjectConverter"><see cref="IExpandoObjectConverter"/> for converting between documents and <see cref="ExpandoObject"/>.</param>
+    /// <param name="typeFormats">The <see cref="ITypeFormats"/> for looking up actual types.</param>
     /// <param name="configuration"><see cref="Storage"/> configuration.</param>
     public MongoDBProjectionSinkFactory(
         IExecutionContextManager executionContextManager,
         IMongoDBClientFactory clientFactory,
         IExpandoObjectConverter expandoObjectConverter,
+        ITypeFormats typeFormats,
         Storage configuration)
     {
+        _executionContextManager = executionContextManager;
         _clientFactory = clientFactory;
         _expandoObjectConverter = expandoObjectConverter;
-        _executionContextManager = executionContextManager;
+        _typeFormats = typeFormats;
         _configuration = configuration;
     }
 
@@ -47,5 +52,6 @@ public class MongoDBProjectionSinkFactory : IProjectionSinkFactory
             _executionContextManager,
             _clientFactory,
             _expandoObjectConverter,
+            _typeFormats,
             _configuration);
 }


### PR DESCRIPTION
### Fixed

- The MongoDB Projection Sink is now much stricter on the models schema and target types and will convert both keys and properties according to the schema.
