### PR TITLE
Fix/tenant-config

### DIFF
--- a/Documentation/clients/dotnet/tenants/tenants.md
+++ b/Documentation/clients/dotnet/tenants/tenants.md
@@ -73,3 +73,79 @@ public class MyController : Controller
     }
 }
 ```
+
+## Configuration values
+
+For each tenant, you can associate configuration values. These are stored as simple key / value pairs for every tenant
+within the Kernel.
+
+You can retrieve values by using the `ITenantConfiguration` interface and the `GetAllFor()` method to get all the
+key / value pairs for a specific tenant:
+
+```csharp
+using Aksio.Cratis.Execution;
+using Aksio.Cratis.Tenants;
+
+[Route("/api/my-controller")]
+public class MyController : Controller
+{
+    readonly ITenants _tenants;
+    readonly ITenantConfiguration _tenantConfiguration,
+    readonly IExecutionContextManager _executionContextManager;
+
+    public MyController(
+        ITenants tenants,
+        ITenantConfiguration tenantConfiguration,
+        IExecutionContextManager executionContextManager)
+    {
+        _tenants = tenants;
+        _tenantConfiguration = tenantConfiguration;
+        _executionContextManager = executionContextManager;
+    }
+
+    [HttpPost]
+    public async Task PerformSomethingInContextOfEveryTenant()
+    {
+        foreach (var tenant in await _tenants.All())
+        {
+            using var scope = _executionContextManager.ForTenant(tenant);
+            var configuration = _tenantConfiguration.GetAllFor(scope.TenantId);
+            // Do something in the context of the tenant.
+        }
+    }
+}
+```
+
+The configuration is encapsulated in a type called `ConfigurationForTenant` which implements a `IDictionary<string, string>`.
+This allows you to then access the values directly.
+
+To set a value you can use the Kernel API with the route '/api/configuration/tenants/{tenantId}'.
+Below is a sample using **curl** to set a key/value pair running locally:
+
+```shell
+curl -X POST http://localhost:8080/api/configuration/tenants/3352d47d-c154-4457-b3fb-8a2efb725113 \
+     -H 'Content-Type: application/json' \
+     -d '{"key":"Hello","value":"world"}'
+```
+
+For local development and working with a team it can be cumbersome to have startup scripts that needs to run to set
+default configuration values. The `cratis.json` file supports holding these key / value pairs as well, which means you
+can check in your configuration for development purposes.
+
+In the tenant object you can add a `configuration` object holding key / value pairs:
+
+```json
+{
+    "tenants": {
+        "3352d47d-c154-4457-b3fb-8a2efb725113": {
+            "name": "development",
+            "configuration": {
+                "something": "43"
+            }
+        }
+    }
+}
+```
+
+> Note: Any key/value pairs in the `cratis.json` has precedence over anything configured in the Kernel using the API.
+> At startup the Kernel will take values in `cratis.json` and import these into the Kernel.

--- a/Source/Clients/DotNET/Tenants/ConfigurationForTenant.cs
+++ b/Source/Clients/DotNET/Tenants/ConfigurationForTenant.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Tenants;
+
+/// <summary>
+/// Represents all configuration key/values for a tenant.
+/// </summary>
+public class ConfigurationForTenant : Dictionary<string, string>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationForTenant"/> class.
+    /// </summary>
+    /// <param name="dictionary">Dictionary to initialize it from.</param>
+    public ConfigurationForTenant(IDictionary<string, string> dictionary) : base(dictionary)
+    {
+    }
+}

--- a/Source/Clients/DotNET/Tenants/ITenantConfiguration.cs
+++ b/Source/Clients/DotNET/Tenants/ITenantConfiguration.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Execution;
+
+namespace Aksio.Cratis.Tenants;
+
+/// <summary>
+/// Defines a system for working with configuration for tenants.
+/// </summary>
+public interface ITenantConfiguration
+{
+    /// <summary>
+    /// Get <see cref="ConfigurationForTenant"/> for a specific tenant.
+    /// </summary>
+    /// <param name="tenantId"><see cref="TenantId"/> to get for.</param>
+    /// <returns>The configuration for the tenant.</returns>
+    Task<ConfigurationForTenant> GetAllFor(TenantId tenantId);
+}

--- a/Source/Clients/DotNET/Tenants/TenantConfiguration.cs
+++ b/Source/Clients/DotNET/Tenants/TenantConfiguration.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Execution;
+using Orleans;
+
+namespace Aksio.Cratis.Tenants;
+
+/// <summary>
+/// Represents an implementation of <see cref="ITenantConfiguration"/>.
+/// </summary>
+public class TenantConfiguration : ITenantConfiguration
+{
+    readonly IClusterClient _clusterClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TenantConfiguration"/> class.
+    /// </summary>
+    /// <param name="clusterClient">The Orleans <see cref="IClusterClient"/>.</param>
+    public TenantConfiguration(IClusterClient clusterClient)
+    {
+        _clusterClient = clusterClient;
+    }
+
+    /// <inheritdoc/>
+    public async Task<ConfigurationForTenant> GetAllFor(TenantId tenantId)
+    {
+        var grain = _clusterClient.GetGrain<Configuration.Grains.Tenants.ITenantConfiguration>(tenantId);
+        var config = await grain.All();
+        return new(config);
+    }
+}

--- a/Source/Kernel/Configuration/Api/Tenants/TenantConfiguration.cs
+++ b/Source/Kernel/Configuration/Api/Tenants/TenantConfiguration.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Configuration.Grains.Tenants;
+using Aksio.Cratis.Execution;
+using Microsoft.AspNetCore.Mvc;
+using Orleans;
+
+namespace Aksio.Cratis.Configuration.Api.Tenants;
+
+/// <summary>
+/// Represents the API for working with configuration related to specific tenants.
+/// </summary>
+[Route("/api/configuration/tenants/{tenantId}")]
+public class TenantConfiguration : Controller
+{
+    readonly IClusterClient _clusterClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TenantConfiguration"/> class.
+    /// </summary>
+    /// <param name="clusterClient">Orleans <see cref="IClusterClient"/>.</param>
+    public TenantConfiguration(IClusterClient clusterClient)
+    {
+        _clusterClient = clusterClient;
+    }
+
+    /// <summary>
+    /// Returns all the configuration key/value pairs associated with a specific tenant.
+    /// </summary>
+    /// <param name="tenantId"><see cref="TenantId"/> for the tenant to get for.</param>
+    /// <returns><see cref="IDictionary{TKey, TValue}"/> with all the key/value pairs.</returns>
+    [HttpGet]
+    public async Task<IDictionary<string, string>> AllConfigurationValuesForTenant([FromRoute] TenantId tenantId)
+    {
+        var tenantConfiguration = _clusterClient.GetGrain<ITenantConfiguration>(tenantId);
+        return await tenantConfiguration.All();
+    }
+
+    /// <summary>
+    /// Set a key/value pair configuration for a specific tenant.
+    /// </summary>
+    /// <param name="tenantId"><see cref="TenantId"/> for the tenant to set for.</param>
+    /// <param name="keyValuePair">The key value pair to set.</param>
+    /// <returns>Awaitable task.</returns>
+    [HttpPost]
+    public async Task SetConfigurationValueForTenant(
+        [FromRoute] TenantId tenantId,
+        [FromBody] KeyValuePair<string, string> keyValuePair)
+    {
+        var tenantConfiguration = _clusterClient.GetGrain<ITenantConfiguration>(tenantId);
+        await tenantConfiguration.Set(keyValuePair.Key, keyValuePair.Value);
+    }
+}

--- a/Source/Kernel/Configuration/Grains.Interfaces/Tenants/ITenantConfiguration.cs
+++ b/Source/Kernel/Configuration/Grains.Interfaces/Tenants/ITenantConfiguration.cs
@@ -19,6 +19,13 @@ public interface ITenantConfiguration : IGrainWithGuidKey
     Task Set(string key, string value);
 
     /// <summary>
+    /// Set a collection of configuration key / value pairs.
+    /// </summary>
+    /// <param name="collection">Dictionary with key/value pairs.</param>
+    /// <returns>Awaitable task.</returns>
+    Task Set(IDictionary<string, string> collection);
+
+    /// <summary>
     /// Gets all the configuration for the tenant.
     /// </summary>
     /// <returns><see cref="TenantConfigurationState"/>.</returns>

--- a/Source/Kernel/Configuration/Grains.Interfaces/Tenants/ITenantConfiguration.cs
+++ b/Source/Kernel/Configuration/Grains.Interfaces/Tenants/ITenantConfiguration.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Orleans;
+
+namespace Aksio.Cratis.Configuration.Grains.Tenants;
+
+/// <summary>
+/// Defines a system for working with configuration for a specific tenant.
+/// </summary>
+public interface ITenantConfiguration : IGrainWithGuidKey
+{
+    /// <summary>
+    /// Set a configuration key / value pair.
+    /// </summary>
+    /// <param name="key">Key to set.</param>
+    /// <param name="value">Value to set.</param>
+    /// <returns>Awaitable task.</returns>
+    Task Set(string key, string value);
+
+    /// <summary>
+    /// Gets all the configuration for the tenant.
+    /// </summary>
+    /// <returns><see cref="TenantConfigurationState"/>.</returns>
+    Task<TenantConfigurationState> All();
+}

--- a/Source/Kernel/Configuration/Grains/Tenants/BootProcedure.cs
+++ b/Source/Kernel/Configuration/Grains/Tenants/BootProcedure.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Boot;
+using Orleans;
+
+namespace Aksio.Cratis.Configuration.Grains.Tenants;
+
+/// <summary>
+/// Represents a <see cref="IPerformBootProcedure"/> for tenant configuration.
+/// </summary>
+public class BootProcedure : IPerformBootProcedure
+{
+    readonly IGrainFactory _grainFactory;
+    readonly KernelConfiguration _configuration;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BootProcedure"/> class.
+    /// </summary>
+    /// <param name="grainFactory"><see cref="IGrainFactory"/> for getting grains.</param>
+    /// <param name="configuration">The <see cref="KernelConfiguration"/>.</param>
+    public BootProcedure(
+        IGrainFactory grainFactory,
+        KernelConfiguration configuration)
+    {
+        _grainFactory = grainFactory;
+        _configuration = configuration;
+    }
+
+    public void Perform()
+    {
+        foreach (var (tenantId, tenant) in _configuration.Tenants)
+        {
+            var tenantConfiguration = _grainFactory.GetGrain<ITenantConfiguration>(Guid.Parse(tenantId));
+            tenantConfiguration.Set(tenant.Configuration).Wait();
+        }
+    }
+}

--- a/Source/Kernel/Configuration/Grains/Tenants/BootProcedure.cs
+++ b/Source/Kernel/Configuration/Grains/Tenants/BootProcedure.cs
@@ -27,6 +27,7 @@ public class BootProcedure : IPerformBootProcedure
         _configuration = configuration;
     }
 
+    /// <inheritdoc/>
     public void Perform()
     {
         foreach (var (tenantId, tenant) in _configuration.Tenants)

--- a/Source/Kernel/Configuration/Grains/Tenants/TenantConfiguration.cs
+++ b/Source/Kernel/Configuration/Grains/Tenants/TenantConfiguration.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Orleans;
+using Orleans.Providers;
+
+namespace Aksio.Cratis.Configuration.Grains.Tenants;
+
+/// <summary>
+/// Represents an implementation of <see cref="ITenantConfiguration"/>.
+/// </summary>
+[StorageProvider(ProviderName = TenantConfigurationState.StorageProvider)]
+public class TenantConfiguration : Grain<TenantConfigurationState>, ITenantConfiguration
+{
+    /// <inheritdoc/>
+    public async Task Set(string key, string value)
+    {
+        State[key] = value;
+        await WriteStateAsync();
+    }
+
+    /// <inheritdoc/>
+    public Task<TenantConfigurationState> All() => Task.FromResult(State);
+}

--- a/Source/Kernel/Configuration/Grains/Tenants/TenantConfiguration.cs
+++ b/Source/Kernel/Configuration/Grains/Tenants/TenantConfiguration.cs
@@ -20,5 +20,15 @@ public class TenantConfiguration : Grain<TenantConfigurationState>, ITenantConfi
     }
 
     /// <inheritdoc/>
+    public async Task Set(IDictionary<string, string> collection)
+    {
+        foreach (var (key, value) in collection)
+        {
+            State[key] = value;
+        }
+        await WriteStateAsync();
+    }
+
+    /// <inheritdoc/>
     public Task<TenantConfigurationState> All() => Task.FromResult(State);
 }

--- a/Source/Kernel/Configuration/Shared/Tenant.cs
+++ b/Source/Kernel/Configuration/Shared/Tenant.cs
@@ -16,5 +16,5 @@ public class Tenant
     /// <summary>
     /// Gets the configuration key/value pairs associated with the tenant.
     /// </summary>
-    public Dictionary<string, string> Configuration { get; init; } = new();
+    public IDictionary<string, string> Configuration { get; init; } = new Dictionary<string, string>();
 }

--- a/Source/Kernel/Configuration/Shared/Tenant.cs
+++ b/Source/Kernel/Configuration/Shared/Tenant.cs
@@ -12,4 +12,9 @@ public class Tenant
     /// Gets the name of the tenant.
     /// </summary>
     public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the configuration key/value pairs associated with the tenant.
+    /// </summary>
+    public Dictionary<string, string> Configuration { get; init; } = new();
 }

--- a/Source/Kernel/Configuration/Shared/TenantConfigurationState.cs
+++ b/Source/Kernel/Configuration/Shared/TenantConfigurationState.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Configuration;
+
+/// <summary>
+/// Represents all configuration key/values for a tenant.
+/// </summary>
+public class TenantConfigurationState : Dictionary<string, string>
+{
+    /// <summary>
+    /// The name of the storage provider used for working with this type of state.
+    /// </summary>
+    public const string StorageProvider = "tenant-configuration-state";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TenantConfigurationState"/> class.
+    /// </summary>
+    public TenantConfigurationState()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TenantConfigurationState"/> class.
+    /// </summary>
+    /// <param name="dictionary">Dictionary to initialize it from.</param>
+    public TenantConfigurationState(IDictionary<string, string> dictionary) : base(dictionary)
+    {
+    }
+
+    /// <summary>
+    /// Creates an empty configuration.
+    /// </summary>
+    /// <returns>A new empty <see cref="TenantConfigurationState"/>.</returns>
+    public static TenantConfigurationState Empty() => new();
+}

--- a/Source/Kernel/Server/cratis.json
+++ b/Source/Kernel/Server/cratis.json
@@ -3,7 +3,7 @@
         "3352d47d-c154-4457-b3fb-8a2efb725113": {
             "name": "development",
             "configuration": {
-                "something": "43"
+                "something": "42.42"
             }
         }
     },

--- a/Source/Kernel/Server/cratis.json
+++ b/Source/Kernel/Server/cratis.json
@@ -1,7 +1,10 @@
 {
     "tenants": {
         "3352d47d-c154-4457-b3fb-8a2efb725113": {
-            "name": "development"
+            "name": "development",
+            "configuration": {
+                "something": "43"
+            }
         }
     },
     "microservices": {

--- a/Source/Kernel/Store/MongoDB/CollectionNames.cs
+++ b/Source/Kernel/Store/MongoDB/CollectionNames.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Aksio.Cratis.Configuration;
 using Aksio.Cratis.Events.Store.Observation;
 using Orleans;
 
@@ -25,4 +26,9 @@ internal static class CollectionNames
     /// The collection that holds <see cref="ReminderEntry"/>.
     /// </summary>
     internal const string Reminders = "reminders";
+
+    /// <summary>
+    /// The collection that holds <see cref="TenantConfigurationState"/>.
+    /// </summary>
+    internal const string TenantConfiguration = "tenants-configuration";
 }

--- a/Source/Kernel/Store/MongoDB/SiloBuilderExtensions.cs
+++ b/Source/Kernel/Store/MongoDB/SiloBuilderExtensions.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Aksio.Cratis.Configuration;
 using Aksio.Cratis.Events.Store;
 using Aksio.Cratis.Events.Store.EventSequences;
 using Aksio.Cratis.Events.Store.MongoDB;
 using Aksio.Cratis.Events.Store.MongoDB.Observation;
+using Aksio.Cratis.Events.Store.MongoDB.Tenants;
 using Aksio.Cratis.Events.Store.Observation;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
@@ -31,6 +33,7 @@ public static class SiloBuilderExtensions
             services.AddSingletonNamedService<IGrainStorage>(EventSequenceState.StorageProvider, (serviceProvider, _) => serviceProvider.GetService<EventSequencesStorageProvider>()!);
             services.AddSingletonNamedService<IGrainStorage>(ObserverState.StorageProvider, (serviceProvider, _) => serviceProvider.GetService<ObserverStorageProvider>()!);
             services.AddSingletonNamedService<IGrainStorage>(ClientObserversState.StorageProvider, (serviceProvider, _) => serviceProvider.GetService<ClientObserversStorageProvider>()!);
+            services.AddSingletonNamedService<IGrainStorage>(TenantConfigurationState.StorageProvider, (serviceProvider, _) => serviceProvider.GetService<TenantConfigurationStorageProvider>()!);
         });
 
         builder.AddPersistentStreams(

--- a/Source/Kernel/Store/MongoDB/Tenants/MongoDBTenantConfigurationKeyValuePair.cs
+++ b/Source/Kernel/Store/MongoDB/Tenants/MongoDBTenantConfigurationKeyValuePair.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Events.Store.MongoDB.Tenants;
+
+/// <summary>
+/// Represents the key / value pair for tenant configuration.
+/// </summary>
+/// <param name="Key">Key of configuration pair.</param>
+/// <param name="Value">Value for the configuration pair. </param>
+public record MongoDBTenantConfigurationKeyValuePair(string Key, string Value);

--- a/Source/Kernel/Store/MongoDB/Tenants/MongoDBTenantConfigurationState.cs
+++ b/Source/Kernel/Store/MongoDB/Tenants/MongoDBTenantConfigurationState.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Execution;
+
+namespace Aksio.Cratis.Events.Store.MongoDB.Tenants;
+
+/// <summary>
+/// Represents the tenant configuration state stored in the database.
+/// </summary>
+/// <param name="Id">The tenant identifier.</param>
+/// <param name="Configuration">Collection of <see cref="MongoDBTenantConfigurationKeyValuePair"/>.</param>
+public record MongoDBTenantConfigurationState(TenantId Id, IEnumerable<MongoDBTenantConfigurationKeyValuePair> Configuration);

--- a/Source/Kernel/Store/MongoDB/Tenants/TenantConfigurationStorageProvider.cs
+++ b/Source/Kernel/Store/MongoDB/Tenants/TenantConfigurationStorageProvider.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Configuration;
+using Aksio.Cratis.Execution;
+using Aksio.Cratis.MongoDB;
+using MongoDB.Driver;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Storage;
+
+namespace Aksio.Cratis.Events.Store.MongoDB.Tenants;
+
+/// <summary>
+/// Represents an implementation of <see cref="IGrainStorage"/> for handling tenant configuration data.
+/// </summary>
+public class TenantConfigurationStorageProvider : IGrainStorage
+{
+    readonly IClusterDatabase _database;
+    IMongoCollection<MongoDBTenantConfigurationState> Collection => _database.GetCollection<MongoDBTenantConfigurationState>(CollectionNames.TenantConfiguration);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TenantConfigurationStorageProvider"/> class.
+    /// </summary>
+    /// <param name="database"><see cref="IClusterDatabase"/> that holds the configuration data.</param>
+    public TenantConfigurationStorageProvider(IClusterDatabase database)
+    {
+        _database = database;
+    }
+
+    /// <inheritdoc/>
+    public Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+    {
+        var tenantId = (TenantId)grainReference.GetPrimaryKey();
+        var cursor = await Collection.FindAsync(_ => _.Id == tenantId);
+        var state = await cursor.FirstOrDefaultAsync();
+        if (state is not null)
+        {
+            grainState.State = new TenantConfigurationState(state.Configuration.ToDictionary(_ => _.Key, _ => _.Value));
+        }
+        else
+        {
+            grainState.State = TenantConfigurationState.Empty();
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+    {
+        var tenantId = (TenantId)grainReference.GetPrimaryKey();
+        var state = (grainState.State as TenantConfigurationState)!;
+        var mongoDBState = new MongoDBTenantConfigurationState(tenantId, state.Select(_ => new MongoDBTenantConfigurationKeyValuePair(_.Key, _.Value)));
+        await Collection.ReplaceOneAsync(
+            _ => _.Id == tenantId,
+            mongoDBState,
+            new ReplaceOptions { IsUpsert = true });
+    }
+}


### PR DESCRIPTION
### Added

- Bringing back `TenantConfiguration` that was considered a wrong design. Turns out it was fine for a specific purpose; associating key / value pairs with a tenant for simple configuration values.
- Support for key / value configuration per tenant in the `cratis.json` file - specifically aimed towards local development and team work and the ability to check in configuration into a repository.

