### PR TITLE
Feature/projections

### DIFF
--- a/Source/Clients/DotNET/Events/Projections/Expressions/EventContentPropertyExpression.cs
+++ b/Source/Clients/DotNET/Events/Projections/Expressions/EventContentPropertyExpression.cs
@@ -6,8 +6,8 @@ using Aksio.Cratis.Properties;
 namespace Aksio.Cratis.Events.Projections.Expressions;
 
 /// <summary>
-/// Represents a <see cref="IKeyBuilder"/> that builds an event content property accessor expression.
-/// </summary>
+/// Represents a <see cref="IEventValueExpression"/> that builds an event content property accessor expression.
+/// /// </summary>
 public class EventContentPropertyExpression : IEventValueExpression
 {
     readonly PropertyPath _propertyPath;

--- a/Source/Clients/DotNET/Events/Projections/Expressions/EventContentPropertyExpression.cs
+++ b/Source/Clients/DotNET/Events/Projections/Expressions/EventContentPropertyExpression.cs
@@ -7,7 +7,7 @@ namespace Aksio.Cratis.Events.Projections.Expressions;
 
 /// <summary>
 /// Represents a <see cref="IEventValueExpression"/> that builds an event content property accessor expression.
-/// /// </summary>
+/// </summary>
 public class EventContentPropertyExpression : IEventValueExpression
 {
     readonly PropertyPath _propertyPath;

--- a/Source/Clients/DotNET/Events/Projections/Expressions/ValueExpression.cs
+++ b/Source/Clients/DotNET/Events/Projections/Expressions/ValueExpression.cs
@@ -16,5 +16,6 @@ public class ValueExpression : IEventValueExpression
     /// <param name="value">The value to set.</param>
     public ValueExpression(string value) => _value = value;
 
+    /// <inheritdoc/>
     public string Build() => $"$value({_value})";
 }

--- a/Source/Clients/DotNET/Events/Projections/Expressions/ValueExpression.cs
+++ b/Source/Clients/DotNET/Events/Projections/Expressions/ValueExpression.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Events.Projections.Expressions;
+
+/// <summary>
+/// Represents a <see cref="IEventValueExpression"/> for setting a constant value.
+/// </summary>
+public class ValueExpression : IEventValueExpression
+{
+    readonly string _value;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValueExpression"/> class.
+    /// </summary>
+    /// <param name="value">The value to set.</param>
+    public ValueExpression(string value) => _value = value;
+
+    public string Build() => $"$value({_value})";
+}

--- a/Source/Clients/DotNET/Events/Projections/IModelPropertiesBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/IModelPropertiesBuilder.cs
@@ -40,6 +40,15 @@ public interface IModelPropertiesBuilder<TModel, TEvent, TBuilder>
     TBuilder UsingParentKey<TProperty>(Expression<Func<TEvent, TProperty>> keyAccessor);
 
     /// <summary>
+    /// Define what property on the event represents the parent key based on a property in the <see cref="EventContext"/>. This is typically used in child relationships to identify the parent model to
+    /// work with.
+    /// </summary>
+    /// <typeparam name="TProperty">Type of the property.</typeparam>
+    /// <param name="keyAccessor">Accessor for the property to use.</param>
+    /// <returns>Builder continuation.</returns>
+    TBuilder UsingParentKeyFromContext<TProperty>(Expression<Func<TEvent, TProperty>> keyAccessor);
+
+    /// <summary>
     /// Define what key to use based on a composite of expressions.
     /// </summary>
     /// <typeparam name="TKeyType">Type of key.</typeparam>
@@ -76,6 +85,6 @@ public interface IModelPropertiesBuilder<TModel, TEvent, TBuilder>
     /// </summary>
     /// <typeparam name="TProperty">Type of the property.</typeparam>
     /// <param name="modelPropertyAccessor">Model property accessor for defining the target property.</param>
-    /// <returns>The <see cref="ISetBuilder{TModel, Tevent, TProperty, TBuilder}"/> to continue building on.</returns>
+    /// <returns>The <see cref="ISetBuilder{TModel, TEvent, TProperty, TBuilder}"/> to continue building on.</returns>
     ISetBuilder<TModel, TEvent, TProperty, TBuilder> Set<TProperty>(Expression<Func<TModel, TProperty>> modelPropertyAccessor);
 }

