### PR TITLE
Getting the actual type of the query argument

### DIFF
--- a/Samples/Banking/Bank/Main/Program.cs
+++ b/Samples/Banking/Bank/Main/Program.cs
@@ -1,7 +1,14 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
 using Sample;
+
+// Force invariant culture for the Kernel
+CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
 
 var builder = Host.CreateDefaultBuilder()
                     .UseAksio(microserviceId: "00000000-0000-0000-0000-000000000000")

--- a/Source/ApplicationModel/CQRS/Commands/CommandActionFilter.cs
+++ b/Source/ApplicationModel/CQRS/Commands/CommandActionFilter.cs
@@ -68,11 +68,15 @@ public class CommandActionFilter : IAsyncActionFilter
 
             if (!commandResult.IsAuthorized)
             {
-                context.HttpContext.Response.StatusCode = 401;   // Forbidden: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.10
+                context.HttpContext.Response.StatusCode = 401;   // Forbidden: https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized
             }
             else if (!commandResult.IsValid)
             {
-                context.HttpContext.Response.StatusCode = 409;   // Conflict: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.10
+                context.HttpContext.Response.StatusCode = 409;   // Conflict: https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict
+            }
+            else if (commandResult.HasExceptions)
+            {
+                context.HttpContext.Response.StatusCode = 500;  // Internal Server error: https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error
             }
 
             result.Result = new ObjectResult(commandResult);

--- a/Source/ApplicationModel/CQRS/Commands/CommandActionFilter.cs
+++ b/Source/ApplicationModel/CQRS/Commands/CommandActionFilter.cs
@@ -46,6 +46,7 @@ public class CommandActionFilter : IAsyncActionFilter
                 }
                 while (exception is not null);
 
+                result.Exception = null!;
                 exceptionStackTrace = exception?.StackTrace ?? string.Empty;
             }
 

--- a/Source/ApplicationModel/CQRS/Commands/CommandActionFilter.cs
+++ b/Source/ApplicationModel/CQRS/Commands/CommandActionFilter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Aksio.Cratis.Applications.Validation;
 using Aksio.Cratis.Execution;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -44,6 +45,8 @@ public class CommandActionFilter : IAsyncActionFilter
                     exception = exception.InnerException;
                 }
                 while (exception is not null);
+
+                exceptionStackTrace = exception?.StackTrace ?? string.Empty;
             }
 
             if (result.Result is ObjectResult objectResult)

--- a/Source/ApplicationModel/CQRS/Commands/CommandResult.cs
+++ b/Source/ApplicationModel/CQRS/Commands/CommandResult.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Aksio.Cratis.Applications.Validation;
 using Aksio.Cratis.Execution;
 
 namespace Aksio.Cratis.Applications.Commands;
@@ -38,12 +39,12 @@ public class CommandResult
     /// <summary>
     /// Gets any validation errors. If this collection is empty, there are errors.
     /// </summary>
-    public IEnumerable<ValidationError> ValidationErrors { get; init; } = Array.Empty<ValidationError>();
+    public IEnumerable<ValidationError> ValidationErrors { get; init; } = Enumerable.Empty<ValidationError>();
 
     /// <summary>
     /// Gets any exception messages that might have occurred.
     /// </summary>
-    public IEnumerable<string> ExceptionMessages { get; init; } = Array.Empty<string>();
+    public IEnumerable<string> ExceptionMessages { get; init; } = Enumerable.Empty<string>();
 
     /// <summary>
     /// Gets the stack trace if there was an exception.

