### PR TITLE
Fix/child-key-resolvers

### DIFF
--- a/Source/Extensions/Specifications/Projections/ProjectionSpecificationContext.cs
+++ b/Source/Extensions/Specifications/Projections/ProjectionSpecificationContext.cs
@@ -84,6 +84,7 @@ public class ProjectionSpecificationContext<TModel> : IHaveEventLog, IDisposable
             _sink,
             objectsComparer,
             new NullChangesetStorage(),
+            new TypeFormats(),
             new NullLogger<ProjectionPipeline>());
     }
 

--- a/Source/Fundamentals/Json/ExpandoObjectConverter.cs
+++ b/Source/Fundamentals/Json/ExpandoObjectConverter.cs
@@ -58,18 +58,20 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
 
         foreach (var (name, sourceValue) in document)
         {
-            object? value;
-
-            if (!schema.ActualProperties.ContainsKey(name))
+            object? value = null;
+            if (sourceValue is not null)
             {
-                value = ConvertUnknownSchemaTypeToClrType(sourceValue!);
+                if (!schema.ActualProperties.ContainsKey(name))
+                {
+                    value = ConvertUnknownSchemaTypeToClrType(sourceValue!);
+                }
+                else
+                {
+                    var schemaProperty = schema.ActualProperties[name];
+                    value = ConvertFromJsonNode(sourceValue!, schemaProperty);
+                }
             }
-            else
-            {
-                var schemaProperty = schema.ActualProperties[name];
-                value = ConvertFromJsonNode(sourceValue!, schemaProperty);
-            }
-            expandoObjectAsDictionary[name] = value;
+            expandoObjectAsDictionary[name] = value!;
         }
 
         return expandoObject;

--- a/Source/Kernel/Projections/Engine/KeyResolvers.cs
+++ b/Source/Kernel/Projections/Engine/KeyResolvers.cs
@@ -78,8 +78,8 @@ public static class KeyResolvers
             var currentProjection = projection;
             if (currentProjection.HasParent)
             {
+                arrayIndexers.Add(new(projection.ChildrenPropertyPath, identifiedByProperty, EventValueProviders.EventSourceId(@event)));
                 currentProjection = currentProjection.Parent!;
-                arrayIndexers.Add(new(currentProjection.ChildrenPropertyPath, identifiedByProperty, EventValueProviders.EventSourceId(@event)));
                 var firstEvent = currentProjection.EventTypes.First()!;
                 var parentEvent = await eventProvider.GetLastInstanceFor(EventSequenceId.Log, firstEvent.Id, parentKey.ToString()!);
                 var keyResolver = currentProjection.GetKeyResolverFor(firstEvent);

--- a/Source/Kernel/Projections/Engine/KeyResolvers.cs
+++ b/Source/Kernel/Projections/Engine/KeyResolvers.cs
@@ -85,6 +85,7 @@ public static class KeyResolvers
                 var keyResolver = currentProjection.GetKeyResolverFor(firstEvent);
                 var resolvedParentKey = await keyResolver(eventProvider, parentEvent);
                 parentKey = resolvedParentKey.Value;
+                arrayIndexers.AddRange(resolvedParentKey.ArrayIndexers.All);
             }
 
             return new(parentKey, new ArrayIndexers(arrayIndexers));

--- a/Source/Kernel/Projections/Engine/Pipelines/ProjectionPipeline.cs
+++ b/Source/Kernel/Projections/Engine/Pipelines/ProjectionPipeline.cs
@@ -6,7 +6,12 @@ using Aksio.Cratis.Changes;
 using Aksio.Cratis.Events.Projections.Changes;
 using Aksio.Cratis.Events.Store;
 using Aksio.Cratis.Execution;
+using Aksio.Cratis.Json;
+using Aksio.Cratis.Properties;
+using Aksio.Cratis.Schemas;
+using Aksio.Cratis.Types;
 using Microsoft.Extensions.Logging;
+using NJsonSchema;
 
 namespace Aksio.Cratis.Events.Projections.Pipelines;
 
