### PR TITLE
Stopping at the end of the array

### DIFF
--- a/Source/Fundamentals/Json/EnumerableModelWithIdToConceptOrPrimitiveEnumerableConverter.cs
+++ b/Source/Fundamentals/Json/EnumerableModelWithIdToConceptOrPrimitiveEnumerableConverter.cs
@@ -36,6 +36,11 @@ public class EnumerableModelWithIdToConceptOrPrimitiveEnumerableConverter<T, TEl
         {
             while (reader.Read())
             {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    break;
+                }
+
                 if (reader.TokenType == JsonTokenType.String)
                 {
                     var value = ReadValue(ref reader, options);


### PR DESCRIPTION
### Fixed

- JSON Converter for dealing with enumerable of objects with Id or concepts now stops at the end of the array, not trying to consume the rest of the JSON.