--- a/Source/Clients/DotNET/Events/Projections/ISetBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/ISetBuilder.cs
@@ -16,6 +16,13 @@ namespace Aksio.Cratis.Events.Projections;
 public interface ISetBuilder<TModel, TEvent, TProperty, TParentBuilder> : IPropertyExpressionBuilder
 {
     /// <summary>
+    /// Set the property to a specific value.
+    /// </summary>
+    /// <param name="value">Value to set.</param>
+    /// <returns>Builder continuation.</returns>
+    TParentBuilder ToValue(TProperty value);
+
+    /// <summary>
     /// Straight map to a property on the event.
     /// </summary>
     /// <param name="eventPropertyAccessor">Event property accessor for defining the source property.</param>

--- a/Source/Clients/DotNET/Events/Projections/ModelPropertiesBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/ModelPropertiesBuilder.cs
@@ -42,6 +42,13 @@ public class ModelPropertiesBuilder<TModel, TEvent, TBuilder> : IModelProperties
     }
 
     /// <inheritdoc/>
+    public TBuilder UsingParentKeyFromContext<TProperty>(Expression<Func<TEvent, TProperty>> keyAccessor)
+    {
+        _parentKey = new KeyBuilder(new EventContextPropertyExpression(keyAccessor.GetPropertyPath()));
+        return (this as TBuilder)!;
+    }
+
+    /// <inheritdoc/>
     public TBuilder UsingKeyFromContext(Expression<Func<TEvent, EventContext>> keyAccessor)
     {
         _parentKey = new KeyBuilder(new EventContextPropertyExpression(keyAccessor.GetPropertyPath()));

--- a/Source/Clients/DotNET/Events/Projections/SetBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/SetBuilder.cs
@@ -39,6 +39,13 @@ public class SetBuilder<TModel, TEvent, TProperty, TParentBuilder> : ISetBuilder
     }
 
     /// <inheritdoc/>
+    public TParentBuilder ToValue(TProperty value)
+    {
+        _expression = new ValueExpression(value?.ToString() ?? string.Empty);
+        return _parent;
+    }
+
+    /// <inheritdoc/>
     public TParentBuilder To(Expression<Func<TEvent, TProperty>> eventPropertyAccessor)
     {
         _expression = new EventContentPropertyExpression(eventPropertyAccessor.GetPropertyPath());

--- a/Source/Kernel/Projections/Engine/EventValueProviders.cs
+++ b/Source/Kernel/Projections/Engine/EventValueProviders.cs
@@ -38,6 +38,13 @@ public static class EventValueProviders
     }
 
     /// <summary>
+    /// Create a <see cref="ValueProvider{T}"/> that provides a constant value.
+    /// </summary>
+    /// <param name="value">Constant to provide.</param>
+    /// <returns>A new <see cref="ValueProvider{T}"/>.</returns>
+    public static ValueProvider<AppendedEvent> Value(string value) => (AppendedEvent _) => value;
+
+    /// <summary>
     /// Create a <see cref="ValueProvider{T}"/> that generates a new unique identifier from the event metadata.
     /// </summary>
     /// <returns>A new <see cref="ValueProvider{T}"/>.</returns>

--- a/Source/Kernel/Projections/Engine/Expressions/EventValues/EventContentExpressionResolver.cs
+++ b/Source/Kernel/Projections/Engine/Expressions/EventValues/EventContentExpressionResolver.cs
@@ -9,7 +9,7 @@ namespace Aksio.Cratis.Events.Projections.Expressions.EventValues;
 /// <summary>
 /// Represents a <see cref="IModelPropertyExpressionResolver"/> for resolving value from a property on the content of an <see cref="AppendedEvent"/>.
 /// </summary>