@@ -17,6 +22,7 @@ public class ProjectionPipeline : IProjectionPipeline
 {
     readonly IObjectsComparer _objectsComparer;
     readonly IChangesetStorage _changesetStorage;
+    readonly ITypeFormats _typeFormats;
     readonly ILogger<ProjectionPipeline> _logger;
     readonly IEventSequenceStorageProvider _eventProvider;
 
@@ -34,6 +40,7 @@ public class ProjectionPipeline : IProjectionPipeline
     /// <param name="sink"><see cref="IProjectionSink"/> to use.</param>
     /// <param name="objectsComparer"><see cref="IObjectsComparer"/> for comparing objects.</param>
     /// <param name="changesetStorage"><see cref="IChangesetStorage"/> for storing changesets as they occur.</param>
+    /// <param name="typeFormats"><see cref="ITypeFormats"/> for resolving actual CLR types for schemas.</param>
     /// <param name="logger"><see cref="ILogger{T}"/> for logging.</param>
     public ProjectionPipeline(
         IProjection projection,
@@ -41,12 +48,14 @@ public class ProjectionPipeline : IProjectionPipeline
         IProjectionSink sink,
         IObjectsComparer objectsComparer,
         IChangesetStorage changesetStorage,
+        ITypeFormats typeFormats,
         ILogger<ProjectionPipeline> logger)
     {
         _eventProvider = eventProvider;
         Sink = sink;
         _objectsComparer = objectsComparer;
         _changesetStorage = changesetStorage;
+        _typeFormats = typeFormats;
         Projection = projection;
         _logger = logger;
     }
@@ -63,6 +72,7 @@ public class ProjectionPipeline : IProjectionPipeline
         var correlationId = CorrelationId.New();
         var keyResolver = Projection.GetKeyResolverFor(@event.Metadata.Type);
         var key = await keyResolver(_eventProvider, @event);
+        key = EnsureCorrectTypeForArrayIndexersOnKey(key);
         _logger.GettingInitialValues(@event.Metadata.SequenceNumber);
         var initialState = await Sink.FindOrDefault(key);
         initialState ??= Projection.InitialModelState;
@@ -80,6 +90,44 @@ public class ProjectionPipeline : IProjectionPipeline
         {
             await Sink.EndReplay();
         }
+    }
+
+    Key EnsureCorrectTypeForArrayIndexersOnKey(Key key)
+    {
+        key = key with
+        {
+            ArrayIndexers = new ArrayIndexers(
+                key.ArrayIndexers.All.Select(_ =>
+                {
+                    var targetType = _.Identifier.GetType();
+                    var originalType = targetType;
+                    var schemaProperty = Projection.Model.Schema.GetSchemaPropertyForPropertyPath(_.ArrayProperty + _.IdentifierProperty);
+                    if (schemaProperty is not null)
+                    {
+                        if (_typeFormats.IsKnown(schemaProperty.Format))
+                        {
+                            targetType = _typeFormats.GetTypeForFormat(schemaProperty.Format);
+                        }
+                        else
+                        {
+                            targetType = schemaProperty.Type switch
+                            {
+                                JsonObjectType.String => typeof(string),
+                                JsonObjectType.Boolean => typeof(bool),
+                                JsonObjectType.Integer => typeof(int),
+                                JsonObjectType.Null => typeof(double),
+                                _ => targetType
+                            };
+                        }
+                    }
+
+                    return targetType == originalType ? _ : _ with
+                    {
+                        Identifier = TypeConversion.Convert(targetType, _.Identifier)
+                    };
+                }))
+        };
+        return key;
     }
 
     async Task HandleEventFor(IProjection projection, ProjectionEventContext context)

