### PR TITLE
Converting enum values to integer till we get #579 done properly

### DIFF
--- a/Source/Clients/DotNET/Events/Projections/SetBuilder.cs
+++ b/Source/Clients/DotNET/Events/Projections/SetBuilder.cs
@@ -41,7 +41,13 @@ public class SetBuilder<TModel, TEvent, TProperty, TParentBuilder> : ISetBuilder
     /// <inheritdoc/>
     public TParentBuilder ToValue(TProperty value)
     {
-        _expression = new ValueExpression(value?.ToString() ?? string.Empty);
+        object actualValue = value!;
+        if (value?.GetType().IsEnum ?? false)
+        {
+            actualValue = Convert.ToInt32(value);
+        }
+
+        _expression = new ValueExpression(actualValue?.ToString() ?? string.Empty);
         return _parent;
     }
 


### PR DESCRIPTION
### Fixed

- Fixing so that we get the actual enum value as an integer before sending it to the kernel for the `.ToValue()` support till we have implemented #579.
