### PR TITLE
Changing the return object of the IProvideIdentityDetails

### DIFF
--- a/Documentation/application-model/identity.md
+++ b/Documentation/application-model/identity.md
@@ -8,13 +8,16 @@ provide the details on the request going in. Having it on the ingress level lets
 
 The values provided by the provider are values that are typically application specific and goes beyond what is already found in the token representing the user.
 This is optimized for working with Microsoft Azure well known HTTP headers passed on by the different app services, such as Azure ContainerApps or WebApps.
-The following headers are required for it to be able to resolve:
+Internally, it is based on the following HTTP headers to be present.
 
 | Header | Description |
 | ------ | ----------- |
 | x-ms-client-principal | The token holding all the details, base64 encoded JWT token |
 | x-ms-client-principal-id | The unique identifier from the identity provider for the identity |
 | x-ms-client-principal-name | The name of the identity, typically resolved from claims within the token |
+
+The system in the application model leverages these header values and encapsulates it into what is called a `IdentityProviderContext` to make it more clear
+and you as an implementor of this don't have to deal with parsing the JWT tokens.
 
 To support the identity details, one of your microservices in your application can implement the `IProvideIdentityDetails` interface
 found in the `Aksio.Cratis.ApplicationModel.Identity` namespace.
@@ -26,13 +29,29 @@ Below is an example of an implementation:
 ```csharp
 public class IdentityDetailsProvider : IProvideIdentityDetails
 {
-    public Task<object> Provide(IdentityProviderContext context)
+    public Task<IdentityDetails> Provide(IdentityProviderContext context)
     {
-        object result = new { Hello = "World" };
+        var result = new IdentityDetails(true, new { Hello = "World" });
         return Task.FromResult(result);
     }
 }
 ```
+
+The `IdentityProviderContext` holds the following properties:
+
+| Property | Description |
+| -------- | ----------- |
+| Id | The identity identifier specific from from the identity provider |
+| Name | The name of the identity |
+| Token | Parsed JWT token represented as a `JsonObject`|
+| Claims | Collection of `KeyValuePair<string, string>` of the claims found in the token |
+
+The code then returns an `IdentityDetails` which holds the following properties:
+
+| Property | Description |
+| -------- | ----------- |
+| IsUserAuthorized | Whether or not the user is authorized into your application or not |
+| Details | The actual details in the form of an object, letting you create your own structure |
 
 > Note: Dependency inversion works for this, so your provider can take any dependencies it wants on its constructor.
 

--- a/Documentation/application-model/identity.md
+++ b/Documentation/application-model/identity.md
@@ -53,6 +53,8 @@ The code then returns an `IdentityDetails` which holds the following properties:
 | IsUserAuthorized | Whether or not the user is authorized into your application or not |
 | Details | The actual details in the form of an object, letting you create your own structure |
 
+If the `IsUserAuthorized` property is set to false the return from this will be an HTTP 403. While if it is authorized, a regular HTTP 200.
+
 > Note: Dependency inversion works for this, so your provider can take any dependencies it wants on its constructor.
 
 Your provider will be exposed on a well known route: `/.aksio/me`.

--- a/Source/ApplicationModel/Applications/Identity/IProvideIdentityDetails.cs
+++ b/Source/ApplicationModel/Applications/Identity/IProvideIdentityDetails.cs
@@ -16,5 +16,5 @@ public interface IProvideIdentityDetails
     /// <remarks>
     /// The result of this will end up being serialized as JSON.
     /// </remarks>
-    Task<object> Provide(IdentityProviderContext context);
+    Task<IdentityDetails> Provide(IdentityProviderContext context);
 }

--- a/Source/ApplicationModel/Applications/Identity/IdentityDetails.cs
+++ b/Source/ApplicationModel/Applications/Identity/IdentityDetails.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Applications.Identity;
+
+/// <summary>
+/// Represents the identity details returned by <see cref="IProvideIdentityDetails"/>.
+/// </summary>
+/// <param name="IsUserAuthorized">Whether or not the user is authorized.</param>
+/// <param name="Details">The actual details.</param>
+public record IdentityDetails(bool IsUserAuthorized, object Details);

--- a/Source/ApplicationModel/Applications/Identity/IdentityProviderEndpointExtensions.cs
+++ b/Source/ApplicationModel/Applications/Identity/IdentityProviderEndpointExtensions.cs
@@ -67,8 +67,16 @@ public static class IdentityProviderEndpointExtensions
 
                         var context = new IdentityProviderContext(identityId, identityName, tokenAsJson, claims);
                         var result = await provider.Provide(context);
-                        response.StatusCode = 200;
-                        await response.WriteAsJsonAsync<object>(result, serializerOptions);
+
+                        if (result.IsUserAuthorized)
+                        {
+                            response.StatusCode = 200;
+                        }
+                        else
+                        {
+                            response.StatusCode = 403;
+                        }
+                        await response.WriteAsJsonAsync(result.Details, serializerOptions);
                     }
                 }
             });

--- a/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/Home.tsx
+++ b/Source/ApplicationModel/Tooling/Templates/templates/aspnet/Web/Home.tsx
@@ -6,10 +6,10 @@ import { default as styles } from './Home.module.scss';
 
 export const Home = () => {
     return (
-        <div style={{margin: '1rem'}} className={styles.home}>
+        <div style={{ margin: '1rem' }} className={styles.home}>
             <h1>Congratulations on your new microservice! 🍾 🎂 </h1>
-            This microservice comes with a default Aksio setup.<br/>
-            <br/>
+            This microservice comes with a default Aksio setup.<br />
+            <br />
             <h2>Projects</h2>
             <ul>
                 <li>Concepts - used for holding reusable domain concepts.</li>


### PR DESCRIPTION
## Summary

Normally this would be a major release, but an oversight in designing the API for getting the identity details caused us to miss the fact that we need to know if the user actually is authorized. Since this is actually needed for the flow to work, we decided to not bump the major.

### Changed

- `IProvideIdentityDetails` is changed to return a structure that holds a property for the actual details and then a property for whether or not the user is authorized.