--- a/Source/Kernel/Projections/Engine/Pipelines/ProjectionPipeline.cs
+++ b/Source/Kernel/Projections/Engine/Pipelines/ProjectionPipeline.cs
@@ -94,7 +94,7 @@ public class ProjectionPipeline : IProjectionPipeline
 
     Key EnsureCorrectTypeForArrayIndexersOnKey(Key key)
     {
-        key = key with
+        return key with
         {
             ArrayIndexers = new ArrayIndexers(
                 key.ArrayIndexers.All.Select(_ =>
@@ -127,7 +127,6 @@ public class ProjectionPipeline : IProjectionPipeline
                     };
                 }))
         };
-        return key;
     }
 
     async Task HandleEventFor(IProjection projection, ProjectionEventContext context)

--- a/Source/Kernel/Projections/Engine/Pipelines/ProjectionPipelineFactory.cs
+++ b/Source/Kernel/Projections/Engine/Pipelines/ProjectionPipelineFactory.cs
@@ -5,6 +5,7 @@ using Aksio.Cratis.Changes;
 using Aksio.Cratis.Events.Projections.Changes;
 using Aksio.Cratis.Events.Projections.Definitions;
 using Aksio.Cratis.Events.Store;
+using Aksio.Cratis.Schemas;
 using Microsoft.Extensions.Logging;
 
 namespace Aksio.Cratis.Events.Projections.Pipelines;
@@ -18,6 +19,7 @@ public class ProjectionPipelineFactory : IProjectionPipelineFactory
     readonly IEventSequenceStorageProvider _eventProvider;
     readonly IObjectsComparer _objectsComparer;
     readonly IChangesetStorage _changesetStorage;
+    readonly ITypeFormats _typeFormats;
     readonly ILoggerFactory _loggerFactory;
 
     /// <summary>
@@ -27,18 +29,21 @@ public class ProjectionPipelineFactory : IProjectionPipelineFactory
     /// <param name="eventProvider"><see cref="IEventSequenceStorageProvider"/> in the system.</param>
     /// <param name="objectsComparer"><see cref="IObjectsComparer"/> for comparing objects.</param>
     /// <param name="changesetStorage"><see cref="IChangesetStorage"/> for storing changesets as they occur.</param>
+    /// <param name="typeFormats"><see cref="ITypeFormats"/> for resolving actual CLR types for schemas.</param>
     /// <param name="loggerFactory"><see cref="ILoggerFactory"/> for creating loggers.</param>
     public ProjectionPipelineFactory(
         IProjectionSinks projectionSinks,
         IEventSequenceStorageProvider eventProvider,
         IObjectsComparer objectsComparer,
         IChangesetStorage changesetStorage,
+        ITypeFormats typeFormats,
         ILoggerFactory loggerFactory)
     {
         _projectionSinks = projectionSinks;
         _eventProvider = eventProvider;
         _objectsComparer = objectsComparer;
         _changesetStorage = changesetStorage;
+        _typeFormats = typeFormats;
         _loggerFactory = loggerFactory;
     }
 
@@ -58,6 +63,7 @@ public class ProjectionPipelineFactory : IProjectionPipelineFactory
             sink,
             _objectsComparer,
             _changesetStorage,
+            _typeFormats,
             _loggerFactory.CreateLogger<ProjectionPipeline>());
     }
 }

--- a/Specifications/Kernel/Projections/Engine/for_EventValueProviders/when_accessing_event_source_id.cs
+++ b/Specifications/Kernel/Projections/Engine/for_EventValueProviders/when_accessing_event_source_id.cs
@@ -4,7 +4,7 @@
 using System.Dynamic;
 using Aksio.Cratis.Events.Store;
 
