### PR TITLE
Sanitizing the output folder path so we get a correct fully qualified path

### DIFF
--- a/Source/ApplicationModel/Tooling/ProxyGenerator/SourceGenerator.cs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/SourceGenerator.cs
@@ -374,6 +374,11 @@ public class SourceGenerator : ISourceGenerator
             importPath = $"./{importPath}";
         }
 
+        if (importPath.StartsWith("./.."))
+        {
+            importPath = importPath.Replace("./..", "..");
+        }
+
         parentImportStatements.Add(new ImportStatement(type.Name, importPath));
 
         var properties = type.GetPublicPropertiesFrom();

--- a/Source/ApplicationModel/Tooling/ProxyGenerator/SourceGenerator.cs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/SourceGenerator.cs
@@ -52,6 +52,9 @@ public class SourceGenerator : ISourceGenerator
             _derivedTypes.Add(type);
         }
 
+        // Sanitize the output folder
+        outputFolder = Path.GetFullPath(outputFolder);
+
         foreach (var classDeclaration in receiver!.Candidates)
         {
             try


### PR DESCRIPTION
### Fixed

- The output folder path for proxy generation was not sanitized and properly resolved to an absolute path, so a relative path of `../Web/API` could end up with a `/your/path/to/the/code//../Web/Api` which then failed getting the correct relative path of a type when outputting types.
