### PR TITLE
Fixing so that we create the correct types from Json and to Json for DateOnly and TimeOnly

### DIFF
--- a/Source/Fundamentals/Json/JsonValueExtensions.cs
+++ b/Source/Fundamentals/Json/JsonValueExtensions.cs
@@ -95,7 +95,7 @@ public static class JsonValueExtensions
                 return DateOnly.FromDateTime(value.GetValue<DateTime>());
             }
 
-            return value.GetValue<DateOnly>();
+            return DateOnly.Parse(value.GetValue<string>());
         }
 
         if (targetType == typeof(TimeOnly))
@@ -105,7 +105,7 @@ public static class JsonValueExtensions
                 return TimeOnly.FromDateTime(value.GetValue<DateTime>());
             }
 
-            return value.GetValue<TimeOnly>();
+            return TimeOnly.Parse(value.GetValue<string>());
         }
 
         return null;


### PR DESCRIPTION
### Fixed

- `DateOnly`and `TimeOnly` serialization from `JsonValue` now parses the string if its not a `DateTime` source type.
- Switched to using the `System.Text.Json` serializer when saving the event content in the event log, which then persists `DateOnly`and `TimeOnly` and other types with converters correctly.