-namespace Aksio.Cratis.Events.Projections;
+namespace Aksio.Cratis.Events.Projections.for_EventValueProviders;
 
 public class when_accessing_event_source_id : Specification
 {

--- a/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_four_levels.cs
+++ b/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_four_levels.cs
@@ -5,7 +5,7 @@ using Aksio.Cratis.Dynamic;
 using Aksio.Cratis.Events.Store;
 using Aksio.Cratis.Properties;
 
-namespace Aksio.Cratis.Events.Projections;
+namespace Aksio.Cratis.Events.Projections.for_KeyResolvers;
 
 public class when_identifying_model_key_from_parent_hierarchy_with_four_levels : Specification
 {
@@ -74,11 +74,11 @@ public class when_identifying_model_key_from_parent_hierarchy_with_four_levels :
         third_level_event = CreateEvent(3, third_level_event_type, third_level_key, new { parentId = second_level_key });
         forth_level_event = CreateEvent(4, forth_level_event_type, forth_level_key, new { parentId = third_level_key });
 
-        root_projection = SetupProjection(root_event_type, root_key, "firstLevels");
-        first_level_projection = SetupProjection(first_level_event_type, first_level_key, "secondLevels", root_projection.Object);
-        second_level_projection = SetupProjection(second_level_event_type, second_level_key, "thirdLevels", first_level_projection.Object);
-        third_level_projection = SetupProjection(third_level_event_type, third_level_key, "forthLevels", second_level_projection.Object);
-        forth_level_projection = SetupProjection(forth_level_event_type, forth_level_key, parent: third_level_projection.Object);
+        root_projection = SetupProjection(root_event_type, root_key);
+        first_level_projection = SetupProjection(first_level_event_type, first_level_key, "firstLevels", root_projection.Object);
+        second_level_projection = SetupProjection(second_level_event_type, second_level_key, "secondLevels", first_level_projection.Object);
+        third_level_projection = SetupProjection(third_level_event_type, third_level_key, "thirdLevels", second_level_projection.Object);
+        forth_level_projection = SetupProjection(forth_level_event_type, forth_level_key, "forthLevels", third_level_projection.Object);
 
         storage = new();
         storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, root_event_type.Id, root_key)).Returns(Task.FromResult(root_event));

