### PR TITLE
Using correct variable; IsEnumerable and not Enumerable

### DIFF
--- a/Source/ApplicationModel/Tooling/ProxyGenerator/Templates/Command.hbs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/Templates/Command.hbs
@@ -13,7 +13,7 @@ const routeTemplate = Handlebars.compile('{{{Route}}}');
 
 export interface I{{Name}} {
     {{#Properties}}
-    {{#if Enumerable}}
+    {{#if IsEnumerable}}
     {{camelcase Name}}?: {{Type}}[];
     {{else}}
     {{camelcase Name}}?: {{Type}};
@@ -39,7 +39,7 @@ export class {{Name}} extends Command<I{{Name}}> implements I{{Name}} {
     readonly validation: CommandValidator = new {{Name}}Validator();
 
     {{#Properties}}
-    {{#if Enumerable}}
+    {{#if IsEnumerable}}
     private _{{camelcase Name}}!: {{Type}}[];
     {{else}}
     private _{{camelcase Name}}!: {{Type}};
@@ -73,7 +73,7 @@ export class {{Name}} extends Command<I{{Name}}> implements I{{Name}} {
     }
 
     {{#Properties}}
-    {{#if Enumerable}}
+    {{#if IsEnumerable}}
     get {{camelcase Name}}(): {{Type}}[] {
         return this._{{camelcase Name}};
     }


### PR DESCRIPTION
### Fixed

- Fixing a bug in the command template so that enumerable properties actually now gets rendered correctly as JS arrays.
