### PR TITLE
Only consider undefined and null values as not set - allow 0 or false

### DIFF
--- a/Samples/Banking/Bank/Web/Home.tsx
+++ b/Samples/Banking/Bank/Web/Home.tsx
@@ -6,10 +6,10 @@ import { default as styles } from './Home.module.scss';
 
 export const Home = () => {
     return (
-        <div style={{margin: '1rem'}} className={styles.home}>
+        <div style={{ margin: '1rem' }} className={styles.home}>
             <h1>Congratulations on your new microservice! 🍾 🎂 </h1>
-            This microservice comes with a default Aksio setup.<br/>
-            <br/>
+            This microservice comes with a default Aksio setup.<br />
+            <br />
             <h2>Projects</h2>
             <ul>
                 <li>Concepts - used for holding reusable domain concepts.</li>


### PR DESCRIPTION
### Fixed

- Fixing queries not to execute twice when explicitly executing them via the React hook. (#644)
- Fixing so that we allow arguments in queries that hold 0 for number or false for booleans. (#645)
