### PR TITLE
Adding log messages to see why client is struggling connecting

### DIFF
--- a/Source/Clients/DotNET/Hosting/ClientBuilder.cs
+++ b/Source/Clients/DotNET/Hosting/ClientBuilder.cs
@@ -140,8 +140,9 @@ public class ClientBuilder : IClientBuilder
             var orleansClient = orleansBuilder.Build();
 
             logger?.ConnectingToKernel();
-            orleansClient.Connect(async (_) =>
+            orleansClient.Connect(async (exception) =>
             {
+                logger?.ProblemsConnectingToSilo(exception.Message);
                 await Task.Delay(1000);
                 return true;
             }).Wait();

--- a/Source/Clients/DotNET/Hosting/ClientBuilderLogMessages.cs
+++ b/Source/Clients/DotNET/Hosting/ClientBuilderLogMessages.cs
@@ -27,4 +27,7 @@ public static partial class ClientBuilderLogMessages
 
     [LoggerMessage(5, LogLevel.Information, "Connected to Kernel")]
     internal static partial void ConnectedToKernel(this ILogger logger);
+
+    [LoggerMessage(6, LogLevel.Information, "Problems connecting to Kernel : {Message}' will retry in 1 second.")]
+    internal static partial void ProblemsConnectingToSilo(this ILogger logger, string message);
 }


### PR DESCRIPTION
### Fixed

- Adding a log message to see why the cluster client is not able to connect to Cratis Kernel.
