### PR TITLE
DateOnlyJsonConverter can handle dates in more formats (esp. ISO 8601)

### DIFF
--- a/Source/Fundamentals/Json/DateOnlyJsonConverter.cs
+++ b/Source/Fundamentals/Json/DateOnlyJsonConverter.cs
@@ -12,7 +12,21 @@ namespace Aksio.Cratis.Json;
 public class DateOnlyJsonConverter : JsonConverter<DateOnly>
 {
     /// <inheritdoc/>
-    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => DateOnly.Parse(reader.GetString()!);
+    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if(reader.TryGetDateTimeOffset(out var dateTimeOffset))
+        {
+            return DateOnly.FromDateTime(dateTimeOffset.DateTime);
+        }
+        
+        if(reader.TryGetDateTime(out var dateTime))
+        {
+            return DateOnly.FromDateTime(dateTime);
+        }
+        
+        var dateFromString = DateTime.Parse(reader.GetString()!);
+        return DateOnly.FromDateTime(dateFromString);
+    }
 
     /// <inheritdoc/>
     public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options) => writer.WriteStringValue(value.ToString("O"));

--- a/Specifications/Fundamentals/Fundamentals.csproj
+++ b/Specifications/Fundamentals/Fundamentals.csproj
@@ -5,6 +5,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="../../Source/Fundamentals/Fundamentals.csproj"/>
+        <ProjectReference Include="../../Source/Fundamentals/Fundamentals.csproj" />
     </ItemGroup>
 </Project>

--- a/Specifications/Fundamentals/Json/for_DateOnlyJsonConverter/when_converting_from_date_only.cs
+++ b/Specifications/Fundamentals/Json/for_DateOnlyJsonConverter/when_converting_from_date_only.cs
@@ -31,3 +31,4 @@ public class when_converting_from_date_only : Specification
 
     [Fact] void should_convert_to_correct_date_string() => result.ShouldEqual($"\"{input:O}\"");
 }
+

--- a/Specifications/Fundamentals/Json/for_DateOnlyJsonConverter/when_converting_to_date_only_from_iso_string.cs
+++ b/Specifications/Fundamentals/Json/for_DateOnlyJsonConverter/when_converting_to_date_only_from_iso_string.cs
@@ -6,21 +6,25 @@ using System.Text.Json;
 
 namespace Aksio.Cratis.Json.for_DateOnlyJsonConverter;
 
-public class when_converting_to_date_only : Specification
+public class when_converting_to_date_only_from_iso_string : Specification
 {
     DateOnlyJsonConverter converter;
+    DateTime now;
     DateOnly input;
+    string inputAsISOString;
     DateOnly result;
 
     void Establish()
     {
+        now = DateTime.Now;
         converter = new();
-        input = DateOnly.FromDateTime(DateTime.UtcNow);
+        input = DateOnly.FromDateTime(now);
+        inputAsISOString = now.ToString("O");
     }
 
     void Because()
     {
-        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes($"\"{input:O}\"").AsSpan());
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes($"\"{inputAsISOString}\"").AsSpan());
         reader.Read();  // Skip quote
         result = converter.Read(ref reader, typeof(DateOnly), default);
     }

--- a/Specifications/Fundamentals/Json/for_DateOnlyJsonConverter/when_converting_to_date_only_from_iso_string_from_datetimeoffset.cs
+++ b/Specifications/Fundamentals/Json/for_DateOnlyJsonConverter/when_converting_to_date_only_from_iso_string_from_datetimeoffset.cs
@@ -6,21 +6,25 @@ using System.Text.Json;
 
 namespace Aksio.Cratis.Json.for_DateOnlyJsonConverter;
 
-public class when_converting_to_date_only : Specification
+public class when_converting_to_date_only_from_iso_string_from_datetimeoffset : Specification
 {
     DateOnlyJsonConverter converter;
+    DateTimeOffset now;
     DateOnly input;
+    string inputAsISOString;
     DateOnly result;
 
     void Establish()
     {
+        now = DateTimeOffset.Now;
         converter = new();
-        input = DateOnly.FromDateTime(DateTime.UtcNow);
+        input = DateOnly.FromDateTime(now.UtcDateTime);
+        inputAsISOString = now.ToString("O");
     }
 
     void Because()
     {
-        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes($"\"{input:O}\"").AsSpan());
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes($"\"{inputAsISOString}\"").AsSpan());
         reader.Read();  // Skip quote
         result = converter.Read(ref reader, typeof(DateOnly), default);
     }

--- a/Specifications/Fundamentals/Json/for_DateOnlyJsonConverter/when_converting_to_date_only_from_string.cs
+++ b/Specifications/Fundamentals/Json/for_DateOnlyJsonConverter/when_converting_to_date_only_from_string.cs
@@ -6,21 +6,25 @@ using System.Text.Json;
 
 namespace Aksio.Cratis.Json.for_DateOnlyJsonConverter;
 
-public class when_converting_to_date_only : Specification
+public class when_converting_to_date_only_from_string : Specification
 {
     DateOnlyJsonConverter converter;
+    DateTime now;
     DateOnly input;
+    string inputAsString;
     DateOnly result;
 
     void Establish()
     {
+        now = DateTime.Now;
         converter = new();
-        input = DateOnly.FromDateTime(DateTime.UtcNow);
+        input = DateOnly.FromDateTime(now);
+        inputAsString = now.ToString();
     }
 
     void Because()
     {
-        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes($"\"{input:O}\"").AsSpan());
+        Utf8JsonReader reader = new(Encoding.UTF8.GetBytes($"\"{inputAsString}\"").AsSpan());
         reader.Read();  // Skip quote
         result = converter.Read(ref reader, typeof(DateOnly), default);
     }


### PR DESCRIPTION
## Summary

DateOnlyJsonConverter handles dates in ISO 8601 format.  This is the format that a Date object in Javascript will serialize to in JSON.stringify.

### Added

- Specs covering more string format

### Changed

- Implementation of DateOnlyJsonConverter to use TryGetDateTimeOffset and falling back to TryGetDateTime and then just Read.

### Fixed

- DateTime string in JSON that was generated from the JS Date Object in the proxy was not deserialized correctly.  The entire command failed as a consequence.
