### PR TITLE
Fixing generated proxies

### DIFF
--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/CloseDebitAccount.ts
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/CloseDebitAccount.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -46,7 +46,7 @@ export class CloseDebitAccount extends Command<ICloseDebitAccount> implements IC
         this.propertyChanged('accountId');
     }
 
-    static use(initialValues?: ICloseDebitAccount): [CloseDebitAccount, SetCommandValues<ICloseDebitAccount>] {
+    static use(initialValues?: ICloseDebitAccount): [CloseDebitAccount, SetCommandValues<ICloseDebitAccount>, ClearCommandValues] {
         return useCommand<CloseDebitAccount, ICloseDebitAccount>(CloseDebitAccount, initialValues);
     }
 }

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/DepositToAccount.ts
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/DepositToAccount.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -59,7 +59,7 @@ export class DepositToAccount extends Command<IDepositToAccount> implements IDep
         this.propertyChanged('amount');
     }
 
-    static use(initialValues?: IDepositToAccount): [DepositToAccount, SetCommandValues<IDepositToAccount>] {
+    static use(initialValues?: IDepositToAccount): [DepositToAccount, SetCommandValues<IDepositToAccount>, ClearCommandValues] {
         return useCommand<DepositToAccount, IDepositToAccount>(DepositToAccount, initialValues);
     }
 }

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/OpenDebitAccount.ts
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/OpenDebitAccount.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import { AccountDetails } from './AccountDetails';
 import Handlebars from 'handlebars';
@@ -58,7 +58,7 @@ export class OpenDebitAccount extends Command<IOpenDebitAccount> implements IOpe
         this.propertyChanged('details');
     }
 
-    static use(initialValues?: IOpenDebitAccount): [OpenDebitAccount, SetCommandValues<IOpenDebitAccount>] {
+    static use(initialValues?: IOpenDebitAccount): [OpenDebitAccount, SetCommandValues<IOpenDebitAccount>, ClearCommandValues] {
         return useCommand<OpenDebitAccount, IOpenDebitAccount>(OpenDebitAccount, initialValues);
     }
 }

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/SetDebitAccountName.ts
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/SetDebitAccountName.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -59,7 +59,7 @@ export class SetDebitAccountName extends Command<ISetDebitAccountName> implement
         this.propertyChanged('name');
     }
 
-    static use(initialValues?: ISetDebitAccountName): [SetDebitAccountName, SetCommandValues<ISetDebitAccountName>] {
+    static use(initialValues?: ISetDebitAccountName): [SetDebitAccountName, SetCommandValues<ISetDebitAccountName>, ClearCommandValues] {
         return useCommand<SetDebitAccountName, ISetDebitAccountName>(SetDebitAccountName, initialValues);
     }
 }

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/WithdrawFromAccount.ts
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/Debit/WithdrawFromAccount.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -59,7 +59,7 @@ export class WithdrawFromAccount extends Command<IWithdrawFromAccount> implement
         this.propertyChanged('amount');
     }
 
-    static use(initialValues?: IWithdrawFromAccount): [WithdrawFromAccount, SetCommandValues<IWithdrawFromAccount>] {
+    static use(initialValues?: IWithdrawFromAccount): [WithdrawFromAccount, SetCommandValues<IWithdrawFromAccount>, ClearCommandValues] {
         return useCommand<WithdrawFromAccount, IWithdrawFromAccount>(WithdrawFromAccount, initialValues);
     }
 }

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/credit/OpenCreditAccount.ts
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/API/Accounts/credit/OpenCreditAccount.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import { AccountDetails } from './AccountDetails';
 import Handlebars from 'handlebars';
@@ -58,7 +58,7 @@ export class OpenCreditAccount extends Command<IOpenCreditAccount> implements IO
         this.propertyChanged('details');
     }
 
-    static use(initialValues?: IOpenCreditAccount): [OpenCreditAccount, SetCommandValues<IOpenCreditAccount>] {
+    static use(initialValues?: IOpenCreditAccount): [OpenCreditAccount, SetCommandValues<IOpenCreditAccount>, ClearCommandValues] {
         return useCommand<OpenCreditAccount, IOpenCreditAccount>(OpenCreditAccount, initialValues);
     }
 }

