### PR TITLE
Fix/bugs

### DIFF
--- a/Source/ApplicationModel/Frontend/queries/ObservableQueryFor.ts
+++ b/Source/ApplicationModel/Frontend/queries/ObservableQueryFor.ts
@@ -44,12 +44,18 @@ export abstract class ObservableQueryFor<TDataType, TArguments = {}> implements 
         const subscriber = new ObservableQuerySubscription(connection);
         connection.connect(data => {
             const result: any = data;
-            if( this.enumerable) {
-                result.data = JsonSerializer.deserializeArrayFromInstance(this.modelType, result.data);
-            } else {
-                result.data = JsonSerializer.deserializeFromInstance(this.modelType, result.data);
+            try {
+                if (this.enumerable) {
+                    if (Array.isArray(result.data)) {
+                        result.data = JsonSerializer.deserializeArrayFromInstance(this.modelType, result.data);
+                    }
+                } else {
+                    result.data = JsonSerializer.deserializeFromInstance(this.modelType, result.data);
+                }
+                callback(result);
+            } catch (ex) {
+                console.log(ex);
             }
-            callback(result);
         });
         return subscriber;
     }

--- a/Source/Kernel/Store/Shared/EventSequences/EventSequenceQueueCacheCursor.cs
+++ b/Source/Kernel/Store/Shared/EventSequences/EventSequenceQueueCacheCursor.cs
@@ -12,11 +12,17 @@ namespace Aksio.Cratis.Events.Store.EventSequences;
 /// </summary>
 public class EventSequenceQueueCacheCursor : IQueueCacheCursor
 {
-    readonly IExecutionContextManager _executionContextManager;
-    readonly IStreamIdentity _streamIdentity;
+#pragma warning disable SA1202, CA1051
+    /// <summary>
+    /// Gets the <see cref="IEventSequenceStorageProvider"/>.
+    /// </summary>
     protected readonly IEventSequenceStorageProvider _storageProvider;
-    IEventCursor _actualCursor;
+    readonly IExecutionContextManager _executionContextManager;
+    readonly EventSequenceNumber _cursorStart;
+    readonly IStreamIdentity _streamIdentity;
+    IEventCursor? _actualCursor;
     EventSequenceNumber _lastProvidedSequenceNumber = EventSequenceNumber.First;
+    bool _firstRun;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EventSequenceQueueCacheCursor"/> class.
@@ -32,9 +38,10 @@ public class EventSequenceQueueCacheCursor : IQueueCacheCursor
         IEventSequenceStorageProvider storageProvider)
     {
         _executionContextManager = executionContextManager;
+        _cursorStart = cursorStart;
         _streamIdentity = streamIdentity;
         _storageProvider = storageProvider;
-        _actualCursor = GetActualEventCursor(_streamIdentity.Guid, cursorStart).GetAwaiter().GetResult();
+        _firstRun = true;
     }
 
     /// <inheritdoc/>
@@ -69,7 +76,11 @@ public class EventSequenceQueueCacheCursor : IQueueCacheCursor
     }
 
     /// <inheritdoc/>
-    public bool MoveNext() => _actualCursor.MoveNext().GetAwaiter().GetResult();
+    public bool MoveNext()
+    {
+        InitializeCursorOnFirstRun();
+        return _actualCursor?.MoveNext().GetAwaiter().GetResult() ?? false;
+    }
 
     /// <inheritdoc/>
     public void RecordDeliveryFailure()
@@ -82,22 +93,32 @@ public class EventSequenceQueueCacheCursor : IQueueCacheCursor
         var microserviceAndTenant = (MicroserviceAndTenant)_streamIdentity.Namespace;
         _executionContextManager.Establish(microserviceAndTenant.TenantId, CorrelationId.New(), microserviceAndTenant.MicroserviceId);
 
-        _actualCursor.Dispose();
+        _actualCursor?.Dispose();
         _actualCursor = GetActualEventCursor(_streamIdentity.Guid, (ulong)_lastProvidedSequenceNumber).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
     public void Dispose()
     {
-        _actualCursor.Dispose();
+        _actualCursor?.Dispose();
         _actualCursor = null!;
+    }
+
+    void InitializeCursorOnFirstRun()
+    {
+        if (_firstRun)
+        {
+            _actualCursor = GetActualEventCursor(_streamIdentity.Guid, _cursorStart).GetAwaiter().GetResult();
+            _firstRun = false;
+        }
     }
 
     /// <summary>
     /// Get the actual event cursor.
     /// </summary>
     /// <param name="sequenceId">The event sequence to get for.</param>
-    /// <param name="sequenceNumber">The start </param>
+    /// <param name="sequenceNumber">The start sequence number.</param>
     /// <returns>Actual event cursor.</returns>
-    protected virtual Task<IEventCursor> GetActualEventCursor(EventSequenceId sequenceId, EventSequenceNumber sequenceNumber) => null!;
+    protected virtual Task<IEventCursor> GetActualEventCursor(EventSequenceId sequenceId, EventSequenceNumber sequenceNumber) =>
+        _storageProvider.GetFromSequenceNumber(sequenceId, sequenceNumber);
 }

--- a/Source/Kernel/Store/Shared/EventSequences/EventSequenceQueueCacheCursorForEventTypes.cs
+++ b/Source/Kernel/Store/Shared/EventSequences/EventSequenceQueueCacheCursorForEventTypes.cs
@@ -32,5 +32,6 @@ public class EventSequenceQueueCacheCursorForEventTypes : EventSequenceQueueCach
     }
 
     /// <inheritdoc/>
-    protected override IEnumerable<AppendedEvent> Filter(IEnumerable<AppendedEvent> events) => events.Where(_ => _eventTypes.Any(et => et.Id == _.Metadata.Type.Id)).ToArray();
+    protected override Task<IEventCursor> GetActualEventCursor(EventSequenceId sequenceId, EventSequenceNumber sequenceNumber) =>
+        _storageProvider.GetFromSequenceNumber(sequenceId, sequenceNumber, eventTypes: _eventTypes);
 }


### PR DESCRIPTION
### Fixed

- Cache cursor was not using correct event store API and was relying on in-memory filtering and a faulty next logic for the cursor.
- Client deserialization of arrays in `ObservableQueryFor` will now not try to deserialize if the data coming back is not an array.
