### PR TITLE
Setting isPerforming = true as initial state for queries when using the react hooks

### DIFF
--- a/Source/ApplicationModel/Frontend/queries/QueryResultWithState.ts
+++ b/Source/ApplicationModel/Frontend/queries/QueryResultWithState.ts
@@ -23,6 +23,19 @@ export class QueryResultWithState<TDataType> implements IQueryResult<TDataType> 
             false);
     }
 
+    static initial<TDataType>(defaultValue: TDataType): QueryResultWithState<TDataType> {
+        return new QueryResultWithState(
+            defaultValue,
+            true,
+            true,
+            true,
+            [],
+            false,
+            [],
+            '',
+            true);
+    }
+
     /**
      * Initializes an instance of {@link QueryResultWithState<TDataType>}.
      * @param {TDataType} data The items returned, if any - can be empty.

--- a/Source/ApplicationModel/Frontend/queries/useQuery.ts
+++ b/Source/ApplicationModel/Frontend/queries/useQuery.ts
@@ -22,7 +22,7 @@ export type PerformQuery<TArguments = {}> = (args?: TArguments) => Promise<void>
  */
 export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, args?: TArguments): [QueryResultWithState<TDataType>, PerformQuery<TArguments>] {
     const queryInstance = new query() as TQuery;
-    const [result, setResult] = useState<QueryResultWithState<TDataType>>(QueryResultWithState.empty(queryInstance.defaultValue));
+    const [result, setResult] = useState<QueryResultWithState<TDataType>>(QueryResultWithState.initial(queryInstance.defaultValue));
     const queryExecutor = (async (args?: TArguments) => {
         const queryResult = await queryInstance.perform(args as any);
         setResult(QueryResultWithState.fromQueryResult(queryResult, false));


### PR DESCRIPTION
### Fixed

- Setting `isPerforming` on query result when using React hook for queries to `true` for the initial state.