--- a/Source/Workbench/API/compliance/gdpr/pii/CreateAndRegisterKeyFor.ts
+++ b/Source/Workbench/API/compliance/gdpr/pii/CreateAndRegisterKeyFor.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -45,7 +45,7 @@ export class CreateAndRegisterKeyFor extends Command<ICreateAndRegisterKeyFor> i
         this.propertyChanged('identifier');
     }
 
-    static use(initialValues?: ICreateAndRegisterKeyFor): [CreateAndRegisterKeyFor, SetCommandValues<ICreateAndRegisterKeyFor>] {
+    static use(initialValues?: ICreateAndRegisterKeyFor): [CreateAndRegisterKeyFor, SetCommandValues<ICreateAndRegisterKeyFor>, ClearCommandValues] {
         return useCommand<CreateAndRegisterKeyFor, ICreateAndRegisterKeyFor>(CreateAndRegisterKeyFor, initialValues);
     }
 }

--- a/Source/Workbench/API/compliance/gdpr/pii/DeletePIIForPerson.ts
+++ b/Source/Workbench/API/compliance/gdpr/pii/DeletePIIForPerson.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -45,7 +45,7 @@ export class DeletePIIForPerson extends Command<IDeletePIIForPerson> implements 
         this.propertyChanged('personId');
     }
 
-    static use(initialValues?: IDeletePIIForPerson): [DeletePIIForPerson, SetCommandValues<IDeletePIIForPerson>] {
+    static use(initialValues?: IDeletePIIForPerson): [DeletePIIForPerson, SetCommandValues<IDeletePIIForPerson>, ClearCommandValues] {
         return useCommand<DeletePIIForPerson, IDeletePIIForPerson>(DeletePIIForPerson, initialValues);
     }
 }

--- a/Source/Workbench/API/compliance/microservices/AddMicroservice.ts
+++ b/Source/Workbench/API/compliance/microservices/AddMicroservice.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -57,7 +57,7 @@ export class AddMicroservice extends Command<IAddMicroservice> implements IAddMi
         this.propertyChanged('name');
     }
 
-    static use(initialValues?: IAddMicroservice): [AddMicroservice, SetCommandValues<IAddMicroservice>] {
+    static use(initialValues?: IAddMicroservice): [AddMicroservice, SetCommandValues<IAddMicroservice>, ClearCommandValues] {
         return useCommand<AddMicroservice, IAddMicroservice>(AddMicroservice, initialValues);
     }
 }

--- a/Source/Workbench/API/events/store/observers/Rewind.ts
+++ b/Source/Workbench/API/events/store/observers/Rewind.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -72,7 +72,7 @@ export class Rewind extends Command<IRewind> implements IRewind {
         this.propertyChanged('tenantId');
     }
 
-    static use(initialValues?: IRewind): [Rewind, SetCommandValues<IRewind>] {
+    static use(initialValues?: IRewind): [Rewind, SetCommandValues<IRewind>, ClearCommandValues] {
         return useCommand<Rewind, IRewind>(Rewind, initialValues);
     }
 }

--- a/Source/Workbench/API/events/store/sequence/Append.ts
+++ b/Source/Workbench/API/events/store/sequence/Append.ts
@@ -2,7 +2,7 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
 import { Validator } from '@aksio/cratis-applications-frontend/validation';
 import Handlebars from 'handlebars';
 
@@ -111,7 +111,7 @@ export class Append extends Command<IAppend> implements IAppend {
         this.propertyChanged('eventGeneration');
     }
 
-    static use(initialValues?: IAppend): [Append, SetCommandValues<IAppend>] {
+    static use(initialValues?: IAppend): [Append, SetCommandValues<IAppend>, ClearCommandValues] {
         return useCommand<Append, IAppend>(Append, initialValues);
     }
 }


### PR DESCRIPTION
### Added

- `useCommand()` now returns a third component to the tuple; `ClearCommandValues` which sets them all to undefined. The proxy generator honors this and creates a proxy that does the same. (#595)

### Fixed

- Fixing the `SetCommandValues` returned from `useCommand()` to only ignore properties that are either undefined or null. Allowing for empty strings to be set. (#596)
