### PR TITLE
Regenerated proxies

### DIFF
--- a/Source/Workbench/API/compliance/gdpr/pii/CreateAndRegisterKeyFor.ts
+++ b/Source/Workbench/API/compliance/gdpr/pii/CreateAndRegisterKeyFor.ts
@@ -25,6 +25,10 @@ export class CreateAndRegisterKeyFor extends Command<ICreateAndRegisterKeyFor> i
 
     private _identifier!: string;
 
+    constructor() {
+        super(Object, false);
+    }
+
     get requestArguments(): string[] {
         return [
         ];

--- a/Source/Workbench/API/compliance/gdpr/pii/DeletePIIForPerson.ts
+++ b/Source/Workbench/API/compliance/gdpr/pii/DeletePIIForPerson.ts
@@ -25,6 +25,10 @@ export class DeletePIIForPerson extends Command<IDeletePIIForPerson> implements 
 
     private _personId!: string;
 
+    constructor() {
+        super(Object, false);
+    }
+
     get requestArguments(): string[] {
         return [
         ];

--- a/Source/Workbench/API/compliance/microservices/AddMicroservice.ts
+++ b/Source/Workbench/API/compliance/microservices/AddMicroservice.ts
@@ -28,6 +28,10 @@ export class AddMicroservice extends Command<IAddMicroservice> implements IAddMi
     private _microserviceId!: string;
     private _name!: string;
 
+    constructor() {
+        super(Object, false);
+    }
+
     get requestArguments(): string[] {
         return [
         ];

--- a/Source/Workbench/API/events/store/observers/Rewind.ts
+++ b/Source/Workbench/API/events/store/observers/Rewind.ts
@@ -31,6 +31,10 @@ export class Rewind extends Command<IRewind> implements IRewind {
     private _microserviceId!: string;
     private _tenantId!: string;
 
+    constructor() {
+        super(Object, false);
+    }
+
     get requestArguments(): string[] {
         return [
             'observerId',

--- a/Source/Workbench/API/events/store/sequence/Append.ts
+++ b/Source/Workbench/API/events/store/sequence/Append.ts
@@ -40,6 +40,10 @@ export class Append extends Command<IAppend> implements IAppend {
     private _eventTypeId!: string;
     private _eventGeneration!: number;
 
+    constructor() {
+        super(Object, false);
+    }
+
     get requestArguments(): string[] {
         return [
             'eventSequenceId',


### PR DESCRIPTION
### Added

- Support for returning a response object as part of a command. POST controller actions can simply just return anything now and this will now become serialized as part of the `CommandResult` and proxy generator generates a type safe version of this with serialization information on it. (#499)

### Fixed

- Command result is now alway included, even when it is a HTTP 200. (#359)