--- a/Source/ApplicationModel/CQRS/Queries/ClientObservable.cs
+++ b/Source/ApplicationModel/CQRS/Queries/ClientObservable.cs
@@ -44,7 +44,10 @@ public class ClientObservable<T> : IClientObservable, IAsyncEnumerable<T>
         using var webSocket = await context.HttpContext.WebSockets.AcceptWebSocketAsync();
         var subscription = _subject.Subscribe(_ =>
         {
-            var queryResult = new QueryResult(_!, true);
+            var queryResult = new QueryResult
+            {
+                Data = _!
+            };
             var json = JsonSerializer.Serialize(queryResult, jsonOptions.JsonSerializerOptions);
             var message = Encoding.UTF8.GetBytes(json);
 

--- a/Source/ApplicationModel/CQRS/Queries/QueryActionFilter.cs
+++ b/Source/ApplicationModel/CQRS/Queries/QueryActionFilter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Aksio.Cratis.Applications.Validation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -37,34 +38,73 @@ public class QueryActionFilter : IAsyncActionFilter
         if (context.HttpContext.Request.Method == HttpMethod.Get.Method
             && context.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
         {
-            var result = await next();
-            if (result.Result is ObjectResult objectResult)
+            if (context.ModelState.IsValid)
             {
-                switch (objectResult.Value)
-                {
-                    case IClientObservable clientObservable:
-                        {
-                            _logger.ClientObservableReturnValue(controllerActionDescriptor.ControllerName, controllerActionDescriptor.ActionName);
-                            HandleWebSocketHeadersForMultipleProxies(context.HttpContext);
-                            if (context.HttpContext.WebSockets.IsWebSocketRequest)
-                            {
-                                _logger.RequestIsWebSocket();
-                                await clientObservable.HandleConnection(context, _options);
-                                result.Result = null;
-                            }
-                            else
-                            {
-                                _logger.RequestIsHttp();
-                            }
-                        }
-                        break;
+                var exceptionMessages = new List<string>();
+                var exceptionStackTrace = string.Empty;
+                object? response = null;
+                var result = await next();
 
-                    default:
-                        {
-                            _logger.NonClientObservableReturnValue(controllerActionDescriptor.ControllerName, controllerActionDescriptor.ActionName);
-                            result.Result = new ObjectResult(new QueryResult(objectResult.Value!, true));
-                        }
-                        break;
+                if (result.Exception is not null)
+                {
+                    var exception = result.Exception;
+
+                    do
+                    {
+                        exceptionMessages.Add(exception.Message);
+                        exception = exception.InnerException;
+                    }
+                    while (exception is not null);
+
+                    result.Exception = null!;
+                    exceptionStackTrace = exception?.StackTrace ?? string.Empty;
+                }
+
+                if (result.Result is ObjectResult objectResult)
+                {
+                    response = objectResult.Value;
+                }
+
+                if (result.Result is ObjectResult or && or?.Value is IClientObservable clientObservable)
+                {
+                    _logger.ClientObservableReturnValue(controllerActionDescriptor.ControllerName, controllerActionDescriptor.ActionName);
+                    HandleWebSocketHeadersForMultipleProxies(context.HttpContext);
+                    if (context.HttpContext.WebSockets.IsWebSocketRequest)
+                    {
+                        _logger.RequestIsWebSocket();
+                        await clientObservable.HandleConnection(context, _options);
+                        result.Result = null;
+                    }
+                    else
+                    {
+                        _logger.RequestIsHttp();
+                    }
+                }
+                else
+                {
+                    _logger.NonClientObservableReturnValue(controllerActionDescriptor.ControllerName, controllerActionDescriptor.ActionName);
+                    var queryResult = new QueryResult
+                    {
+                        ValidationErrors = context.ModelState.SelectMany(_ => _.Value!.Errors.Select(p => new ValidationError(p.ErrorMessage, new string[] { _.Key }))),
+                        ExceptionMessages = exceptionMessages.ToArray(),
+                        ExceptionStackTrace = exceptionStackTrace,
+                        Data = response!
+                    };
+
+                    if (!queryResult.IsAuthorized)
+                    {
+                        context.HttpContext.Response.StatusCode = 401;   // Forbidden: https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized
+                    }
+                    else if (!queryResult.IsValid)
+                    {
+                        context.HttpContext.Response.StatusCode = 409;   // Conflict: https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict
+                    }
+                    else if (queryResult.HasExceptions)
+                    {
+                        context.HttpContext.Response.StatusCode = 500;  // Internal Server error: https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error
+                    }
+
+                    result.Result = new ObjectResult(queryResult);
                 }
             }
         }

--- a/Source/ApplicationModel/CQRS/Queries/QueryResult.cs
+++ b/Source/ApplicationModel/CQRS/Queries/QueryResult.cs
@@ -1,11 +1,52 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Aksio.Cratis.Applications.Validation;
+
 namespace Aksio.Cratis.Applications.Queries;
 
 /// <summary>
 /// Represents the result coming from performing a query.
 /// </summary>
-/// <param name="Data">Data returned by the query.</param>
-/// <param name="IsSuccess">Whether or not everything is Ok.</param>
-public record QueryResult(object Data, bool IsSuccess);
+public class QueryResult
+{
+    /// <summary>
+    /// The data returned.
+    /// </summary>
+    public object Data { get; set; } = null!;
+
+    /// <summary>
+    /// Gets whether or not the query executed successfully.
+    /// </summary>
+    public bool IsSuccess => IsAuthorized && IsValid && !HasExceptions;
+
+    /// <summary>
+    /// Gets whether or not the query was authorized to execute.
+    /// </summary>
+    public bool IsAuthorized { get; init; } = true;
+
+    /// <summary>
+    /// Gets whether or not the query is valid.
+    /// </summary>
+    public bool IsValid => !ValidationErrors.Any();
+
+    /// <summary>
+    /// Gets whether or not there are any exceptions that occurred.
+    /// </summary>
+    public bool HasExceptions => ExceptionMessages.Any();
+
+    /// <summary>
+    /// Gets any validation errors. If this collection is empty, there are errors.
+    /// </summary>
+    public IEnumerable<ValidationError> ValidationErrors { get; init; } = Enumerable.Empty<ValidationError>();
+
+    /// <summary>
+    /// Gets any exception messages that might have occurred.
+    /// </summary>
+    public IEnumerable<string> ExceptionMessages { get; init; } = Enumerable.Empty<string>();
+
+    /// <summary>
+    /// Gets the stack trace if there was an exception.
+    /// </summary>
+    public string ExceptionStackTrace { get; init; } = string.Empty;
+}

--- a/Source/ApplicationModel/CQRS/Validation/ValidationError.cs
+++ b/Source/ApplicationModel/CQRS/Validation/ValidationError.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Aksio.Cratis.Applications.Commands;
+namespace Aksio.Cratis.Applications.Validation;
 
 /// <summary>
 /// Represents the an failed validation rule.

--- a/Source/ApplicationModel/Frontend/queries/IQueryResult.ts
+++ b/Source/ApplicationModel/Frontend/queries/IQueryResult.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ValidationError } from '../validation/ValidationError';
+
+/**
+ * Defines the result from executing a query.
+ */
+export interface IQueryResult<TDataType> {
+    /**
+     * Gets the data result from the query.
+     */
+    readonly data: TDataType;
+
+    /**
+     * Gets whether or not the query executed successfully.
+     */
+    readonly isSuccess: boolean;
+
+    /**
+     * Gets whether or not the query was authorized to execute.
+     */
+    readonly isAuthorized: boolean;
+
+    /**
+     * Gets whether or not the query is valid.
+     */
+    readonly isValid: boolean;
+
+    /**
+     * Gets whether or not there are any exceptions that occurred.
+     */
+    readonly hasExceptions: boolean;
+
+    /**
+     * Gets any validation errors. If this collection is empty, there are errors.
+     */
+    readonly validationErrors: ValidationError[];
+
+    /**
+     * Gets any exception messages that might have occurred.
+     */
+    readonly exceptionMessages: string[];
+
+    /**
+     * Gets the stack trace if there was an exception.
+     */
+    readonly exceptionStackTrace: string;
+}

--- a/Source/ApplicationModel/Frontend/queries/NullObservableQueryConnection.ts
+++ b/Source/ApplicationModel/Frontend/queries/NullObservableQueryConnection.ts
@@ -19,7 +19,7 @@ export class NullObservableQueryConnection<TDataType> implements IObservableQuer
 
     /** @inheritdoc */
     connect(dataReceived: DataReceived<TDataType>) {
-        dataReceived(new QueryResult(this.defaultValue, true));
+        dataReceived(QueryResult.empty(this.defaultValue));
     }
 
     /** @inheritdoc */

--- a/Source/ApplicationModel/Frontend/queries/QueryFor.ts
+++ b/Source/ApplicationModel/Frontend/queries/QueryFor.ts
@@ -22,7 +22,7 @@ export abstract class QueryFor<TDataType, TArguments = {}> implements IQueryFor<
      * @param modelType Type of model, if an enumerable, this is the instance type.
      * @param enumerable Whether or not it is an enumerable.
      */
-     constructor(readonly modelType: Constructor, readonly enumerable: boolean) {
+    constructor(readonly modelType: Constructor, readonly enumerable: boolean) {
     }
 
     /** @inheritdoc */
@@ -31,7 +31,7 @@ export abstract class QueryFor<TDataType, TArguments = {}> implements IQueryFor<
 
         if (!ValidateRequestArguments(this.constructor.name, this.requestArguments, args)) {
             return new Promise<QueryResult<TDataType>>((resolve) => {
-                resolve(new QueryResult(this.defaultValue, true));
+                resolve({ ...QueryResult.noSuccess, ...{ data: this.defaultValue } } as QueryResult<TDataType>);
             });
         }
 
@@ -44,6 +44,11 @@ export abstract class QueryFor<TDataType, TArguments = {}> implements IQueryFor<
             }
         });
 
-        return await QueryResult.fromResponse<TDataType>(response,this.modelType, this.enumerable);
+        try {
+            const result = await response.json();
+            return new QueryResult(result, this.modelType, this.enumerable);
+        } catch (ex) {
+            return QueryResult.noSuccess as any;
+        }
     }
 }

