### PR TITLE
Feature/rule-for-concept

### DIFF
--- a/Documentation/application-model/validation.md
+++ b/Documentation/application-model/validation.md
@@ -25,6 +25,24 @@ to inject localized strings or similar you won't be able to get to it.
 Another alternative approach to validation is to use [FluentValidation](https://docs.fluentvalidation.net).
 Cratis comes with this all setup and automatically hooks up different types of validators for specific purposes.
 
+### Base Validator
+
+The formalized validator types (`CommandValidator`, `QueryValidator` and `ConceptValidator`) all derive from a
+type called `BaseValidator`. This base type provides methods for defining validation rules for known `ConceptAs<>`
+primitives and will unwrap the inner `Value` property automatically, providing you a clean way of validating the
+concepts inner primitive type without considering the `Value` property.
+
+However, if you're hooking up validators for the actual concept, you need to use the method `RuleForConcept()`
+to work directly with the concept. The `IRuilBuilderInitial` type returned would then be for the actual concept and
+not its primitive type its encapsulating.
+
+### Discoverable validators
+
+Validators can be automatically discovered. This done through the discovery of anything that implements the marker
+interface `IDiscoverableValidator<>`. The formalized types for Commands, Queries and Concepts all implement this.
+There is also a base type that can be used, which inherits from `BaseValidator` to give you the additional functionality
+it provides. All you need to do is inherit from `DiscoverableValidator<>`.
+
 ### Command Validator
 
 To write command validators, all you need to do is implement the `CommandValidator<>` class and create

--- a/Source/ApplicationModel/CQRS/Validation/BaseValidator.cs
+++ b/Source/ApplicationModel/CQRS/Validation/BaseValidator.cs
@@ -14,6 +14,14 @@ namespace Aksio.Cratis.Applications.Validation;
 public class BaseValidator<T> : AbstractValidator<T>
 {
     /// <summary>
+    /// Defines a validation rules for a property based on <see cref="ConceptAs{T}"/> for the actual concept type.
+    /// </summary>
+    /// <param name="expression">The expression representing the property to validate.</param>
+    /// <typeparam name="TProperty">Type of the concept.</typeparam>
+    /// <returns>An IRuleBuilder instance on which validators can be defined.</returns>
+    public IRuleBuilderInitial<T, TProperty> RuleForConcept<TProperty>(Expression<Func<T, TProperty>> expression) => RuleFor(expression);
+
+    /// <summary>
     /// Defines a validation rules for a specific property based on <see cref="ConceptAs{T}"/> for string.
     /// </summary>
     /// <param name="expression">The expression representing the property to validate.</param>

--- a/Source/ApplicationModel/CQRS/Validation/DiscoverableValidatorMustImplementAbstractValidator.cs
+++ b/Source/ApplicationModel/CQRS/Validation/DiscoverableValidatorMustImplementAbstractValidator.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Applications.Validation;
+
+/// <summary>
+/// Exception that gets thrown when a validator.
+/// </summary>
+public class DiscoverableValidatorMustImplementAbstractValidator : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiscoverableValidatorMustImplementAbstractValidator"/> class.
+    /// </summary>
+    /// <param name="type">Validator type that is invalid.</param>
+    public DiscoverableValidatorMustImplementAbstractValidator(Type type) : base($"Discoverable validator of type '{type.FullName}' does not derive from AbstractValidator<>, suggest using either BaseValidator<>, DiscoverableValidator<>, CommandValidator<>, QueryValidator<>, ConceptValidator<> or the AbstractValidator<> as base type.")
+    {
+    }
+}

--- a/Source/ApplicationModel/CQRS/Validation/IDiscoverableValidator.cs
+++ b/Source/ApplicationModel/CQRS/Validation/IDiscoverableValidator.cs
@@ -4,9 +4,13 @@
 namespace Aksio.Cratis.Applications.Validation;
 
 /// <summary>
-/// Represents a base validator that can be discovered and automatically hooked up.
+/// Defines a discoverable validator that can be discovered and automatically hooked up.
 /// </summary>
 /// <typeparam name="T">Type of object the validator is for.</typeparam>
-public class DiscoverableValidator<T> : BaseValidator<T>, IDiscoverableValidator<T>
+/// <remarks>
+/// The type needs to in addition implement fluent validation AbstractValidator or something that
+/// implements it.
+/// </remarks>
+public interface IDiscoverableValidator<T>
 {
 }


### PR DESCRIPTION
### Added

- Added `RuleForConcept` in the `BaseValidator` type to be able to hook up validation that is for an actual concept and not the primitive it is encapsulating.
- Extracting out discoverability of validators into `IDiscoverableValidator`. This can now be used indepdendently, allowing you to work directly with `AbstractValidator` for instance and still be discovered at runtime.
