### PR TITLE
Adding inner exception to log message when errored connect

### DIFF
--- a/Source/Clients/DotNET/Hosting/ClientBuilder.cs
+++ b/Source/Clients/DotNET/Hosting/ClientBuilder.cs
@@ -142,7 +142,7 @@ public class ClientBuilder : IClientBuilder
             logger?.ConnectingToKernel();
             orleansClient.Connect(async (exception) =>
             {
-                logger?.ProblemsConnectingToSilo(exception.Message);
+                logger?.ProblemsConnectingToSilo(exception.Message, exception.InnerException?.Message ?? "<no more details>");
                 await Task.Delay(1000);
                 return true;
             }).Wait();

--- a/Source/Clients/DotNET/Hosting/ClientBuilderLogMessages.cs
+++ b/Source/Clients/DotNET/Hosting/ClientBuilderLogMessages.cs
@@ -28,6 +28,6 @@ public static partial class ClientBuilderLogMessages
     [LoggerMessage(5, LogLevel.Information, "Connected to Kernel")]
     internal static partial void ConnectedToKernel(this ILogger logger);
 
-    [LoggerMessage(6, LogLevel.Information, "Problems connecting to Kernel : {Message}' will retry in 1 second.")]
-    internal static partial void ProblemsConnectingToSilo(this ILogger logger, string message);
+    [LoggerMessage(6, LogLevel.Information, "Problems connecting to Kernel : '{Message}' - inner message '{InnerMessage}' will retry in 1 second.")]
+    internal static partial void ProblemsConnectingToSilo(this ILogger logger, string message, string innerMessage);
 }


### PR DESCRIPTION
### Fixed

- Adding inner exception to the log message when connection failed to Kernel.