--- a/Source/ApplicationModel/Frontend/queries/QueryResultWithState.ts
+++ b/Source/ApplicationModel/Frontend/queries/QueryResultWithState.ts
@@ -1,21 +1,68 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { ValidationError } from '../validation/ValidationError';
+import { IQueryResult } from './IQueryResult';
 import { QueryResult } from './QueryResult';
 
 /**
  * Represents a specialized {@link QueryResult<TDataType} that holds state for its execution
  */
+export class QueryResultWithState<TDataType> implements IQueryResult<TDataType> {
 
-export class QueryResultWithState<TDataType> extends QueryResult<TDataType> {
+    static empty<TDataType>(defaultValue: TDataType): QueryResultWithState<TDataType> {
+        return new QueryResultWithState(
+            defaultValue,
+            true,
+            true,
+            true,
+            [],
+            false,
+            [],
+            '',
+            false);
+    }
 
     /**
      * Initializes an instance of {@link QueryResultWithState<TDataType>}.
      * @param {TDataType} data The items returned, if any - can be empty.
      * @param {boolean} isSuccess Whether or not the query was successful.
+     * @param {boolean} isAuthorized Whether or not the query was authorized.
+     * @param {boolean} isValid Whether or not it is valid.
+     * @param {ValidationError[]} validationErrors Any validation errors.
+     * @param {boolean} hasExceptions Whether or not it has exceptions.
+     * @param {string[]} exceptionMessages Any exception messages.
+     * @param {string} exceptionStackTrace Exception stack trace, if any.
      * @param {boolean} isPerforming Whether or not the query is being performed. True if its performing, false if it is done.
      */
-    constructor(readonly data: TDataType, readonly isSuccess: boolean, readonly isPerforming: boolean) {
-        super(data, isSuccess);
+    constructor(
+        readonly data: TDataType,
+        readonly isSuccess: boolean,
+        readonly isAuthorized: boolean,
+        readonly isValid: boolean,
+        readonly validationErrors: ValidationError[],
+        readonly hasExceptions: boolean,
+        readonly exceptionMessages: string[],
+        readonly exceptionStackTrace: string,
+        readonly isPerforming: boolean) {
+    }
+
+    /**
+     * Create a new {@link QueryResultWithState<TDataType>} from {@link QueryResult<TDataType>}.
+     * @param queryResult The original query result.
+     * @param isPerforming Whether or not the query is performing.
+     * @returns A new {@link QueryResultWithState<TDataType>}
+     */
+    static fromQueryResult<TDataType>(queryResult: QueryResult<TDataType>, isPerforming: boolean) {
+        return new QueryResultWithState<TDataType>(
+            queryResult.data,
+            queryResult.isSuccess,
+            queryResult.isAuthorized,
+            queryResult.isValid,
+            queryResult.validationErrors,
+            queryResult.hasExceptions,
+            queryResult.exceptionMessages,
+            queryResult.exceptionStackTrace,
+            isPerforming);
     }
 }

--- a/Source/ApplicationModel/Frontend/queries/useObservableQuery.ts
+++ b/Source/ApplicationModel/Frontend/queries/useObservableQuery.ts
@@ -17,13 +17,13 @@ import { QueryResult } from './QueryResult';
  */
 export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, args?: TArguments): [QueryResultWithState<TDataType>] {
     const queryInstance = new query() as TQuery;
-    const [result, setResult] = useState<QueryResultWithState<TDataType>>(new QueryResultWithState(queryInstance.defaultValue, true, true));
+    const [result, setResult] = useState<QueryResultWithState<TDataType>>(QueryResultWithState.empty(queryInstance.defaultValue));
     const argumentsDependency = queryInstance.requestArguments.map(_ => args?.[_]);
 
     useEffect(() => {
         const subscription = queryInstance.subscribe(_ => {
             const response = _ as unknown as QueryResult<TDataType>;
-            setResult(new QueryResultWithState(response.data, response.isSuccess, false));
+            setResult(QueryResultWithState.fromQueryResult(response, false));
         }, args as any);
 
         return () => subscription.unsubscribe();

--- a/Source/ApplicationModel/Frontend/queries/useQuery.ts
+++ b/Source/ApplicationModel/Frontend/queries/useQuery.ts
@@ -22,10 +22,10 @@ export type PerformQuery<TArguments = {}> = (args?: TArguments) => Promise<void>
  */
 export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, args?: TArguments): [QueryResultWithState<TDataType>, PerformQuery<TArguments>] {
     const queryInstance = new query() as TQuery;
-    const [result, setResult] = useState<QueryResultWithState<TDataType>>(new QueryResultWithState(queryInstance.defaultValue, true, true));
+    const [result, setResult] = useState<QueryResultWithState<TDataType>>(QueryResultWithState.empty(queryInstance.defaultValue));
     const queryExecutor = (async (args?: TArguments) => {
-        const response = await queryInstance.perform(args as any);
-        setResult(new QueryResultWithState(response.data, response.isSuccess, false));
+        const queryResult = await queryInstance.perform(args as any);
+        setResult(QueryResultWithState.fromQueryResult(queryResult, false));
     });
 
     useEffect(() => {
@@ -33,7 +33,8 @@ export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArgume
     }, []);
 
     return [result, async (args?: TArguments) => {
-        setResult(new QueryResultWithState(result.data, result.isSuccess, true));
+        const queryResult = await queryInstance.perform(args as any);
+        setResult(QueryResultWithState.fromQueryResult(queryResult, true));
         await queryExecutor(args);
     }];
 }

--- a/Source/ApplicationModel/Tooling/ProxyGenerator/Templates/Query.hbs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/Templates/Query.hbs
@@ -14,9 +14,9 @@ const routeTemplate = Handlebars.compile('{{{Route}}}');
 export interface {{Name}}Arguments {
     {{#Arguments}}
     {{#if IsOptional}}
-    {{camelcase Name}}?: string;
+    {{camelcase Name}}?: {{Type}};
     {{else}}
-    {{camelcase Name}}: string;
+    {{camelcase Name}}: {{Type}};
     {{/if}}
     {{/Arguments}}
 }


### PR DESCRIPTION
### Fixed

- Honoring the actual type of the query argument when generating proxies. (#636)
- Forcing invariant culture for Kernel. (#611)
- Returning proper query result structure with all details which then automatically fixed #637
- Returning correct command result even if exceptions happen in controller action.
- Making member names camel cased in validation result. (#593)
