### PR TITLE
Fix/use-commands

### DIFF
--- a/Samples/Banking/Bank/Web/API/accounts/credit/OpenCreditAccount.ts
+++ b/Samples/Banking/Bank/Web/API/accounts/credit/OpenCreditAccount.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import { AccountDetails } from './AccountDetails';
 import Handlebars from 'handlebars';
@@ -58,7 +58,7 @@ export class OpenCreditAccount extends Command<IOpenCreditAccount> implements IO
         this.propertyChanged('details');
     }
 
-    static use(initialValues?: IOpenCreditAccount): [OpenCreditAccount, SetCommandValues<IOpenCreditAccount>] {
+    static use(initialValues?: IOpenCreditAccount): [OpenCreditAccount, SetCommandValues<IOpenCreditAccount>, ClearCommandValues] {
         return useCommand<OpenCreditAccount, IOpenCreditAccount>(OpenCreditAccount, initialValues);
     }
 }

--- a/Samples/Banking/Bank/Web/API/accounts/debit/CloseDebitAccount.ts
+++ b/Samples/Banking/Bank/Web/API/accounts/debit/CloseDebitAccount.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -46,7 +46,7 @@ export class CloseDebitAccount extends Command<ICloseDebitAccount> implements IC
         this.propertyChanged('accountId');
     }
 
-    static use(initialValues?: ICloseDebitAccount): [CloseDebitAccount, SetCommandValues<ICloseDebitAccount>] {
+    static use(initialValues?: ICloseDebitAccount): [CloseDebitAccount, SetCommandValues<ICloseDebitAccount>, ClearCommandValues] {
         return useCommand<CloseDebitAccount, ICloseDebitAccount>(CloseDebitAccount, initialValues);
     }
 }

--- a/Samples/Banking/Bank/Web/API/accounts/debit/DepositToAccount.ts
+++ b/Samples/Banking/Bank/Web/API/accounts/debit/DepositToAccount.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -59,7 +59,7 @@ export class DepositToAccount extends Command<IDepositToAccount> implements IDep
         this.propertyChanged('amount');
     }
 
-    static use(initialValues?: IDepositToAccount): [DepositToAccount, SetCommandValues<IDepositToAccount>] {
+    static use(initialValues?: IDepositToAccount): [DepositToAccount, SetCommandValues<IDepositToAccount>, ClearCommandValues] {
         return useCommand<DepositToAccount, IDepositToAccount>(DepositToAccount, initialValues);
     }
 }

--- a/Samples/Banking/Bank/Web/API/accounts/debit/OpenDebitAccount.ts
+++ b/Samples/Banking/Bank/Web/API/accounts/debit/OpenDebitAccount.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import { AccountDetails } from './AccountDetails';
 import Handlebars from 'handlebars';
@@ -58,7 +58,7 @@ export class OpenDebitAccount extends Command<IOpenDebitAccount> implements IOpe
         this.propertyChanged('details');
     }
 
-    static use(initialValues?: IOpenDebitAccount): [OpenDebitAccount, SetCommandValues<IOpenDebitAccount>] {
+    static use(initialValues?: IOpenDebitAccount): [OpenDebitAccount, SetCommandValues<IOpenDebitAccount>, ClearCommandValues] {
         return useCommand<OpenDebitAccount, IOpenDebitAccount>(OpenDebitAccount, initialValues);
     }
 }

--- a/Samples/Banking/Bank/Web/API/accounts/debit/SetDebitAccountName.ts
+++ b/Samples/Banking/Bank/Web/API/accounts/debit/SetDebitAccountName.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -59,7 +59,7 @@ export class SetDebitAccountName extends Command<ISetDebitAccountName> implement
         this.propertyChanged('name');
     }
 
-    static use(initialValues?: ISetDebitAccountName): [SetDebitAccountName, SetCommandValues<ISetDebitAccountName>] {
+    static use(initialValues?: ISetDebitAccountName): [SetDebitAccountName, SetCommandValues<ISetDebitAccountName>, ClearCommandValues] {
         return useCommand<SetDebitAccountName, ISetDebitAccountName>(SetDebitAccountName, initialValues);
     }
 }

--- a/Samples/Banking/Bank/Web/API/accounts/debit/WithdrawFromAccount.ts
+++ b/Samples/Banking/Bank/Web/API/accounts/debit/WithdrawFromAccount.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -59,7 +59,7 @@ export class WithdrawFromAccount extends Command<IWithdrawFromAccount> implement
         this.propertyChanged('amount');
     }
 
-    static use(initialValues?: IWithdrawFromAccount): [WithdrawFromAccount, SetCommandValues<IWithdrawFromAccount>] {
+    static use(initialValues?: IWithdrawFromAccount): [WithdrawFromAccount, SetCommandValues<IWithdrawFromAccount>, ClearCommandValues] {
         return useCommand<WithdrawFromAccount, IWithdrawFromAccount>(WithdrawFromAccount, initialValues);
     }
 }

--- a/Source/ApplicationModel/Frontend/commands/useCommand.ts
+++ b/Source/ApplicationModel/Frontend/commands/useCommand.ts
@@ -8,8 +8,9 @@ import React from 'react';
 import { CommandTrackerContext } from './CommandTracker';
 
 export type SetCommandValues<TCommandContent> = (command: TCommandContent) => void;
+export type ClearCommandValues = () => void;
 
-export function useCommand<TCommand extends Command, TCommandContent>(commandType: Constructor<TCommand>, initialValues?: TCommandContent): [TCommand, SetCommandValues<TCommandContent>] {
+export function useCommand<TCommand extends Command, TCommandContent>(commandType: Constructor<TCommand>, initialValues?: TCommandContent): [TCommand, SetCommandValues<TCommandContent>, ClearCommandValues] {
     const instance = new commandType();
     const [command, setCommand] = useState<TCommand>(instance);
     const [hasChanges, setHasChanges] = useState(false);
@@ -33,11 +34,17 @@ export function useCommand<TCommand extends Command, TCommandContent>(commandTyp
 
     const setCommandValues = (values: TCommandContent) => {
         command!.properties.forEach(property => {
-            if (values[property]) {
+            if (values[property] !== undefined && values[property] != null) {
                 command![property] = values[property];
             }
         });
     };
 
-    return [command!, setCommandValues];
+    const clearCommandValues = () => {
+        command!.properties.forEach(property => {
+            command![property] = undefined;
+        });
+    };
+
+    return [command!, setCommandValues, clearCommandValues];
 }

--- a/Source/ApplicationModel/Tooling/ProxyGenerator/Templates/Command.hbs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/Templates/Command.hbs
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 {{#Imports}}
 import { {{Type}} } from '{{Module}}';
@@ -80,7 +80,7 @@ export class {{Name}} extends Command<I{{Name}}> implements I{{Name}} {
     {{/if}}
     {{/Properties}}
 
-    static use(initialValues?: I{{Name}}): [{{Name}}, SetCommandValues<I{{Name}}>] {
+    static use(initialValues?: I{{Name}}): [{{Name}}, SetCommandValues<I{{Name}}>, ClearCommandValues] {
         return useCommand<{{Name}}, I{{Name}}>({{Name}}, initialValues);
     }
 }


### PR DESCRIPTION
### Added

- `useCommand()` now returns a third component to the tuple; `ClearCommandValues` which sets them all to undefined. The proxy generator honors this and creates a proxy that does the same. (#595)

### Fixed

- Fixing the `SetCommandValues` returned from `useCommand()` to only ignore properties that are either undefined or null. Allowing for empty strings to be set. (#596)
