### PR TITLE
Supporting use of the StringEnumConverter for Newtonsoft for enums

### DIFF
--- a/Source/Fundamentals/Json/ExpandoObjectConverter.cs
+++ b/Source/Fundamentals/Json/ExpandoObjectConverter.cs
@@ -151,13 +151,6 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
         switch (type)
         {
             case JsonObjectType.String:
-                if (genericArguments.Length == 1 &&
-                    genericArguments[0] == typeof(int) &&
-                    schemaProperty.Reference?.IsEnumeration == true)
-                {
-                    return value.GetValue<int>();
-                }
-
                 var valueAsString = value.GetValue<string>();
                 return schemaProperty.Format == "guid" ?
                         Guid.Parse(valueAsString) :

--- a/Source/Fundamentals/Json/ExpandoObjectConverter.cs
+++ b/Source/Fundamentals/Json/ExpandoObjectConverter.cs
@@ -146,9 +146,18 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
             type ^= JsonObjectType.Null;
         }
 
+        var genericArguments = value.GetType().GetGenericArguments();
+
         switch (type)
         {
             case JsonObjectType.String:
+                if (genericArguments.Length == 1 &&
+                    genericArguments[0] == typeof(int) &&
+                    schemaProperty.Reference?.IsEnumeration == true)
+                {
+                    return value.GetValue<int>();
+                }
+
                 var valueAsString = value.GetValue<string>();
                 return schemaProperty.Format == "guid" ?
                         Guid.Parse(valueAsString) :
@@ -158,7 +167,6 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
                 return value.GetValue<bool>();
 
             case JsonObjectType.Integer:
-                var genericArguments = value.GetType().GetGenericArguments();
                 if (genericArguments.Length == 1 &&
                     genericArguments[0] == typeof(string) &&
                     schemaProperty.Reference?.IsEnumeration == true)

--- a/Source/Fundamentals/Schemas/ReflectionService.cs
+++ b/Source/Fundamentals/Schemas/ReflectionService.cs
@@ -3,6 +3,7 @@
 
 using Aksio.Cratis.Concepts;
 using Namotion.Reflection;
+using Newtonsoft.Json;
 using NJsonSchema.Generation;
 
 namespace Aksio.Cratis.Schemas;
@@ -12,6 +13,9 @@ namespace Aksio.Cratis.Schemas;
 /// </summary>
 public class ReflectionService : DefaultReflectionService
 {
+    /// <inheritdoc/>
+    public override bool IsStringEnum(ContextualType contextualType, JsonSerializerSettings serializerSettings) => false;
+
     /// <inheritdoc/>
     public override JsonTypeDescription GetDescription(ContextualType contextualType, ReferenceTypeNullHandling defaultReferenceTypeNullHandling, JsonSchemaGeneratorSettings settings)
     {

--- a/Specifications/Fundamentals/Json/for_ExpandoObjectConverter/TargetType.cs
+++ b/Specifications/Fundamentals/Json/for_ExpandoObjectConverter/TargetType.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Aksio.Cratis.Json.for_ExpandoObjectConverter;
 
@@ -11,8 +13,24 @@ public enum AnEnumValue
     Second = 2
 }
 
-public enum AnEnumAsStringValue
+public enum AnEnumWithStringValues
 {
+    [EnumMember(Value = "Undefined")]
+    Undefined = 0,
+
+    [EnumMember(Value = "First")]
+    First = 1,
+
+    [EnumMember(Value = "Second")]
+    Second = 2,
+}
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum AnEnumWithStringValuesAndJsonConverter
+{
+    [EnumMember(Value = "Undefined")]
+    Undefined = 0,
+
     [EnumMember(Value = "First")]
     First = 1,
 
@@ -25,7 +43,9 @@ public record TargetType(
     float FloatValue,
     double DoubleValue,
     AnEnumValue EnumValue,
-    AnEnumAsStringValue EnumAsStringValue,
+    AnEnumWithStringValues EnumAsStringValueRepresentedAsInt,
+    AnEnumWithStringValues EnumAsStringValue,
+    AnEnumWithStringValuesAndJsonConverter EnumAsStringValueWithJsonConverter,
     Guid GuidValue,
     DateTime DateTimeValue,
     DateTimeOffset DateTimeOffsetValue,

--- a/Specifications/Fundamentals/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
+++ b/Specifications/Fundamentals/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
@@ -36,6 +36,8 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
             ["floatValue"] = 42.42,
             ["doubleValue"] = 42.42,
             ["enumValue"] = 2,
+            ["enumAsStringValueRepresentedAsInt"] = 2,
+            ["enumAsStringValueWithJsonConverter"] = 2,
             ["enumAsStringValue"] = "Second",
             ["guidValue"] = "251b9fbe-83d4-4306-9a5d-9d0e7d4dd456",
             ["dateTimeValue"] = DateTime.Parse("2022-10-31T14:51:32.8450000Z"),
@@ -58,7 +60,11 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
     [Fact] void should_set_top_level_enum_value_to_be_of_int_type() => ((object)result.enumValue).ShouldBeOfExactType<int>();
     [Fact] void should_set_top_level_enum_value_to_hold_correct_value() => ((int)result.enumValue).ShouldEqual(source["enumValue"].GetValue<int>());
     [Fact] void should_set_top_level_enum_as_string_value_to_be_of_int_type() => ((object)result.enumValue).ShouldBeOfExactType<int>();
-    [Fact] void should_set_top_level_enum_as_string_value_to_hold_correct_value() => ((int)result.enumValue).ShouldEqual((int)AnEnumAsStringValue.Second);
+    [Fact] void should_set_top_level_enum_as_string_value_to_hold_correct_value() => ((int)result.enumValue).ShouldEqual((int)AnEnumWithStringValues.Second);
+    [Fact] void should_set_top_level_enum_as_string_value_represented_as_int_to_be_of_int_type() => ((object)result.enumAsStringValueRepresentedAsInt).ShouldBeOfExactType<int>();
+    [Fact] void should_set_top_level_enum_as_string_value_represented_as_int_to_hold_correct_value() => ((int)result.enumAsStringValueRepresentedAsInt).ShouldEqual((int)AnEnumWithStringValues.Second);
+    [Fact] void should_set_top_level_enum_as_string_value_with_string_json_converter_represented_as_int_to_be_of_int_type() => ((object)result.enumAsStringValueWithJsonConverter).ShouldBeOfExactType<int>();
+    [Fact] void should_set_top_level_enum_as_string_value_with_string_json_converter_represented_as_int_to_hold_correct_value() => ((int)result.enumAsStringValueWithJsonConverter).ShouldEqual((int)AnEnumWithStringValues.Second);
     [Fact] void should_set_top_level_guid_value_to_be_of_guid_type() => ((object)result.guidValue).ShouldBeOfExactType<Guid>();
     [Fact] void should_set_top_level_guid_value_to_hold_correct_value() => ((Guid)result.guidValue).ShouldEqual(Guid.Parse(source["guidValue"].GetValue<string>()));
     [Fact] void should_set_top_level_date_time_value_to_be_of_date_time_type() => ((object)result.dateTimeValue).ShouldBeOfExactType<DateTime>();


### PR DESCRIPTION
### Fixed

- When using Newtonsofts `[JsonConverter(typeof(StringEnumConverter))]`, NJsonSchema would by default treat it as a string value. Changed this behavior and it will now always treat it as an integer.
