### PR TITLE
Adding execution context log enricher

### DIFF
--- a/Source/ApplicationModel/Applications/Logging/ExecutionContextLogEnricher.cs
+++ b/Source/ApplicationModel/Applications/Logging/ExecutionContextLogEnricher.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Execution;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Aksio.Cratis.Applications.Logging;
+
+/// <summary>
+/// Represents an implementation of <see cref="ILogEventEnricher"/> for enriching log events with values from the execution context.
+/// </summary>
+public class ExecutionContextLogEnricher : ILogEventEnricher
+{
+    /// <summary>
+    /// The name of the property for the microservice identifier.
+    /// </summary>
+    public const string MicroserviceIdProperty = "MicroserviceId";
+
+    /// <summary>
+    /// The name of the property for the tenant identifier.
+    /// </summary>
+    public const string TenantIdProperty = "TenantId";
+
+    /// <summary>
+    /// The name of the property for the correlation identifier.
+    /// </summary>
+    public const string CorrelationIdProperty = "CorrelationId";
+
+    /// <summary>
+    /// The name of the property for the causation identifier.
+    /// </summary>
+    public const string CausationIdProperty = "CausationId";
+
+    /// <summary>
+    /// The name of the property for the caused by identifier.
+    /// </summary>
+    public const string CausedByIdProperty = "CausedById";
+
+    /// <inheritdoc/>
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        if (ExecutionContextManager.HasCurrent)
+        {
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(MicroserviceIdProperty, ExecutionContextManager.GetCurrent().MicroserviceId.Value));
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(TenantIdProperty, ExecutionContextManager.GetCurrent().TenantId.Value));
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(CorrelationIdProperty, ExecutionContextManager.GetCurrent().CorrelationId.Value));
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(CausationIdProperty, ExecutionContextManager.GetCurrent().CausationId.Value));
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(CausedByIdProperty, ExecutionContextManager.GetCurrent().CausedBy.Value));
+        }
+    }
+}

--- a/Source/ApplicationModel/Applications/Logging/ExecutionContextLoggingExtensions.cs
+++ b/Source/ApplicationModel/Applications/Logging/ExecutionContextLoggingExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Serilog;
+using Serilog.Configuration;
+
+namespace Aksio.Cratis.Applications.Logging;
+
+/// <summary>
+/// Extension methods for <see cref="LoggerEnrichmentConfiguration"/>.
+/// </summary>
+public static class ExecutionContextLoggingExtensions
+{
+    /// <summary>
+    /// Adds a log enricher that adds values from the execution context to the log event.
+    /// </summary>
+    /// <param name="enrich"><see cref="LoggerEnrichmentConfiguration"/> to enrich.</param>
+    /// <returns><see cref="LoggerConfiguration"/> for builder continuation.</returns>
+    public static LoggerConfiguration WithExecutionContext(this LoggerEnrichmentConfiguration enrich)
+    {
+        return enrich.With<ExecutionContextLogEnricher>();
+    }
+}

--- a/Source/ApplicationModel/Applications/Logging/LoggingHostBuilderExtensions.cs
+++ b/Source/ApplicationModel/Applications/Logging/LoggingHostBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Aksio.Cratis.Applications.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog;
@@ -22,6 +23,7 @@ public static class LoggingHostBuilderExtensions
     {
         Log.Logger = new LoggerConfiguration()
             .Enrich.WithExceptionDetails()
+            .Enrich.WithExecutionContext()
             .ReadFrom.Configuration(ConfigurationHostBuilderExtensions.Configuration)
             .CreateLogger();
 

--- a/Source/Fundamentals/Execution/ExecutionContextManager.cs
+++ b/Source/Fundamentals/Execution/ExecutionContextManager.cs
@@ -12,6 +12,11 @@ public class ExecutionContextManager : IExecutionContextManager
     static readonly AsyncLocal<ExecutionContext> _currentExecutionContext = new();
 
     /// <summary>
+    /// Get whether or not there is a current <see cref="ExecutionContext"/>.
+    /// </summary>
+    public static bool HasCurrent => _currentExecutionContext.Value != default;
+
+    /// <summary>
     /// Get whether or not we're inside the kernel.
     /// </summary>
     public static bool IsInKernel { get; private set; }

--- a/Source/Kernel/Server/README.md
+++ b/Source/Kernel/Server/README.md
@@ -6,13 +6,20 @@ This sets up what is needed to work with Kernel development.
 ## Seq logging
 
 [Seq](https://datalust.co/seq) has been configured as logging tool in the `docker-compose.yml` file.
-To use it for the kernel, add a Serilog Sink in the `appsettings.Development.json` file:
+To use it for the kernel, add a Serilog Sink in `Serilog.WriteTo` section in the `appsettings.Development.json` file:
 
 ```json
 {
-    "Name": "Seq",
-    "Args": {
-        "serverUrl": "http://localhost:5341"
+    "Serilog": {
+        "WriteTo": [
+            // Other sinks...
+            {
+                "Name": "Seq",
+                "Args": {
+                    "serverUrl": "http://localhost:5341"
+                }
+            }
+        ]
     }
 }
 ````


### PR DESCRIPTION
### Added

- Adding log enrichment for Serilog to execution context. Automatically hooked up in Application Model. (#445)

Usage:

```csharp
        Log.Logger = new LoggerConfiguration()
            .Enrich.WithExecutionContext()
            .CreateLogger();
```
