### PR TITLE
Fixing cache key for node_modules

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -40,7 +40,7 @@ jobs:
             **/.eslintcache
             **/yarn.lock
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
             **/node_modules
             **/.eslintcache
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
             **/.eslintcache
             **/yarn.lock
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 
@@ -181,7 +181,7 @@ jobs:
             **/.eslintcache
             **/yarn.lock
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -94,7 +94,7 @@ jobs:
             **/.eslintcache
             **/yarn.lock
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 
@@ -177,7 +177,7 @@ jobs:
       #       **/.eslintcache
       #       **/yarn.lock
       #       ${{ steps.yarn-cache-dir-path.outputs.dir }}
-      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
       #     restore-keys: |
       #       ${{ runner.os }}-yarn-
 


### PR DESCRIPTION
Long story; I'm opinionated about not keeping yarn.lock files in the repository.
I see them as relevant for local build, a cache of sorts for knowing what versions are installed.
They can camouflage real issues with versioning and also can hold OS dependent
references.

Anyways, funny being this opioninated and then screwing up the configuration of the builds
by taking a dependency to yarn.lock - files that aren't there :)

## Summary

Summary of the PR here. The GitHub release description is created from this comment so keep it nice and descriptive.
Remember to remove sections that you don't need or use.
If it does not make sense to have a summary, you can take that out as well.

### Added

- Describe the added features

### Changed

- Describe the outwards facing code change

### Fixed

- Describe the fix and the bug

### Removed

- Describe what was removed and why

### Security

- Describe the security issue and the fix

### Deprecated

- Describe the part of the code being deprecated and why