--- a/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_four_levels.cs
+++ b/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_four_levels.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Dynamic;
+using Aksio.Cratis.Events.Store;
+using Aksio.Cratis.Properties;
+
+namespace Aksio.Cratis.Events.Projections;
+
+public class when_identifying_model_key_from_parent_hierarchy_with_four_levels : Specification
+{
+    AppendedEvent root_event;
+    AppendedEvent first_level_event;
+    AppendedEvent second_level_event;
+    AppendedEvent third_level_event;
+    AppendedEvent forth_level_event;
+
+    Mock<IProjection> root_projection;
+    Mock<IProjection> first_level_projection;
+    Mock<IProjection> second_level_projection;
+    Mock<IProjection> third_level_projection;
+    Mock<IProjection> forth_level_projection;
+
+    Mock<IEventSequenceStorageProvider> storage;
+    Key result;
+
+    static EventType root_event_type = new("5f4f4368-6989-4d9d-a84e-7393e0b41cfd", 1);
+    static EventType first_level_event_type = new("eef0f7c0-25eb-48dc-b824-7e27ba4593f2", 1);
+    static EventType second_level_event_type = new("6682281b-64e0-431b-8b90-dd49ba25ca55", 1);
+    static EventType third_level_event_type = new("90ae84f7-84f0-4e3a-a38a-329d782da158", 1);
+    static EventType forth_level_event_type = new("e72686b1-b0e4-40a8-9651-4841602638da", 1);
+
+    const string root_key = "4e3a1e36-714c-41f7-83e3-5cc84717db16";
+    const string first_level_key = "805908d8-ed72-4a70-b313-6f592632663d";
+    const string second_level_key = "02311df8-fcf2-42ff-b2d0-b7fa2f576485";
+    const string third_level_key = "935e1158-cedb-4530-a9aa-d925d6d9b10d";
+    const string forth_level_key = "537d661f-8b12-4a1e-917b-faf639923380";
+
+    AppendedEvent CreateEvent(EventSequenceNumber sequenceNumber, EventType type, EventSourceId eventSourceId, object content)
+    {
+        return new(
+            new(sequenceNumber, type),
+            new(eventSourceId, sequenceNumber, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "123b8935-a1a4-410d-aace-e340d48f0aa0", "41f18595-4748-4b01-88f7-4c0d0907aa90", "50308963-d8b5-4b6e-97c7-e2486e8237e1", "bfb7fd4a-1822-4937-a6d1-52464a173f84"),
+            content.AsExpandoObject());
+    }
+
+    Mock<IProjection> SetupProjection(EventType eventType, string key, string childrenProperty = "no-levels", IProjection? parent = null)
+    {
+        var projection = new Mock<IProjection>();
+        projection.SetupGet(_ => _.EventTypes).Returns(new EventType[] {
+            eventType
+        });
+        projection.SetupGet(_ => _.Path).Returns(childrenProperty);
+        projection.SetupGet(_ => _.ChildrenPropertyPath).Returns(childrenProperty);
+
+        if (parent is not null)
+        {
+            projection.Setup(_ => _.GetKeyResolverFor(eventType)).Returns(KeyResolvers.FromParentHierarchy(projection.Object, "parentId", "childId"));
+            projection.SetupGet(_ => _.HasParent).Returns(true);
+            projection.SetupGet(_ => _.Parent).Returns(parent);
+        }
+        else
+        {
+            projection.Setup(_ => _.GetKeyResolverFor(eventType)).Returns((_, __) => Task.FromResult(new Key(key, ArrayIndexers.NoIndexers)));
+        }
+        return projection;
+    }
+
+    void Establish()
+    {
+        root_event = CreateEvent(0, root_event_type, root_key, new { });
+        first_level_event = CreateEvent(1, first_level_event_type, first_level_key, new { parentId = root_key });
+        second_level_event = CreateEvent(2, second_level_event_type, second_level_key, new { parentId = first_level_key });
+        third_level_event = CreateEvent(3, third_level_event_type, third_level_key, new { parentId = second_level_key });
+        forth_level_event = CreateEvent(4, forth_level_event_type, forth_level_key, new { parentId = third_level_key });
+
+        root_projection = SetupProjection(root_event_type, root_key, "firstLevels");
+        first_level_projection = SetupProjection(first_level_event_type, first_level_key, "secondLevels", root_projection.Object);
+        second_level_projection = SetupProjection(second_level_event_type, second_level_key, "thirdLevels", first_level_projection.Object);
+        third_level_projection = SetupProjection(third_level_event_type, third_level_key, "forthLevels", second_level_projection.Object);
+        forth_level_projection = SetupProjection(forth_level_event_type, forth_level_key, parent: third_level_projection.Object);
+
+        storage = new();
+        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, root_event_type.Id, root_key)).Returns(Task.FromResult(root_event));
+        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, first_level_event_type.Id, first_level_key)).Returns(Task.FromResult(first_level_event));
+        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, second_level_event_type.Id, second_level_key)).Returns(Task.FromResult(second_level_event));
+        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, third_level_event_type.Id, third_level_key)).Returns(Task.FromResult(third_level_event));
+        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, forth_level_event_type.Id, forth_level_key)).Returns(Task.FromResult(forth_level_event));
+    }
+
+    async Task Because() => result = await KeyResolvers.FromParentHierarchy(forth_level_projection.Object, "parentId", "childId")(storage.Object, forth_level_event);
+
+    [Fact] void should_return_expected_key() => result.Value.ShouldEqual(root_key);
+    [Fact] void should_hold_array_indexer_for_first_level_with_correct_identifier() => result.ArrayIndexers.All.Single(_ => _.ArrayProperty == "firstLevels").Identifier.ToString().ShouldEqual(first_level_key);
+    [Fact] void should_hold_array_indexer_for_second_level_with_correct_identifier() => result.ArrayIndexers.All.Single(_ => _.ArrayProperty == "secondLevels").Identifier.ToString().ShouldEqual(second_level_key);
+    [Fact] void should_hold_array_indexer_for_third_level_with_correct_identifier() => result.ArrayIndexers.All.Single(_ => _.ArrayProperty == "thirdLevels").Identifier.ToString().ShouldEqual(third_level_key);
+    [Fact] void should_hold_array_indexer_for_forth_level_with_correct_identifier() => result.ArrayIndexers.All.Single(_ => _.ArrayProperty == "forthLevels").Identifier.ToString().ShouldEqual(forth_level_key);
+}

