### PR TITLE
Fix/cache

### DIFF
--- a/Source/Kernel/Store/Grains/EventSequenceLogMessages.cs
+++ b/Source/Kernel/Store/Grains/EventSequenceLogMessages.cs
@@ -11,14 +11,14 @@ namespace Aksio.Cratis.Events.Store.Grains;
 /// </summary>
 public static partial class EventSequenceLogMessages
 {
-    [LoggerMessage(0, LogLevel.Information, "Appending '{EventType}' for EventSource {EventSource} with sequence number {SequenceNumber} to event sequence '{EventSequenceId} for microservice {MicroserviceId} on tenant {TenantId}")]
-    internal static partial void Appending(this ILogger logger, MicroserviceId microserviceId, TenantId tenantId, EventSequenceId eventSequenceId, EventType eventType, EventSourceId eventSource, ulong sequenceNumber);
+    [LoggerMessage(0, LogLevel.Information, "Appending '{EventName}-{EventType}' for EventSource {EventSource} with sequence number {SequenceNumber} to event sequence '{EventSequenceId} for microservice {MicroserviceId} on tenant {TenantId}")]
+    internal static partial void Appending(this ILogger logger, MicroserviceId microserviceId, TenantId tenantId, EventSequenceId eventSequenceId, EventType eventType, string eventName, EventSourceId eventSource, ulong sequenceNumber);
 
-    [LoggerMessage(1, LogLevel.Information, "Compensatin event @ {SequenceNumber} in event sequence {EventSequenceId} - event type {EventType} for microservice '{MicroserviceId}' on tenant {TenantId}")]
-    internal static partial void Compensating(this ILogger logger, MicroserviceId microserviceId, TenantId tenantId, EventType eventTYpe, EventSequenceId eventSequenceId, ulong sequenceNumber);
+    [LoggerMessage(1, LogLevel.Information, "Compensatin event @ {SequenceNumber} in event sequence {EventSequenceId} - event type '{EventType}' for microservice '{MicroserviceId}' on tenant {TenantId}")]
+    internal static partial void Compensating(this ILogger logger, MicroserviceId microserviceId, TenantId tenantId, EventType eventType, EventSequenceId eventSequenceId, ulong sequenceNumber);
 
-    [LoggerMessage(2, LogLevel.Critical, "Failed appending event at sequence {SequenceNumber} for event source {EventSourceId} to stream {StreamId} for microservice '{MicroserviceId}' on tenant {TenantId}")]
-    internal static partial void FailedAppending(this ILogger logger, MicroserviceId microserviceId, TenantId tenantId, Guid streamId, string eventSourceId, ulong sequenceNumber, Exception exception);
+    [LoggerMessage(2, LogLevel.Critical, "Failed appending event type '{EventType}' at sequence {SequenceNumber} for event source {EventSourceId} to stream {StreamId} for microservice '{MicroserviceId}' on tenant {TenantId}")]
+    internal static partial void FailedAppending(this ILogger logger, MicroserviceId microserviceId, TenantId tenantId, EventType eventType, Guid streamId, string eventSourceId, ulong sequenceNumber, Exception exception);
 
     [LoggerMessage(3, LogLevel.Error, "Error when appending event at sequence {SequenceNumber} for event source {EventSourceId} to event sequence {EventSequenceId} for microservice {MicroserviceId} on tenant {TenantId}")]
     internal static partial void ErrorAppending(this ILogger logger, MicroserviceId microserviceId, TenantId tenantId, EventSequenceId eventSequenceId, string eventSourceId, ulong sequenceNumber, Exception exception);

--- a/Source/Kernel/Store/Grains/Inboxes/Inbox.cs
+++ b/Source/Kernel/Store/Grains/Inboxes/Inbox.cs
@@ -79,10 +79,11 @@ public class Inbox : Grain, IInbox
 
     async Task HandleEvent(AppendedEvent @event, StreamSequenceToken token)
     {
-        _executionContextManager.Establish(_key!.TenantId, @event.Context.CorrelationId, _microserviceId!);
-        _logger.ForwardingEvent(_key!.TenantId, _microserviceId!, @event.Metadata.Type.Id, @event.Metadata.SequenceNumber);
+        _executionContextManager.Establish(_key!.TenantId, @event.Context.CorrelationId, _microserviceId);
 
         var eventSchema = await _schemaStore.GetFor(@event.Metadata.Type.Id, @event.Metadata.Type.Generation);
+        _logger.ForwardingEvent(_key!.TenantId, _microserviceId!, @event.Metadata.Type.Id, eventSchema.Schema.GetDisplayName(), @event.Metadata.SequenceNumber);
+
         var content = _expandoObjectConverter.ToJsonObject(@event.Content, eventSchema.Schema);
         await _inboxEventSequence!.Append(@event.Context.EventSourceId, @event.Metadata.Type, content!);
     }

--- a/Source/Kernel/Store/Grains/Inboxes/InboxLogMessages.cs
+++ b/Source/Kernel/Store/Grains/Inboxes/InboxLogMessages.cs
@@ -11,6 +11,6 @@ namespace Aksio.Cratis.Events.Store.Grains.Inboxes;
 /// </summary>
 public static partial class InboxLogMessages
 {
-    [LoggerMessage(0, LogLevel.Debug, "Forwarding event ({EventTypeId}) with sequence number from origin {SequenceNumber} for microservice '{MicroserviceId}' and tenant '{TenantId}'")]
-    internal static partial void ForwardingEvent(this ILogger logger, TenantId tenantId, MicroserviceId microserviceId, EventTypeId eventTypeId, EventSequenceNumber sequenceNumber);
+    [LoggerMessage(0, LogLevel.Debug, "Forwarding event ({EventName}-{EventTypeId}) with sequence number from origin {SequenceNumber} for microservice '{MicroserviceId}' and tenant '{TenantId}'")]
+    internal static partial void ForwardingEvent(this ILogger logger, TenantId tenantId, MicroserviceId microserviceId, EventTypeId eventTypeId, string eventName, EventSequenceNumber sequenceNumber);
 }

--- a/Source/Kernel/Store/Shared/EventSequences/Caching/EventSequenceCaches.cs
+++ b/Source/Kernel/Store/Shared/EventSequences/Caching/EventSequenceCaches.cs
@@ -39,6 +39,6 @@ public class EventSequenceCaches : IEventSequenceCaches
         }
 
         _executionContextManager.Establish(key.TenantId, CorrelationId.New(), key.MicroserviceId);
-        return _caches[key] = new EventSequenceCache(key.EventSequenceId, 500, _eventLogStorageProvider());
+        return _caches[key] = new EventSequenceCache(key.EventSequenceId, 20000, _eventLogStorageProvider());
     }
 }


### PR DESCRIPTION
### Fixed

- We have identified a major bug in the cache. We will remove our cache implementation and go for the vanilla Orleans one instead, very soon. Until that point, we've set the cache to hold 20K events for now. This is absolutely not good.
- Adding more details with event names to the log.