-public class EventContentExpressionProvider : IEventValueProviderExpressionResolver
+public class EventContentExpressionResolver : IEventValueProviderExpressionResolver
 {
     /// <inheritdoc/>
     public bool CanResolve(string expression) => !expression.StartsWith("$", StringComparison.InvariantCultureIgnoreCase);

--- a/Source/Kernel/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
+++ b/Source/Kernel/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
@@ -15,7 +15,8 @@ public class EventValueProviderExpressionResolvers : IEventValueProviderExpressi
     {
         new EventSourceIdExpressionResolver(),
         new EventContextPropertyExpressionResolver(),
-        new EventContentExpressionProvider()
+        new EventContentExpressionProvider(),
+        new ValueExpressionResolver()
     };
 
     /// <inheritdoc/>

--- a/Source/Kernel/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
+++ b/Source/Kernel/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
@@ -15,7 +15,7 @@ public class EventValueProviderExpressionResolvers : IEventValueProviderExpressi
     {
         new EventSourceIdExpressionResolver(),
         new EventContextPropertyExpressionResolver(),
-        new EventContentExpressionProvider(),
+        new EventContentExpressionResolver(),
         new ValueExpressionResolver()
     };
 

--- a/Source/Kernel/Projections/Engine/Expressions/EventValues/ValueExpressionResolver.cs
+++ b/Source/Kernel/Projections/Engine/Expressions/EventValues/ValueExpressionResolver.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.RegularExpressions;
+using Aksio.Cratis.Events.Store;
+using Aksio.Cratis.Properties;
+
+namespace Aksio.Cratis.Events.Projections.Expressions.EventValues;
+
+/// <summary>
+/// Represents a <see cref="IModelPropertyExpressionResolver"/> for resolving value to a constant.
+/// </summary>
+public class ValueExpressionResolver : IEventValueProviderExpressionResolver
+{
+    static readonly Regex _regularExpression = new("\\$value\\((?<value>[\\w ._\\*\\+\\-]*)\\)", RegexOptions.Compiled | RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(1));
+
+    /// <inheritdoc/>
+    public bool CanResolve(string expression) => _regularExpression.Match(expression).Success;
+
+    /// <inheritdoc/>
+    public ValueProvider<AppendedEvent> Resolve(string expression)
+    {
+        var match = _regularExpression.Match(expression);
+        return EventValueProviders.Value(match.Groups["value"].Value);
+    }
+}

--- a/Source/Kernel/Projections/Engine/Expressions/Keys/EventValueKeyExpressionResolver.cs
+++ b/Source/Kernel/Projections/Engine/Expressions/Keys/EventValueKeyExpressionResolver.cs
@@ -25,6 +25,6 @@ public class EventValueKeyExpressionResolver : IKeyExpressionResolver
     /// <inheritdoc/>
     public KeyResolver Resolve(IProjection projection, string expression, PropertyPath identifiedByProperty)
     {
-        return KeyResolvers.FromEventValueProvider(projection, identifiedByProperty, _resolvers.Resolve(expression));
+        return KeyResolvers.FromEventValueProvider(_resolvers.Resolve(expression));
     }
 }

--- a/Source/Kernel/Projections/Engine/IProjection.cs
+++ b/Source/Kernel/Projections/Engine/IProjection.cs
@@ -68,6 +68,11 @@ public interface IProjection
     IEnumerable<EventType> EventTypes { get; }
 
     /// <summary>
+    /// Gets the <see cref="EventType">event types</see> that are exclusive to this projection and not including any of the child projections.
+    /// </summary>
+    IEnumerable<EventType> ExclusiveEventTypes { get; }
+
+    /// <summary>
     /// Gets the <see cref="EventTypeWithKeyResolver"/> collection.
     /// </summary>
     IEnumerable<EventTypeWithKeyResolver> EventTypesWithKeyResolver { get; }