--- a/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_one_level.cs
+++ b/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_one_level.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Aksio.Cratis.Dynamic;
+using Aksio.Cratis.Events.Store;
+using Aksio.Cratis.Properties;
+
+namespace Aksio.Cratis.Events.Projections;
+
+public class when_identifying_model_key_from_parent_hierarchy_with_one_level : Specification
+{
+    AppendedEvent root_event;
+    AppendedEvent @event;
+    Key result;
+    Mock<IProjection> root_projection;
+    Mock<IProjection> child_projection;
+    Mock<IEventSequenceStorageProvider> storage;
+
+    static EventType root_event_type = new("5f4f4368-6989-4d9d-a84e-7393e0b41cfd", 1);
+    const string parent_key = "61fcc353-3478-4cf9-a783-da508013b36f";
+
+    void Establish()
+    {
+        root_event = new(
+            new(1, root_event_type),
+            new("2f005aaf-2f4e-4a47-92ea-63687ef74bd4", 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "123b8935-a1a4-410d-aace-e340d48f0aa0", "41f18595-4748-4b01-88f7-4c0d0907aa90", "50308963-d8b5-4b6e-97c7-e2486e8237e1", "bfb7fd4a-1822-4937-a6d1-52464a173f84"),
+            new ExpandoObject());
+
+        @event = new(
+            new(0,
+            new("02405794-91e7-4e4f-8ad1-f043070ca297", 1)),
+            new("2f005aaf-2f4e-4a47-92ea-63687ef74bd4", 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "123b8935-a1a4-410d-aace-e340d48f0aa0", "41f18595-4748-4b01-88f7-4c0d0907aa90", "50308963-d8b5-4b6e-97c7-e2486e8237e1", "bfb7fd4a-1822-4937-a6d1-52464a173f84"),
+            new
+            {
+                parentId = parent_key
+            }.AsExpandoObject());
+
+        root_projection = new();
+        root_projection.SetupGet(_ => _.EventTypes).Returns(new EventType[] {
+            root_event_type
+        });
+
+        child_projection = new();
+        child_projection.SetupGet(_ => _.HasParent).Returns(true);
+        child_projection.SetupGet(_ => _.Parent).Returns(root_projection.Object);
+        child_projection.SetupGet(_ => _.ChildrenPropertyPath).Returns("children");
+        storage = new();
+
+        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, root_event_type.Id, parent_key)).Returns(Task.FromResult(root_event));
+        root_projection.Setup(_ => _.GetKeyResolverFor(root_event_type)).Returns((_, e) => Task.FromResult(new Key(parent_key, ArrayIndexers.NoIndexers)));
+    }
+
+    async Task Because() => result = await KeyResolvers.FromParentHierarchy(child_projection.Object, "parentId", "childId")(storage.Object, @event);
+
+    [Fact] void should_return_expected_key() => result.Value.ShouldEqual(parent_key);
+}

--- a/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_one_level.cs
+++ b/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_one_level.cs
@@ -6,7 +6,7 @@ using Aksio.Cratis.Dynamic;
 using Aksio.Cratis.Events.Store;
 using Aksio.Cratis.Properties;
 
-namespace Aksio.Cratis.Events.Projections;
+namespace Aksio.Cratis.Events.Projections.for_KeyResolvers;
 
 public class when_identifying_model_key_from_parent_hierarchy_with_one_level : Specification
 {


### PR DESCRIPTION
### Fixed

- FIxing conversion of events to treat null values as null and not try to convert them to target type.
- The array indexer values - key is now honoring the target models type representing the key. Making child relations work again.
- Fixing the recursiveness of the internal `.FromParentHierarchy()` key resolver to actually be recursive. Its implementation was completely wrong where it did a recurse, but also a loop of its own hierarchy and getting random results.
