### PR TITLE
Composite keys will now resolve the actual nested properties

### DIFF
--- a/Source/Kernel/Projections/Engine/Expressions/Keys/CompositeKeyExpressionResolver.cs
+++ b/Source/Kernel/Projections/Engine/Expressions/Keys/CompositeKeyExpressionResolver.cs
@@ -46,8 +46,9 @@ public class CompositeKeyExpressionResolver : IKeyExpressionResolver
             {
                 throw new InvalidCompositeKeyPropertyMappingExpression(projection.Identifier, identifiedByProperty, _);
             }
+            var actualProperty = identifiedByProperty + keyValue[0];
 
-            var schemaProperty = projection.Model.Schema.GetSchemaPropertyForPropertyPath(identifiedByProperty)!;
+            var schemaProperty = projection.Model.Schema.GetSchemaPropertyForPropertyPath(actualProperty)!;
             schemaProperty ??= new JsonSchemaProperty
             {
                 Type = JsonObjectType.String
@@ -55,7 +56,7 @@ public class CompositeKeyExpressionResolver : IKeyExpressionResolver
 
             return new
             {
-                Property = new PropertyPath(keyValue[0]),
+                Property =  new PropertyPath(keyValue[0]),
                 KeyResolver = _resolvers.Resolve(schemaProperty, keyValue[1])
             };
         }).ToDictionary(_ => _.Property, _ => _.KeyResolver);

--- a/Source/Kernel/Projections/Engine/Expressions/Keys/CompositeKeyExpressionResolver.cs
+++ b/Source/Kernel/Projections/Engine/Expressions/Keys/CompositeKeyExpressionResolver.cs
@@ -56,7 +56,7 @@ public class CompositeKeyExpressionResolver : IKeyExpressionResolver
 
             return new
             {
-                Property =  new PropertyPath(keyValue[0]),
+                Property = new PropertyPath(keyValue[0]),
                 KeyResolver = _resolvers.Resolve(schemaProperty, keyValue[1])
             };
         }).ToDictionary(_ => _.Property, _ => _.KeyResolver);


### PR DESCRIPTION
### Fixed

- Composite key resolver now maintains the correct property path, enabling it to resolve to the correct type for the nested properties.