--- a/Source/Kernel/Projections/Engine/KeyResolvers.cs
+++ b/Source/Kernel/Projections/Engine/KeyResolvers.cs
@@ -79,7 +79,8 @@ public static class KeyResolvers
             var currentProjection = projection;
             if (currentProjection.HasParent)
             {
-                arrayIndexers.Add(new(projection.ChildrenPropertyPath, identifiedByProperty, thisLevelKeyResolver(eventProvider, @event)));
+                var thisLevelKey = await thisLevelKeyResolver(eventProvider, @event);
+                arrayIndexers.Add(new(projection.ChildrenPropertyPath, identifiedByProperty, thisLevelKey.Value));
                 currentProjection = currentProjection.Parent!;
                 var parentEvent = await eventProvider.GetLastInstanceOfAny(EventSequenceId.Log, parentKey.ToString()!, currentProjection.EventTypes.Select(_ => _.Id));
                 var eventType = currentProjection.EventTypes.First(_ => _.Id == parentEvent.Metadata.Type.Id);

--- a/Source/Kernel/Projections/Engine/KeyResolvers.cs
+++ b/Source/Kernel/Projections/Engine/KeyResolvers.cs
@@ -22,24 +22,14 @@ public static class KeyResolvers
     /// <summary>
     /// Create a <see cref="KeyResolver"/> that provides a value from the event content.
     /// </summary>
-    /// <param name="projection"><see cref="IProjection"/> to start at.</param>
-    /// <param name="identifiedByProperty">The property that identifies the key on the child object.</param>
     /// <param name="eventValueProvider">The actual <see cref="ValueProvider{T}"/> for resolving key.</param>
     /// <returns>A new <see cref="KeyResolver"/>.</returns>
-    public static KeyResolver FromEventValueProvider(IProjection projection, PropertyPath identifiedByProperty, ValueProvider<AppendedEvent> eventValueProvider)
+    public static KeyResolver FromEventValueProvider(ValueProvider<AppendedEvent> eventValueProvider)
     {
         return (IEventSequenceStorageProvider eventProvider, AppendedEvent @event) =>
         {
             var key = eventValueProvider(@event);
-            if (!projection.HasParent)
-            {
-                return Task.FromResult(new Key(key, ArrayIndexers.NoIndexers))!;
-            }
-
-            var arrayIndexers = new List<ArrayIndexer>();
-            var parentKey = EventValueProviders.EventSourceId(@event);
-            arrayIndexers.Add(new(projection.ChildrenPropertyPath, identifiedByProperty, key));
-            return Task.FromResult(new Key(parentKey, new ArrayIndexers(arrayIndexers)))!;
+            return Task.FromResult(new Key(key, ArrayIndexers.NoIndexers))!;
         };
     }
 
@@ -66,31 +56,34 @@ public static class KeyResolvers
     /// Create a <see cref="KeyResolver"/> that provides a key value hierarchically upwards in Child->Parent relationships.
     /// </summary>
     /// <param name="projection"><see cref="IProjection"/> to start at.</param>
-    /// <param name="thisLevelKeyResolver">see cref=KeyResolver"/> to use for resolving the key for the incoming event.</param>
-    /// <param name="parentKeyProperty">The property that represents the parent key.</param>
+    /// <param name="keyResolver">see cref=KeyResolver"/> to use for resolving the key for the incoming event.</param>
+    /// <param name="parentKeyResolver">The property that represents the parent key.</param>
     /// <param name="identifiedByProperty">The property that identifies the key on the child object.</param>
     /// <returns>A new <see cref="KeyResolver"/>.</returns>
-    public static KeyResolver FromParentHierarchy(IProjection projection, KeyResolver thisLevelKeyResolver, PropertyPath parentKeyProperty, PropertyPath identifiedByProperty)
+    public static KeyResolver FromParentHierarchy(IProjection projection, KeyResolver keyResolver, KeyResolver parentKeyResolver, PropertyPath identifiedByProperty)
     {
         return async (IEventSequenceStorageProvider eventProvider, AppendedEvent @event) =>
         {
             var arrayIndexers = new List<ArrayIndexer>();
-            var parentKey = EventValueProviders.EventContent(parentKeyProperty)(@event);
-            var currentProjection = projection;
-            if (currentProjection.HasParent)
+            var parentKey = await parentKeyResolver(eventProvider, @event);
+            if (projection.HasParent)
             {
-                var thisLevelKey = await thisLevelKeyResolver(eventProvider, @event);
-                arrayIndexers.Add(new(projection.ChildrenPropertyPath, identifiedByProperty, thisLevelKey.Value));
-                currentProjection = currentProjection.Parent!;
-                var parentEvent = await eventProvider.GetLastInstanceOfAny(EventSequenceId.Log, parentKey.ToString()!, currentProjection.EventTypes.Select(_ => _.Id));
-                var eventType = currentProjection.EventTypes.First(_ => _.Id == parentEvent.Metadata.Type.Id);
-                var keyResolver = currentProjection.GetKeyResolverFor(eventType);
-                var resolvedParentKey = await keyResolver(eventProvider, parentEvent);
-                parentKey = resolvedParentKey.Value;
-                arrayIndexers.AddRange(resolvedParentKey.ArrayIndexers.All);
+                var key = await keyResolver(eventProvider, @event);
+                arrayIndexers.Add(new(projection.ChildrenPropertyPath, identifiedByProperty, key.Value));
+                var parentProjection = projection.Parent!;
+                var parentEventTypeIds = parentProjection.ExclusiveEventTypes.Select(_ => _.Id).ToArray();
+                if (parentEventTypeIds.Length > 0)
+                {
+                    var parentEvent = await eventProvider.GetLastInstanceOfAny(EventSequenceId.Log, parentKey.Value.ToString()!, parentEventTypeIds);
+                    var eventType = parentProjection.EventTypes.First(_ => _.Id == parentEvent.Metadata.Type.Id);
+                    var keyResolverForEventType = parentProjection.GetKeyResolverFor(eventType);
+                    var resolvedParentKey = await keyResolverForEventType(eventProvider, parentEvent);
+                    parentKey = resolvedParentKey;
+                    arrayIndexers.AddRange(resolvedParentKey.ArrayIndexers.All);
+                }
             }
 
-            return new(parentKey, new ArrayIndexers(arrayIndexers));
+            return new(parentKey.Value, new ArrayIndexers(arrayIndexers));
         };
     }
 }

