### PR TITLE
Fix/clone-serialization

### DIFF
--- a/Source/Extensions/MongoDB/ExpandoObjectConverter.cs
+++ b/Source/Extensions/MongoDB/ExpandoObjectConverter.cs
@@ -72,7 +72,10 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
                 value = ConvertFromBsonValue(element.Value, schemaProperty);
             }
 
-            expandoObjectAsDictionary[name] = value;
+            if (value is not null)
+            {
+                expandoObjectAsDictionary[name] = value;
+            }
         }
 
         return expandoObject;

--- a/Source/Extensions/MongoDB/ExpandoObjectConverter.cs
+++ b/Source/Extensions/MongoDB/ExpandoObjectConverter.cs
@@ -36,7 +36,7 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
             var schemaProperty = schemaProperties.SingleOrDefault(_ => _.Name == name);
             if (schemaProperty is null)
             {
-                ConvertUnknownSchemaTypeToBsonValue(keyValue.Value);
+                value = ConvertUnknownSchemaTypeToBsonValue(keyValue.Value);
             }
             else
             {
@@ -71,6 +71,7 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
             {
                 value = ConvertFromBsonValue(element.Value, schemaProperty);
             }
+
             expandoObjectAsDictionary[name] = value;
         }
 

--- a/Source/Fundamentals/Json/ExpandoObjectConverter.cs
+++ b/Source/Fundamentals/Json/ExpandoObjectConverter.cs
@@ -45,7 +45,10 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
                 value = ConvertToJsonNode(keyValue.Value, schemaProperty);
             }
 
-            jsonObject[name] = value;
+            if (value is not null)
+            {
+                jsonObject[name] = value;
+            }
         }
 
         return jsonObject;
@@ -73,7 +76,11 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
                     value = ConvertFromJsonNode(sourceValue!, schemaProperty);
                 }
             }
-            expandoObjectAsDictionary[name] = value!;
+
+            if (value is not null)
+            {
+                expandoObjectAsDictionary[name] = value;
+            }
         }
 
         return expandoObject;

--- a/Source/Fundamentals/Json/Globals.cs
+++ b/Source/Fundamentals/Json/Globals.cs
@@ -44,7 +44,7 @@ public static class Globals
         _jsonSerializerOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters =
             {
                 new ConceptAsJsonConverterFactory(),

--- a/Source/Fundamentals/Json/Globals.cs
+++ b/Source/Fundamentals/Json/Globals.cs
@@ -44,7 +44,7 @@ public static class Globals
         _jsonSerializerOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
             Converters =
             {
                 new ConceptAsJsonConverterFactory(),

--- a/Source/Fundamentals/Json/Globals.cs
+++ b/Source/Fundamentals/Json/Globals.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Aksio.Cratis.Serialization;
 
 namespace Aksio.Cratis.Json;
@@ -43,6 +44,7 @@ public static class Globals
         _jsonSerializerOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters =
             {
                 new ConceptAsJsonConverterFactory(),

--- a/Source/Fundamentals/Json/JsonObjectExtensions.cs
+++ b/Source/Fundamentals/Json/JsonObjectExtensions.cs
@@ -19,7 +19,7 @@ public static class JsonObjectExtensions
     /// <returns>A new <see cref="JsonObject"/> instance.</returns>
     public static JsonObject DeepClone(this JsonObject json)
     {
-        return (JsonNode.Parse(json.ToJsonString()) as JsonObject)!;
+        return (JsonNode.Parse(json.ToJsonString(Globals.JsonSerializerOptions)) as JsonObject)!;
     }
 
     /// <summary>


### PR DESCRIPTION
### Fixed

- Making deep cloning of JSON objects use the global `JsonSerializerOptions` to support the types we support.
- Setting default ignore condition for JSON serialization to ignore null values.
- Ignoring properties that are null when converting to `ExpandoObject` and `JsonObject` internally. The JSON serializer will then ignore these properties when deserializing in the client.
