### PR TITLE
Changing all calls to MongoDB to be synchronous

### DIFF
--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Concepts/Accounts/DebitAccountCloseReason.cs
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Concepts/Accounts/DebitAccountCloseReason.cs
@@ -5,6 +5,7 @@ namespace Concepts.Accounts;
 
 public enum DebitAccountCloseReason
 {
+    None = 0,
     Fraud = 1,
     CustomerRequest = 2
 }


### PR DESCRIPTION
### Fixed

- Changing all MongoDB calls for the schema store to be synchronous. To avoid problems with the Orleans task model.
