### PR TITLE
Adding NuGet readme

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,7 @@
         <Copyright>Copyright Aksio Insurtech</Copyright>
         <Authors>all contributors</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/aksio-insurtech/Cratis</RepositoryUrl>
         <PackageProjectUrl>https://github.com/aksio-insurtech/Cratis</PackageProjectUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -18,5 +19,9 @@
     <ItemGroup>
         <PackageReference Include="Aksio.Defaults" Version="$(AksioDefaults)" PrivateAssets="All" Condition="'$(PublishReadyToRun)' != 'true'" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="$(MSBuildThisFileDirectory)/README.md" Pack="true" PackagePath="/"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Fixed

- Adding root `README.md` file to the NuGet packages produced.
