### PR TITLE
Parent hierarchy resolution now does not rely on the first event type of the parent, but any of them

### DIFF
--- a/Source/Extensions/Specifications/EventSequenceStorageProviderForSpecifications.cs
+++ b/Source/Extensions/Specifications/EventSequenceStorageProviderForSpecifications.cs
@@ -70,6 +70,13 @@ public class EventSequenceStorageProviderForSpecifications : IEventSequenceStora
     }
 
     /// <inheritdoc/>
+    public Task<AppendedEvent> GetLastInstanceOfAny(EventSequenceId eventSequenceId, EventSourceId eventSourceId, IEnumerable<EventTypeId> eventTypes)
+    {
+        var lastInstance = _eventLog.AppendedEvents.Where(_ => eventTypes.Any(et => et == _.Metadata.Type.Id) && _.Context.EventSourceId == eventSourceId).OrderByDescending(_ => _.Metadata.SequenceNumber).First();
+        return Task.FromResult(new AppendedEvent(lastInstance.Metadata, lastInstance.Context, lastInstance.Content));
+    }
+
+    /// <inheritdoc/>
     public Task<bool> HasInstanceFor(EventSequenceId eventSequenceId, EventTypeId eventTypeId, EventSourceId eventSourceId)
     {
         var count = _eventLog.AppendedEvents.Count(_ => _.Metadata.Type.Id == eventTypeId && _.Context.EventSourceId == eventSourceId);

--- a/Source/Kernel/Projections/Engine/KeyResolvers.cs
+++ b/Source/Kernel/Projections/Engine/KeyResolvers.cs
@@ -80,9 +80,9 @@ public static class KeyResolvers
             {
                 arrayIndexers.Add(new(projection.ChildrenPropertyPath, identifiedByProperty, EventValueProviders.EventSourceId(@event)));
                 currentProjection = currentProjection.Parent!;
-                var firstEvent = currentProjection.EventTypes.First()!;
-                var parentEvent = await eventProvider.GetLastInstanceFor(EventSequenceId.Log, firstEvent.Id, parentKey.ToString()!);
-                var keyResolver = currentProjection.GetKeyResolverFor(firstEvent);
+                var parentEvent = await eventProvider.GetLastInstanceOfAny(EventSequenceId.Log, parentKey.ToString()!, currentProjection.EventTypes.Select(_ => _.Id));
+                var eventType = currentProjection.EventTypes.First(_ => _.Id == parentEvent.Metadata.Type.Id);
+                var keyResolver = currentProjection.GetKeyResolverFor(eventType);
                 var resolvedParentKey = await keyResolver(eventProvider, parentEvent);
                 parentKey = resolvedParentKey.Value;
                 arrayIndexers.AddRange(resolvedParentKey.ArrayIndexers.All);

--- a/Source/Kernel/Store/Shared/IEventSequenceStorageProvider.cs
+++ b/Source/Kernel/Store/Shared/IEventSequenceStorageProvider.cs
@@ -45,6 +45,15 @@ public interface IEventSequenceStorageProvider
     Task<AppendedEvent> GetLastInstanceFor(EventSequenceId eventSequenceId, EventTypeId eventTypeId, EventSourceId eventSourceId);
 
     /// <summary>
+    /// Get the last instance of any of the specified event types for a specific event source.
+    /// </summary>
+    /// <param name="eventSequenceId">The event sequence to get for.</param>
+    /// <param name="eventSourceId"><see cref="EventSourceId"/> to get for.</param>
+    /// <param name="eventTypes">Any in the collection of <see cref="EventTypeId"/> to get for.</param>
+    /// <returns>The <see cref="AppendedEvent"/> found.</returns>
+    Task<AppendedEvent> GetLastInstanceOfAny(EventSequenceId eventSequenceId, EventSourceId eventSourceId, IEnumerable<EventTypeId> eventTypes);
+
+    /// <summary>
     /// Get events using a specific sequence number as starting point within the event sequence.
     /// </summary>
     /// <param name="eventSequenceId">The event sequence to get for.</param>

--- a/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_four_levels.cs
+++ b/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_four_levels.cs
@@ -81,11 +81,11 @@ public class when_identifying_model_key_from_parent_hierarchy_with_four_levels :
         forth_level_projection = SetupProjection(forth_level_event_type, forth_level_key, "forthLevels", third_level_projection.Object);
 
         storage = new();
-        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, root_event_type.Id, root_key)).Returns(Task.FromResult(root_event));
-        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, first_level_event_type.Id, first_level_key)).Returns(Task.FromResult(first_level_event));
-        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, second_level_event_type.Id, second_level_key)).Returns(Task.FromResult(second_level_event));
-        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, third_level_event_type.Id, third_level_key)).Returns(Task.FromResult(third_level_event));
-        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, forth_level_event_type.Id, forth_level_key)).Returns(Task.FromResult(forth_level_event));
+        storage.Setup(_ => _.GetLastInstanceOfAny(EventSequenceId.Log, root_key, new[] { root_event_type.Id })).Returns(Task.FromResult(root_event));
+        storage.Setup(_ => _.GetLastInstanceOfAny(EventSequenceId.Log, first_level_key, new[] { first_level_event_type.Id })).Returns(Task.FromResult(first_level_event));
+        storage.Setup(_ => _.GetLastInstanceOfAny(EventSequenceId.Log, second_level_key, new[] { second_level_event_type.Id })).Returns(Task.FromResult(second_level_event));
+        storage.Setup(_ => _.GetLastInstanceOfAny(EventSequenceId.Log, third_level_key, new[] { third_level_event_type.Id })).Returns(Task.FromResult(third_level_event));
+        storage.Setup(_ => _.GetLastInstanceOfAny(EventSequenceId.Log, forth_level_key, new[] { forth_level_event_type.Id })).Returns(Task.FromResult(forth_level_event));
     }
 
     async Task Because() => result = await KeyResolvers.FromParentHierarchy(forth_level_projection.Object, "parentId", "childId")(storage.Object, forth_level_event);

--- a/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_one_level.cs
+++ b/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_one_level.cs
@@ -47,8 +47,8 @@ public class when_identifying_model_key_from_parent_hierarchy_with_one_level : S
         child_projection.SetupGet(_ => _.ChildrenPropertyPath).Returns("children");
         storage = new();
 
-        storage.Setup(_ => _.GetLastInstanceFor(EventSequenceId.Log, root_event_type.Id, parent_key)).Returns(Task.FromResult(root_event));
-        root_projection.Setup(_ => _.GetKeyResolverFor(root_event_type)).Returns((_, e) => Task.FromResult(new Key(parent_key, ArrayIndexers.NoIndexers)));
+        storage.Setup(_ => _.GetLastInstanceOfAny(EventSequenceId.Log, parent_key, new[] { root_event_type.Id })).Returns(Task.FromResult(root_event));
+        root_projection.Setup(_ => _.GetKeyResolverFor(root_event_type)).Returns((_, __) => Task.FromResult(new Key(parent_key, ArrayIndexers.NoIndexers)));
     }
 
     async Task Because() => result = await KeyResolvers.FromParentHierarchy(child_projection.Object, "parentId", "childId")(storage.Object, @event);


### PR DESCRIPTION
### Fixed

- Making parent hierarchy key resolution use any of the parents event types, not forcing the first in its definition. The first in the definition might not be the first that gets appended.
