### PR TITLE
Fixing query results to have the hasData

### DIFF
--- a/Source/ApplicationModel/CQRS/Commands/CommandActionFilter.cs
+++ b/Source/ApplicationModel/CQRS/Commands/CommandActionFilter.cs
@@ -41,6 +41,7 @@ public class CommandActionFilter : IAsyncActionFilter
                 if (result.Exception is not null)
                 {
                     var exception = result.Exception;
+                    exceptionStackTrace = exception.StackTrace;
 
                     do
                     {
@@ -50,7 +51,6 @@ public class CommandActionFilter : IAsyncActionFilter
                     while (exception is not null);
 
                     result.Exception = null!;
-                    exceptionStackTrace = exception?.StackTrace ?? string.Empty;
                 }
 
                 if (result.Result is ObjectResult objectResult)
@@ -64,7 +64,7 @@ public class CommandActionFilter : IAsyncActionFilter
                 CorrelationId = _executionContextManager.Current.CorrelationId,
                 ValidationErrors = context.ModelState.SelectMany(_ => _.Value!.Errors.Select(p => new ValidationError(p.ErrorMessage, new string[] { _.Key.ToCamelCase() }))),
                 ExceptionMessages = exceptionMessages.ToArray(),
-                ExceptionStackTrace = exceptionStackTrace,
+                ExceptionStackTrace = exceptionStackTrace ?? string.Empty,
                 Response = response
             };
 

--- a/Source/ApplicationModel/CQRS/Queries/QueryActionFilter.cs
+++ b/Source/ApplicationModel/CQRS/Queries/QueryActionFilter.cs
@@ -51,6 +51,7 @@ public class QueryActionFilter : IAsyncActionFilter
                 if (result.Exception is not null)
                 {
                     var exception = result.Exception;
+                    exceptionStackTrace = exception.StackTrace;
 
                     do
                     {
@@ -60,7 +61,6 @@ public class QueryActionFilter : IAsyncActionFilter
                     while (exception is not null);
 
                     result.Exception = null!;
-                    exceptionStackTrace = exception?.StackTrace ?? string.Empty;
                 }
 
                 if (result.Result is ObjectResult objectResult)
@@ -69,7 +69,7 @@ public class QueryActionFilter : IAsyncActionFilter
                 }
             }
 
-            if (result?.Result is ObjectResult or && or?.Value is IClientObservable clientObservable)
+            if (result?.Result is ObjectResult or && or.Value is IClientObservable clientObservable)
             {
                 _logger.ClientObservableReturnValue(controllerActionDescriptor.ControllerName, controllerActionDescriptor.ActionName);
                 HandleWebSocketHeadersForMultipleProxies(context.HttpContext);
@@ -91,7 +91,7 @@ public class QueryActionFilter : IAsyncActionFilter
                 {
                     ValidationErrors = context.ModelState.SelectMany(_ => _.Value!.Errors.Select(p => new ValidationError(p.ErrorMessage, new string[] { _.Key.ToCamelCase() }))),
                     ExceptionMessages = exceptionMessages.ToArray(),
-                    ExceptionStackTrace = exceptionStackTrace,
+                    ExceptionStackTrace = exceptionStackTrace ?? string.Empty,
                     Data = response!
                 };
 

--- a/Source/ApplicationModel/Frontend/queries/IQueryResult.ts
+++ b/Source/ApplicationModel/Frontend/queries/IQueryResult.ts
@@ -46,4 +46,9 @@ export interface IQueryResult<TDataType> {
      * Gets the stack trace if there was an exception.
      */
     readonly exceptionStackTrace: string;
+
+    /**
+     * Gets whether or not the query has data.
+     */
+    readonly hasData: boolean;
 }

--- a/Source/ApplicationModel/Frontend/queries/QueryResultWithState.ts
+++ b/Source/ApplicationModel/Frontend/queries/QueryResultWithState.ts
@@ -47,6 +47,22 @@ export class QueryResultWithState<TDataType> implements IQueryResult<TDataType> 
         readonly isPerforming: boolean) {
     }
 
+    /** @inheritdoc */
+    get hasData(): boolean {
+        const data = this.data as any;
+        if (data) {
+            if (data.constructor && data.constructor === Array) {
+                if (data.length || 0 > 0) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Create a new {@link QueryResultWithState<TDataType>} from {@link QueryResult<TDataType>}.
      * @param queryResult The original query result.

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Main/Program.cs
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Main/Program.cs
@@ -1,7 +1,14 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
 using Sample;
+
+// Force invariant culture for the Kernel
+CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
 
 var builder = Host.CreateDefaultBuilder()
                     .UseAksio(microserviceId: "00000000-0000-0000-0000-000000000000")

--- a/Source/Kernel/Server/Program.cs
+++ b/Source/Kernel/Server/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
 using Aksio.Cratis.Execution;
 using Orleans;
 using Orleans.Hosting;
@@ -14,6 +15,12 @@ public static class Program
     public static Task Main(string[] args)
     {
         AppDomain.CurrentDomain.UnhandledException += UnhandledExceptions;
+
+        // Force invariant culture for the Kernel
+        CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
 
         return CreateHostBuilder(args).RunConsoleAsync();
     }


### PR DESCRIPTION
### Fixed

- Honoring the actual type of the query argument when generating proxies. (#636)
- Forcing invariant culture for Kernel. (#611)
- Returning proper query result structure with all details which then automatically fixed #637
- Returning correct command result even if exceptions happen in controller action.
- Making member names camel cased in validation result. (#593)