--- a/Source/Kernel/Projections/Engine/Projection.cs
+++ b/Source/Kernel/Projections/Engine/Projection.cs
@@ -45,6 +45,9 @@ public class Projection : IProjection
     public IEnumerable<EventType> EventTypes { get; private set; } = Array.Empty<EventType>();
 
     /// <inheritdoc/>
+    public IEnumerable<EventType> ExclusiveEventTypes { get; private set; } = Array.Empty<EventType>();
+
+    /// <inheritdoc/>
     public IEnumerable<IProjection> ChildProjections { get; }
 
     /// <inheritdoc/>
@@ -120,6 +123,9 @@ public class Projection : IProjection
         _eventTypesToKeyResolver = eventTypesWithKeyResolver.ToDictionary(
             _ => new EventType(_.EventType.Id, _.EventType.Generation),
             _ => _.KeyResolver);
+
+        var childEventTypes = ChildProjections.SelectMany(p => p.EventTypes);
+        ExclusiveEventTypes = EventTypes.Where(_ => !childEventTypes.Any(et => et == _)).ToArray();
     }
 
     /// <inheritdoc/>

--- a/Source/Kernel/Projections/Engine/ProjectionFactory.cs
+++ b/Source/Kernel/Projections/Engine/ProjectionFactory.cs
@@ -160,17 +160,18 @@ public class ProjectionFactory : IProjectionFactory
     {
         KeyResolver keyResolver;
 
-        if (!string.IsNullOrEmpty(parentKey))
-        {
-            keyResolver = KeyResolvers.FromParentHierarchy(projection, parentKey, actualIdentifiedByProperty);
-        }
-        else if (!string.IsNullOrEmpty(key) && _keyExpressionResolvers.CanResolve(key))
+        if (!string.IsNullOrEmpty(key) && _keyExpressionResolvers.CanResolve(key))
         {
             keyResolver = _keyExpressionResolvers.Resolve(projection, key, actualIdentifiedByProperty);
         }
         else
         {
             keyResolver = KeyResolvers.FromEventSourceId;
+        }
+
+        if (!string.IsNullOrEmpty(parentKey))
+        {
+            keyResolver = KeyResolvers.FromParentHierarchy(projection, keyResolver, parentKey, actualIdentifiedByProperty);
         }
 
         return new EventTypeWithKeyResolver(eventType, keyResolver);

--- a/Specifications/Kernel/Projections/Engine/Expressions/EventValues/for_EventContentExpressionResolver/when_asking_can_resolve_for_known_expression.cs
+++ b/Specifications/Kernel/Projections/Engine/Expressions/EventValues/for_EventContentExpressionResolver/when_asking_can_resolve_for_known_expression.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Aksio.Cratis.Events.Projections.Expressions.EventValues.for_EventContentExpressionProvider;
+namespace Aksio.Cratis.Events.Projections.Expressions.EventValues.for_EventContentExpressionResolver;
 
-public class when_asking_can_resolve_for_regular_property : Specification
+public class when_asking_can_resolve_for_known_expression : Specification
 {
-    EventContentExpressionProvider resolvers;
+    EventContentExpressionResolver resolvers;
     bool result;
 
-    void Establish() => resolvers = new EventContentExpressionProvider();
+    void Establish() => resolvers = new EventContentExpressionResolver();
 
     void Because() => result = resolvers.CanResolve("someProperty");
 

--- a/Specifications/Kernel/Projections/Engine/Expressions/EventValues/for_EventContentExpressionResolver/when_asking_can_resolve_for_system_type_property.cs
+++ b/Specifications/Kernel/Projections/Engine/Expressions/EventValues/for_EventContentExpressionResolver/when_asking_can_resolve_for_system_type_property.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Aksio.Cratis.Events.Projections.Expressions.EventValues.for_EventContentExpressionProvider;
+namespace Aksio.Cratis.Events.Projections.Expressions.EventValues.for_EventContentExpressionResolver;
 
 public class when_asking_can_resolve_for_system_type_property : Specification
 {
-    EventContentExpressionProvider resolvers;
+    EventContentExpressionResolver resolvers;
     bool result;
 
-    void Establish() => resolvers = new EventContentExpressionProvider();
+    void Establish() => resolvers = new EventContentExpressionResolver();
 
     void Because() => result = resolvers.CanResolve("$someProperty");
 

--- a/Specifications/Kernel/Projections/Engine/Expressions/EventValues/for_EventContentExpressionResolver/when_trying_to_resolve_valid_event_content_expression.cs
+++ b/Specifications/Kernel/Projections/Engine/Expressions/EventValues/for_EventContentExpressionResolver/when_trying_to_resolve_valid_event_content_expression.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Aksio.Cratis.Events.Projections.Expressions.EventValues.for_EventContentExpressionProvider;
+namespace Aksio.Cratis.Events.Projections.Expressions.EventValues.for_EventContentExpressionResolver;
 
 public class when_trying_to_resolve_valid_event_content_expression : given.an_appended_event
 {
-    EventContentExpressionProvider resolver;
+    EventContentExpressionResolver resolver;
     object result;
 
     void Establish() => resolver = new();

--- a/Specifications/Kernel/Projections/Engine/Expressions/EventValues/for_ValueExpressionResolver/when_asking_can_resolve_for_known_expression.cs
+++ b/Specifications/Kernel/Projections/Engine/Expressions/EventValues/for_ValueExpressionResolver/when_asking_can_resolve_for_known_expression.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Events.Projections.Expressions.EventValues.for_ValueExpressionResolver;
+
+public class when_asking_can_resolve_for_known_expression : Specification
+{
+    ValueExpressionResolver resolvers;
+    bool result;
+
+    void Establish() => resolvers = new();
+
+    void Because() => result = resolvers.CanResolve("$value(42)");
+
+    [Fact] void should_be_able_to_resolve() => result.ShouldBeTrue();
+}

--- a/Specifications/Kernel/Projections/Engine/Expressions/EventValues/for_ValueExpressionResolver/when_trying_to_resolve_valid_value_expression.cs
+++ b/Specifications/Kernel/Projections/Engine/Expressions/EventValues/for_ValueExpressionResolver/when_trying_to_resolve_valid_value_expression.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Events.Projections.Expressions.EventValues.for_ValueExpressionResolver;
+
+public class when_trying_to_resolve_valid_value_expression : given.an_appended_event
+{
+    ValueExpressionResolver resolver;
+    object result;
+
+    void Establish() => resolver = new();
+
+    void Because() => result = resolver.Resolve("$value(42)")(@event);
+
+    [Fact] void should_resolve_to_a_value_provider_that_returns_the_value() => result.ShouldEqual("42");
+}

--- a/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_four_levels.cs
+++ b/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_four_levels.cs
@@ -55,7 +55,7 @@ public class when_identifying_model_key_from_parent_hierarchy_with_four_levels :
 
         if (parent is not null)
         {
-            projection.Setup(_ => _.GetKeyResolverFor(eventType)).Returns(KeyResolvers.FromParentHierarchy(projection.Object, "parentId", "childId"));
+            projection.Setup(_ => _.GetKeyResolverFor(eventType)).Returns(KeyResolvers.FromParentHierarchy(projection.Object, KeyResolvers.FromEventSourceId, "parentId", "childId"));
             projection.SetupGet(_ => _.HasParent).Returns(true);
             projection.SetupGet(_ => _.Parent).Returns(parent);
         }
@@ -88,7 +88,7 @@ public class when_identifying_model_key_from_parent_hierarchy_with_four_levels :
         storage.Setup(_ => _.GetLastInstanceOfAny(EventSequenceId.Log, forth_level_key, new[] { forth_level_event_type.Id })).Returns(Task.FromResult(forth_level_event));
     }
 
-    async Task Because() => result = await KeyResolvers.FromParentHierarchy(forth_level_projection.Object, "parentId", "childId")(storage.Object, forth_level_event);
+    async Task Because() => result = await KeyResolvers.FromParentHierarchy(forth_level_projection.Object, KeyResolvers.FromEventSourceId, "parentId", "childId")(storage.Object, forth_level_event);
 
     [Fact] void should_return_expected_key() => result.Value.ShouldEqual(root_key);
     [Fact] void should_hold_array_indexer_for_first_level_with_correct_identifier() => result.ArrayIndexers.All.Single(_ => _.ArrayProperty == "firstLevels").Identifier.ToString().ShouldEqual(first_level_key);

--- a/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_one_level.cs
+++ b/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_one_level.cs
@@ -51,7 +51,11 @@ public class when_identifying_model_key_from_parent_hierarchy_with_one_level : S
         root_projection.Setup(_ => _.GetKeyResolverFor(root_event_type)).Returns((_, __) => Task.FromResult(new Key(parent_key, ArrayIndexers.NoIndexers)));
     }
 
-    async Task Because() => result = await KeyResolvers.FromParentHierarchy(child_projection.Object, KeyResolvers.FromEventSourceId, "parentId", "childId")(storage.Object, @event);
+    async Task Because() => result = await KeyResolvers.FromParentHierarchy(
+        child_projection.Object,
+        KeyResolvers.FromEventSourceId,
+        KeyResolvers.FromEventValueProvider(EventValueProviders.EventContent("parentId")),
+        "childId")(storage.Object, @event);
 
     [Fact] void should_return_expected_key() => result.Value.ShouldEqual(parent_key);
 }

--- a/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_one_level.cs
+++ b/Specifications/Kernel/Projections/Engine/for_KeyResolvers/when_identifying_model_key_from_parent_hierarchy_with_one_level.cs
@@ -51,7 +51,7 @@ public class when_identifying_model_key_from_parent_hierarchy_with_one_level : S
         root_projection.Setup(_ => _.GetKeyResolverFor(root_event_type)).Returns((_, __) => Task.FromResult(new Key(parent_key, ArrayIndexers.NoIndexers)));
     }
 
-    async Task Because() => result = await KeyResolvers.FromParentHierarchy(child_projection.Object, "parentId", "childId")(storage.Object, @event);
+    async Task Because() => result = await KeyResolvers.FromParentHierarchy(child_projection.Object, KeyResolvers.FromEventSourceId, "parentId", "childId")(storage.Object, @event);
 
     [Fact] void should_return_expected_key() => result.Value.ShouldEqual(parent_key);
 }


### PR DESCRIPTION
## Summary

This version brings improved stability and predictability to child relationships.
It is now possible to specify a relationship of events where all the events are linked to the same event source id.
The resolution through the parent key will by default resolve itself by using the parents event source id if no `.UsingParentKey()` or the new `.UsingParentKeyFromContext()` is specified. With such a structure, you might need to resolve the actual key for the child item, this can now be done by using the `.UsingKey()` on the child level of the projection.

### Added

- Supporting `.UsingKey()` for identifying child items without forcing it to be identified through the `EventSourceId`.
- Add support for mapping to constants using `.ToValue()`for the set builders for projections. (#573)
- Support for using parent key from context `.UsingParentKeyFromContext()`. (#576)
