### PR TITLE
Only use key resolver for child projection if it actually has it

### DIFF
--- a/Source/Kernel/Projections/Engine/IProjection.cs
+++ b/Source/Kernel/Projections/Engine/IProjection.cs
@@ -110,6 +110,13 @@ public interface IProjection
     bool Accepts(EventType eventType);
 
     /// <summary>
+    /// Get whether or not there is a key resolver for a specific <see cref="EventType"/>.
+    /// </summary>
+    /// <param name="eventType"><see cref="EventType"/> to check.</param>
+    /// <returns>True if there is, false if not.</returns>
+    bool HasKeyResolverFor(EventType eventType);
+
+    /// <summary>
     /// Get the <see cref="ValueProvider{Event}"/> associated with a given <see cref="EventType"/>.
     /// </summary>
     /// <param name="eventType"><see cref="EventType"/> to get for.</param>

--- a/Source/Kernel/Projections/Engine/Pipelines/ProjectionPipeline.cs
+++ b/Source/Kernel/Projections/Engine/Pipelines/ProjectionPipeline.cs
@@ -125,9 +125,16 @@ public class ProjectionPipeline : IProjectionPipeline
         }
         foreach (var child in projection.ChildProjections)
         {
-            var keyResolver = child.GetKeyResolverFor(context.Event.Metadata.Type);
-            var key = await keyResolver(_eventProvider, context.Event);
-            await HandleEventFor(child, context with { Key = key });
+            if (child.HasKeyResolverFor(context.Event.Metadata.Type))
+            {
+                var keyResolver = child.GetKeyResolverFor(context.Event.Metadata.Type);
+                var key = await keyResolver(_eventProvider, context.Event);
+                await HandleEventFor(child, context with { Key = key });
+            }
+            else
+            {
+                await HandleEventFor(child, context);
+            }
         }
     }
 }

--- a/Source/Kernel/Projections/Engine/Projection.cs
+++ b/Source/Kernel/Projections/Engine/Projection.cs
@@ -107,6 +107,9 @@ public class Projection : IProjection
     public bool Accepts(EventType eventType) => _eventTypesToKeyResolver.Keys.Any(_ => _.Id == eventType.Id);
 
     /// <inheritdoc/>
+    public bool HasKeyResolverFor(EventType eventType) => _eventTypesToKeyResolver.ContainsKey(new(eventType.Id, eventType.Generation));
+
+    /// <inheritdoc/>
     public KeyResolver GetKeyResolverFor(EventType eventType)
     {
         // We only care about the actual event type identifier and generation, any other properties should be the default


### PR DESCRIPTION
### Fixed

- Bug with projections having children - it was assumed the child projection had a key resolver for the parent event, which in most cases it does not.
