### PR TITLE
Fix/observers-resubscription

### DIFF
--- a/Source/Kernel/Grains.Interfaces/Observation/ICatchUp.cs
+++ b/Source/Kernel/Grains.Interfaces/Observation/ICatchUp.cs
@@ -13,10 +13,9 @@ public interface ICatchUp : IGrainWithGuidCompoundKey
     /// <summary>
     /// Starts a catch up process for a given observer.
     /// </summary>
-    /// <param name="subscriberType">Type of subscriber.</param>
-    /// <param name="subscriberArgs">Arguments associated with the subscriber.</param>
+    /// <param name="subscription">The <see cref="ObserverSubscription"/> to use to catch up.</param>
     /// <returns>Awaitable task.</returns>
-    Task Start(Type subscriberType, object? subscriberArgs = default);
+    Task Start(ObserverSubscription subscription);
 
     /// <summary>
     /// Stop catching up.

--- a/Source/Kernel/Grains.Interfaces/Observation/IObserverSupervisor.cs
+++ b/Source/Kernel/Grains.Interfaces/Observation/IObserverSupervisor.cs
@@ -31,6 +31,12 @@ public interface IObserverSupervisor : IGrainWithGuidCompoundKey
         where TObserverSubscriber : IObserverSubscriber;
 
     /// <summary>
+    /// Get the current subscription.
+    /// </summary>
+    /// <returns><see cref="ObserverSubscription"/>.</returns>
+    Task<ObserverSubscription> GetCurrentSubscription();
+
+    /// <summary>
     /// Unsubscribe from the observer.
     /// </summary>
     /// <returns>Awaitable task.</returns>

--- a/Source/Kernel/Grains.Interfaces/Observation/ObserverSubscription.cs
+++ b/Source/Kernel/Grains.Interfaces/Observation/ObserverSubscription.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Kernel.Grains.Observation;
+
+/// <summary>
+/// Represents a subscription to an observer.
+/// </summary>
+/// <param name="SubscriberType">Type that is subscribing.</param>
+/// <param name="Arguments">Any arguments it passed.</param>
+public record ObserverSubscription(Type SubscriberType, object Arguments)
+{
+    /// <summary>
+    /// Gets a subscription representing no subscription.
+    /// </summary>
+    public static readonly ObserverSubscription Unsubscribed = new(typeof(IObserverSubscriber), null!);
+
+    /// <summary>
+    /// Check whether or not the subscription is subscribed.
+    /// </summary>
+    public bool IsSubscribed => !Equals(Unsubscribed);
+}

--- a/Source/Kernel/Grains/Observation/CatchUp.cs
+++ b/Source/Kernel/Grains/Observation/CatchUp.cs
@@ -62,7 +62,7 @@ public class CatchUp : ObserverWorker, ICatchUp
     }
 
     /// <inheritdoc/>
-    public Task Start(Type subscriberType, object? subscriberArgs = default)
+    public Task Start(ObserverSubscription subscription)
     {
         if (_isRunning)
         {
@@ -71,8 +71,7 @@ public class CatchUp : ObserverWorker, ICatchUp
         }
 
         _logger.Starting(ObserverId, MicroserviceId, TenantId, EventSequenceId, SourceMicroserviceId, SourceTenantId);
-        SubscriberType = subscriberType;
-        SubscriberArgs = subscriberArgs;
+        CurrentSubscription = subscription;
         _isRunning = true;
         _timer = RegisterTimer(PerformCatchUp, null, TimeSpan.Zero, TimeSpan.MaxValue);
         return Task.CompletedTask;

--- a/Source/Kernel/Grains/Observation/CatchUp.cs
+++ b/Source/Kernel/Grains/Observation/CatchUp.cs
@@ -79,12 +79,12 @@ public class CatchUp : ObserverWorker, ICatchUp
     }
 
     /// <inheritdoc/>
-    public Task Stop()
+    public async Task Stop()
     {
         _logger.Stopping(ObserverId, MicroserviceId, TenantId, EventSequenceId, SourceMicroserviceId, SourceTenantId);
         _isRunning = false;
         _timer?.Dispose();
-        return Task.CompletedTask;
+        await WriteStateAsync();
     }
 
     async Task PerformCatchUp(object arg)
@@ -106,7 +106,7 @@ public class CatchUp : ObserverWorker, ICatchUp
             foreach (var @event in cursor.Current)
             {
                 if (!_isRunning) break;
-                await Handle(@event, false);
+                await Handle(@event);
             }
         }
 

--- a/Source/Kernel/Grains/Observation/ObserverSupervisor.Rewinding.cs
+++ b/Source/Kernel/Grains/Observation/ObserverSupervisor.Rewinding.cs
@@ -19,7 +19,7 @@ public partial class ObserverSupervisor
         State.RunningState = ObserverRunningState.Rewinding;
         State.NextEventSequenceNumber = EventSequenceNumber.First;
 
-        if (disconnected || SubscriberType is null)
+        if (disconnected || !CurrentSubscription.IsSubscribed)
         {
             await WriteStateAsync();
             return;
@@ -37,7 +37,7 @@ public partial class ObserverSupervisor
             _logger.OffsetIsAtTail(_observerId, _microserviceId, _eventSequenceId, _tenantId);
             State.RunningState = ObserverRunningState.TailOfReplay;
             await WriteStateAsync();
-            await Subscribe(SubscriberType!, State.EventTypes);
+            await Subscribe(CurrentSubscription.SubscriberType!, State.EventTypes);
             return;
         }
 
@@ -100,7 +100,7 @@ public partial class ObserverSupervisor
             await UnsubscribeStream();
             if (!State.IsDisconnected)
             {
-                await Subscribe(SubscriberType!, State.EventTypes);
+                await Subscribe(CurrentSubscription.SubscriberType!, State.EventTypes);
             }
         }
     }

--- a/Source/Kernel/Grains/Observation/ObserverSupervisor.Subscribing.cs
+++ b/Source/Kernel/Grains/Observation/ObserverSupervisor.Subscribing.cs
@@ -38,6 +38,8 @@ public partial class ObserverSupervisor
         IEnumerable<EventType> eventTypes,
         object? subscriberArgs = default)
     {
+        await ReadStateAsync();
+
         _logger.Subscribing(_observerId, subscriberType, _microserviceId, _eventSequenceId, _tenantId);
         SubscriberType = subscriberType;
         SubscriberArgs = subscriberArgs;
@@ -106,6 +108,6 @@ public partial class ObserverSupervisor
             return Task.CompletedTask;
         }
 
-        return Handle(@event, true);
+        return Handle(@event);
     }
 }

--- a/Source/Kernel/Grains/Observation/ObserverSupervisor.Subscribing.cs
+++ b/Source/Kernel/Grains/Observation/ObserverSupervisor.Subscribing.cs
@@ -19,8 +19,7 @@ public partial class ObserverSupervisor
     /// <inheritdoc/>
     public async Task Unsubscribe()
     {
-        SubscriberType = null!;
-        SubscriberArgs = null!;
+        CurrentSubscription = ObserverSubscription.Unsubscribed;
         _logger.Unsubscribing(_observerId, _microserviceId, _eventSequenceId, _tenantId);
         await StopAnyRunningCatchup();
         State.RunningState = ObserverRunningState.Disconnected;
@@ -41,8 +40,7 @@ public partial class ObserverSupervisor
         await ReadStateAsync();
 
         _logger.Subscribing(_observerId, subscriberType, _microserviceId, _eventSequenceId, _tenantId);
-        SubscriberType = subscriberType;
-        SubscriberArgs = subscriberArgs;
+        CurrentSubscription = new(subscriberType, subscriberArgs!);
 
         if (State.RunningState == ObserverRunningState.Rewinding)
         {

--- a/Source/Kernel/Grains/Observation/ObserverSupervisor.cs
+++ b/Source/Kernel/Grains/Observation/ObserverSupervisor.cs
@@ -128,8 +128,10 @@ public partial class ObserverSupervisor : ObserverWorker, IObserverSupervisor, I
         await WriteStateAsync();
     }
 
+    #pragma warning disable CA1721 // Property names should not match get methods
     /// <inheritdoc/>
     public Task<ObserverSubscription> GetCurrentSubscription() => Task.FromResult(CurrentSubscription);
+    #pragma warning restore CA1721 // Property names should not match get methods
 
     /// <inheritdoc/>
     public async Task NotifyCatchUpComplete()

--- a/Source/Kernel/Grains/Observation/ObserverSupervisor.cs
+++ b/Source/Kernel/Grains/Observation/ObserverSupervisor.cs
@@ -107,15 +107,16 @@ public partial class ObserverSupervisor : ObserverWorker, IObserverSupervisor, I
     {
         _logger.Deactivating(_observerId, _eventSequenceId, _microserviceId, _tenantId, _sourceMicroserviceId, _sourceTenantId);
 
-        await StopAnyRunningCatchup();
-        State.RunningState = ObserverRunningState.Disconnected;
-        await WriteStateAsync();
         await UnsubscribeStream();
 
         if (_recoverReminder is not null)
         {
             await UnregisterReminder(_recoverReminder);
         }
+
+        await StopAnyRunningCatchup();
+        State.RunningState = ObserverRunningState.Disconnected;
+        await WriteStateAsync();
     }
 
     /// <inheritdoc/>
@@ -152,6 +153,7 @@ public partial class ObserverSupervisor : ObserverWorker, IObserverSupervisor, I
     }
 
     Task StartCatchup() => GrainFactory.GetGrain<ICatchUp>(_observerId, keyExtension: _observerKey).Start(SubscriberType, SubscriberArgs);
+
     async Task StopAnyRunningCatchup()
     {
         if (State.RunningState != ObserverRunningState.CatchingUp)

--- a/Source/Kernel/Grains/Observation/ObserverSupervisor.cs
+++ b/Source/Kernel/Grains/Observation/ObserverSupervisor.cs
@@ -129,6 +129,9 @@ public partial class ObserverSupervisor : ObserverWorker, IObserverSupervisor, I
     }
 
     /// <inheritdoc/>
+    public Task<ObserverSubscription> GetCurrentSubscription() => Task.FromResult(CurrentSubscription);
+
+    /// <inheritdoc/>
     public async Task NotifyCatchUpComplete()
     {
         await ReadStateAsync();
@@ -152,7 +155,7 @@ public partial class ObserverSupervisor : ObserverWorker, IObserverSupervisor, I
         await HandleReminderRegistration();
     }
 
-    Task StartCatchup() => GrainFactory.GetGrain<ICatchUp>(_observerId, keyExtension: _observerKey).Start(SubscriberType, SubscriberArgs);
+    Task StartCatchup() => GrainFactory.GetGrain<ICatchUp>(_observerId, keyExtension: _observerKey).Start(CurrentSubscription);
 
     async Task StopAnyRunningCatchup()
     {

--- a/Source/Kernel/Grains/Observation/ObserverWorker.cs
+++ b/Source/Kernel/Grains/Observation/ObserverWorker.cs
@@ -26,12 +26,7 @@ public abstract class ObserverWorker : Grain
     /// <summary>
     /// Gets or sets the subscriber type.
     /// </summary>
-    protected Type SubscriberType { get; set; } = typeof(IObserverSubscriber);
-
-    /// <summary>
-    /// Gets or sets any subscriber arguments.
-    /// </summary>
-    protected object? SubscriberArgs { get; set; }
+    protected ObserverSubscription CurrentSubscription { get; set; } = ObserverSubscription.Unsubscribed;
 
     /// <summary>
     /// Gets the <see cref="ObserverState"/>.
@@ -71,7 +66,7 @@ public abstract class ObserverWorker : Grain
     /// <summary>
     /// Gets a value indicating whether or not the observer is active.
     /// </summary>
-    protected bool IsActive => !State.IsDisconnected && SubscriberType is not null && SubscriberType != typeof(IObserverSubscriber);
+    protected bool IsActive => !State.IsDisconnected && CurrentSubscription.IsSubscribed;
 
     /// <summary>
     /// Gets the <see cref="IObserverSupervisor"/>.
@@ -197,8 +192,8 @@ public abstract class ObserverWorker : Grain
             SourceMicroserviceId,
             SourceTenantId);
 
-        var subscriber = (GrainFactory.GetGrain(SubscriberType, ObserverId, key) as IObserverSubscriber)!;
-        return subscriber.OnNext(@event, new(SubscriberArgs!));
+        var subscriber = (GrainFactory.GetGrain(CurrentSubscription.SubscriberType, ObserverId, key) as IObserverSubscriber)!;
+        return subscriber.OnNext(@event, new(CurrentSubscription.Arguments));
     }
 
     /// <summary>

--- a/Source/Kernel/Grains/Observation/ObserverWorker.cs
+++ b/Source/Kernel/Grains/Observation/ObserverWorker.cs
@@ -31,7 +31,7 @@ public abstract class ObserverWorker : Grain
     /// <summary>
     /// Gets or sets any subscriber arguments.
     /// </summary>
-    protected object? SubscriberArgs { get; set; }
+    protected object? SubscriberArgs { get; set; }
 
     /// <summary>
     /// Gets the <see cref="ObserverState"/>.
@@ -121,9 +121,8 @@ public abstract class ObserverWorker : Grain
     /// Handle an <see cref="AppendedEvent"/>.
     /// </summary>
     /// <param name="event">The <see cref="AppendedEvent"/> to handle.</param>
-    /// <param name="setLastHandled">Whether or not to set last handled.</param>
     /// <returns>Awaitable task.</returns>
-    public async Task Handle(AppendedEvent @event, bool setLastHandled = false)
+    public async Task Handle(AppendedEvent @event)
     {
         var failed = false;
         var exceptionMessages = Enumerable.Empty<string>();
@@ -151,9 +150,8 @@ public abstract class ObserverWorker : Grain
                         return;
                     }
                 }
-
                 State.NextEventSequenceNumber = @event.Metadata.SequenceNumber + 1;
-                if (setLastHandled)
+                if (State.LastHandled < @event.Metadata.SequenceNumber)
                 {
                     State.LastHandled = @event.Metadata.SequenceNumber;
                 }

--- a/Source/Kernel/MongoDB/Observation/CatchUpStorageProvider.cs
+++ b/Source/Kernel/MongoDB/Observation/CatchUpStorageProvider.cs
@@ -38,7 +38,8 @@ public class CatchUpStorageProvider : ObserverStorageProvider
 
         var state = (ObserverState)grainState.State;
         var update = Builders<ObserverState>.Update
-            .Set(_ => _.NextEventSequenceNumber, state.NextEventSequenceNumber);
+            .Set(_ => _.NextEventSequenceNumber, state.NextEventSequenceNumber)
+            .Set(_ => _.LastHandled, state.LastHandled);
 
         await Collection.UpdateOneAsync(
             _ => _.Id == key,

--- a/Specifications/Kernel/Grains/Observation/for_CatchUp/when_catching_up_twice.cs
+++ b/Specifications/Kernel/Grains/Observation/for_CatchUp/when_catching_up_twice.cs
@@ -16,8 +16,8 @@ public class when_catching_up_twice : given.a_catch_up_worker_with_two_pending_e
 
     async Task Because()
     {
-        await catch_up.Start(typeof(ObserverSubscriber));
-        await catch_up.Start(typeof(ObserverSubscriber));
+        await catch_up.Start(new(typeof(ObserverSubscriber), null!));
+        await catch_up.Start(new(typeof(ObserverSubscriber), null!));
     }
 
     [Fact] void should_not_start_more_than_once() => timer_registry.Verify(_ => _.RegisterTimer(grain, IsAny<Func<object, Task>>(), IsAny<object>(), IsAny<TimeSpan>(), IsAny<TimeSpan>()), Once);

--- a/Specifications/Kernel/Grains/Observation/for_CatchUp/when_catching_up_with_failure.cs
+++ b/Specifications/Kernel/Grains/Observation/for_CatchUp/when_catching_up_with_failure.cs
@@ -12,7 +12,7 @@ public class when_catching_up_with_failure : given.a_catch_up_worker_with_two_pe
             .Returns(Task.FromResult(ObserverSubscriberResult.Failed));
     }
 
-    Task Because() => catch_up.Start(typeof(ObserverSubscriber));
+    Task Because() => catch_up.Start(new(typeof(ObserverSubscriber), null!));
 
     [Fact] void should_notify_supervisor_that_partition_has_failed_for_second_event() => supervisor.Verify(_ => _.PartitionFailed(second_appended_event, IsAny<IEnumerable<string>>(), IsAny<string>()), Once);
     [Fact] void should_notify_supervisor_that_catch_up_is_complete() => supervisor.Verify(_ => _.NotifyCatchUpComplete(), Once);

--- a/Specifications/Kernel/Grains/Observation/for_CatchUp/when_catching_up_with_no_events_to_catch_up_to.cs
+++ b/Specifications/Kernel/Grains/Observation/for_CatchUp/when_catching_up_with_no_events_to_catch_up_to.cs
@@ -6,7 +6,7 @@ namespace Aksio.Cratis.Kernel.Grains.Observation.for_CatchUp;
 public class when_catching_up_with_no_events_to_catch_up_to : given.a_catch_up_worker
 {
 
-    Task Because() => catch_up.Start(typeof(ObserverSubscriber));
+    Task Because() => catch_up.Start(new(typeof(ObserverSubscriber), null!));
 
     [Fact] void should_notify_supervisor_that_catch_up_is_complete() => supervisor.Verify(_ => _.NotifyCatchUpComplete(), Once);
 }

--- a/Specifications/Kernel/Grains/Observation/for_CatchUp/when_catching_up_with_two_events_to_catch_up_with.cs
+++ b/Specifications/Kernel/Grains/Observation/for_CatchUp/when_catching_up_with_two_events_to_catch_up_with.cs
@@ -5,7 +5,7 @@ namespace Aksio.Cratis.Kernel.Grains.Observation.for_CatchUp;
 
 public class when_catching_up_with_two_events_to_catch_up_with : given.a_catch_up_worker_with_two_pending_events
 {
-    Task Because() => catch_up.Start(typeof(ObserverSubscriber), subscriber_args);
+    Task Because() => catch_up.Start(new(typeof(ObserverSubscriber), subscriber_args));
 
     [Fact] void should_call_on_next_for_first_event() => subscriber.Verify(_ => _.OnNext(first_appended_event, new(subscriber_args)), Once);
     [Fact] void should_call_on_next_for_second_event() => subscriber.Verify(_ => _.OnNext(second_appended_event, new(subscriber_args)), Once);

--- a/Specifications/Kernel/Grains/Observation/for_ObserverSupervisor/when_subscribing/and_events_are_in_sequence/with_observer_being_in_catchup.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverSupervisor/when_subscribing/and_events_are_in_sequence/with_observer_being_in_catchup.cs
@@ -14,7 +14,7 @@ public class with_observer_being_in_catchup : given.an_observer_and_two_event_ty
 
     async Task Because() => await observer.Subscribe<ObserverSubscriber>(event_types, subscriber_args);
 
-    [Fact] void should_initiate_catchup() => catch_up.Verify(_ => _.Start(IsAny<Type>(), subscriber_args), Once);
+    [Fact] void should_initiate_catchup() => catch_up.Verify(_ => _.Start(IsAny<ObserverSubscription>()), Once);
     [Fact] void should_not_subscribe_to_stream() => sequence_stream.Verify(_ => _.SubscribeAsync(IsAny<IAsyncObserver<AppendedEvent>>(), IsAny<StreamSequenceToken>(), IsAny<StreamFilterPredicate>(), IsAny<object>()), Never);
     [Fact] void should_not_forward_event_to_observer_subscriber() => subscriber.Verify(_ => _.OnNext(appended_event, IsAny<ObserverSubscriberContext>()), Never);
     [Fact] void should_not_set_offset_to_next_event_sequence() => state_on_write.NextEventSequenceNumber.Value.ShouldEqual(appended_event.Metadata.SequenceNumber.Value);

--- a/Specifications/Kernel/Grains/Observation/for_ObserverSupervisor/when_subscribing/and_observer_is_new.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverSupervisor/when_subscribing/and_observer_is_new.cs
@@ -16,5 +16,5 @@ public class and_observer_is_new : given.an_observer_and_two_event_types
     async Task Because() => await observer.Subscribe<ObserverSubscriber>(event_types, subscriber_args);
 
     [Fact] void should_set_state_to_catching_up() => state_on_write.RunningState.ShouldEqual(ObserverRunningState.CatchingUp);
-    [Fact] void should_initiate_catchup() => catch_up.Verify(_ => _.Start(typeof(ObserverSubscriber), subscriber_args), Once);
+    [Fact] void should_initiate_catchup() => catch_up.Verify(_ => _.Start(new(typeof(ObserverSubscriber), subscriber_args)), Once);
 }

--- a/Specifications/Kernel/Grains/Observation/for_ObserverSupervisor/when_subscribing/and_sequence_is_ahead.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverSupervisor/when_subscribing/and_sequence_is_ahead.cs
@@ -13,5 +13,5 @@ public class and_sequence_is_ahead : given.an_observer_and_two_event_types
     async Task Because() => await observer.Subscribe<ObserverSubscriber>(event_types, subscriber_args);
 
     [Fact] void should_set_state_to_catching_up() => state_on_write.RunningState.ShouldEqual(ObserverRunningState.CatchingUp);
-    [Fact] void should_initiate_catchup() => catch_up.Verify(_ => _.Start(typeof(ObserverSubscriber), subscriber_args), Once);
+    [Fact] void should_initiate_catchup() => catch_up.Verify(_ => _.Start(new(typeof(ObserverSubscriber), subscriber_args)), Once);
 }

--- a/Specifications/Kernel/Grains/Observation/for_ObserverWorker/ObserverWorkerImplementation.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverWorker/ObserverWorkerImplementation.cs
@@ -41,6 +41,6 @@ public class ObserverWorkerImplementation : ObserverWorker
     public void SetEventSequenceId(EventSequenceId eventSequenceId) => _eventSequenceId = eventSequenceId;
     public void SetSourceMicroserviceId(MicroserviceId sourceMicroserviceId) => _sourceMicroserviceId = sourceMicroserviceId;
     public void SetSourceTenantId(TenantId sourceTenantId) => _sourceTenantId = sourceTenantId;
-    public void SetSubscriberType(Type subscriberType) => SubscriberType = subscriberType;
+    public void SetCurrentSubscription(ObserverSubscription subscription) => CurrentSubscription = subscription;
 }
 

--- a/Specifications/Kernel/Grains/Observation/for_ObserverWorker/given/an_observer_worker.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverWorker/given/an_observer_worker.cs
@@ -56,7 +56,7 @@ public class an_observer_worker : GrainSpecification
             persistent_state.Object,
             Mock.Of<ILogger<ObserverWorker>>());
 
-        worker.SetSubscriberType(typeof(ObserverSubscriber));
+        worker.SetCurrentSubscription(new(typeof(ObserverSubscriber), null!));
 
         return worker;
     }

--- a/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_event_should_be_handled.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_event_should_be_handled.cs
@@ -16,8 +16,9 @@ public class and_event_should_be_handled : given.an_observer_worker
         @event = new AppendedEvent(EventMetadata.EmptyWithEventSequenceNumber(sequence_number), EventContext.Empty with { EventSourceId = Guid.NewGuid() }, new System.Dynamic.ExpandoObject());
     }
 
-    Task Because() => worker.Handle(@event, false);
+    Task Because() => worker.Handle(@event);
 
     [Fact] void should_call_the_subscriber() => subscriber.Verify(_ => _.OnNext(@event, IsAny<ObserverSubscriberContext>()), Once);
     [Fact] void should_move_the_sequence_number() => state.NextEventSequenceNumber.ShouldEqual(sequence_number + 1);
+    [Fact] void should_set_last_handled() => state.LastHandled.ShouldEqual(sequence_number);
 }

--- a/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_event_should_be_handled_but_has_handled_before.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_event_should_be_handled_but_has_handled_before.cs
@@ -3,21 +3,25 @@
 
 namespace Aksio.Cratis.Kernel.Grains.Observation.for_ObserverWorker.when_handling;
 
-public class and_subscriber_is_disconnected : given.an_observer_worker
+public class and_event_should_be_handled_but_has_handled_before : given.an_observer_worker
 {
     AppendedEvent @event;
     EventSequenceNumber sequence_number;
+    EventSequenceNumber last_handled;
 
     void Establish()
     {
         state.RunningState = ObserverRunningState.Active;
         sequence_number = (ulong)Random.Shared.Next();
         state.NextEventSequenceNumber = sequence_number;
+        state.LastHandled = last_handled = sequence_number + 1;
+
         @event = new AppendedEvent(EventMetadata.EmptyWithEventSequenceNumber(sequence_number), EventContext.Empty with { EventSourceId = Guid.NewGuid() }, new System.Dynamic.ExpandoObject());
-        subscriber.Setup(_ => _.OnNext(IsAny<AppendedEvent>(), IsAny<ObserverSubscriberContext>())).Returns(Task.FromResult(ObserverSubscriberResult.Disconnected));
     }
 
     Task Because() => worker.Handle(@event);
 
-    [Fact] void should_not_move_the_sequence_number() => state.NextEventSequenceNumber.ShouldEqual(sequence_number);
+    [Fact] void should_call_the_subscriber() => subscriber.Verify(_ => _.OnNext(@event, IsAny<ObserverSubscriberContext>()), Once);
+    [Fact] void should_move_the_sequence_number() => state.NextEventSequenceNumber.ShouldEqual(sequence_number + 1);
+    [Fact] void should_not_set_last_handled() => state.LastHandled.ShouldEqual(last_handled);
 }

--- a/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_observer_is_disconnected.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_observer_is_disconnected.cs
@@ -16,7 +16,7 @@ public class and_observer_is_disconnected : given.an_observer_worker
         state.NextEventSequenceNumber = expected_sequence_number;
     }
 
-    Task Because() => worker.Handle(@event, false);
+    Task Because() => worker.Handle(@event);
 
     [Fact] void should_not_call_the_subscriber() => subscriber.VerifyNoOtherCalls();
     [Fact] void should_not_move_the_sequence_number() => state.NextEventSequenceNumber.ShouldEqual(expected_sequence_number);

--- a/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_partition_for_appended_event_is_failed.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_partition_for_appended_event_is_failed.cs
@@ -17,7 +17,7 @@ public class and_partition_for_appended_event_is_failed : given.an_observer_work
         state.FailPartition(@event.Context.EventSourceId, @event.Metadata.SequenceNumber, Array.Empty<string>(), string.Empty);
     }
 
-    Task Because() => worker.Handle(@event, false);
+    Task Because() => worker.Handle(@event);
 
     [Fact] void should_not_call_the_subscriber() => subscriber.VerifyNoOtherCalls();
     [Fact] void should_move_the_sequence_number() => state.NextEventSequenceNumber.ShouldEqual(sequence_number + 1);

--- a/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_subscriber_is_failed.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_subscriber_is_failed.cs
@@ -17,7 +17,7 @@ public class and_subscriber_is_failed : given.an_observer_worker
         subscriber.Setup(_ => _.OnNext(IsAny<AppendedEvent>(), IsAny<ObserverSubscriberContext>())).Returns(Task.FromResult(ObserverSubscriberResult.Failed));
     }
 
-    Task Because() => worker.Handle(@event, false);
+    Task Because() => worker.Handle(@event);
 
     [Fact] void should_fail_the_partition() => supervisor.Verify(_ => _.PartitionFailed(@event, IsAny<IEnumerable<string>>(), IsAny<string>()), Once);
     [Fact] void should_move_the_sequence_number() => state.NextEventSequenceNumber.ShouldEqual(sequence_number + 1);

--- a/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_subscriber_is_null.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_subscriber_is_null.cs
@@ -17,7 +17,7 @@ public class and_subscriber_is_null : given.an_observer_worker
         state.NextEventSequenceNumber = expected_sequence_number;
     }
 
-    Task Because() => worker.Handle(@event, false);
+    Task Because() => worker.Handle(@event);
 
     [Fact] void should_not_call_the_subscriber() => subscriber.VerifyNoOtherCalls();
     [Fact] void should_not_move_the_sequence_number() => state.NextEventSequenceNumber.ShouldEqual(expected_sequence_number);

--- a/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_subscriber_is_of_default_type.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_subscriber_is_of_default_type.cs
@@ -17,7 +17,7 @@ public class and_subscriber_is_of_default_type : given.an_observer_worker
         state.NextEventSequenceNumber = expected_sequence_number;
     }
 
-    Task Because() => worker.Handle(@event, false);
+    Task Because() => worker.Handle(@event);
 
     [Fact] void should_not_call_the_subscriber() => subscriber.VerifyNoOtherCalls();
     [Fact] void should_not_move_the_sequence_number() => state.NextEventSequenceNumber.ShouldEqual(expected_sequence_number);

--- a/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_subscriber_is_of_default_type.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_subscriber_is_of_default_type.cs
@@ -11,7 +11,7 @@ public class and_subscriber_is_of_default_type : given.an_observer_worker
     void Establish()
     {
         state.RunningState = ObserverRunningState.Active;
-        worker.SetSubscriberType(typeof(IObserverSubscriber));
+        worker.SetCurrentSubscription(new(typeof(IObserverSubscriber), null));
         @event = AppendedEvent.EmptyWithEventType(EventType.Unknown);
         expected_sequence_number = (ulong)Random.Shared.Next();
         state.NextEventSequenceNumber = expected_sequence_number;

--- a/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_subscriber_is_unsubscribed.cs
+++ b/Specifications/Kernel/Grains/Observation/for_ObserverWorker/when_handling/and_subscriber_is_unsubscribed.cs
@@ -3,7 +3,7 @@
 
 namespace Aksio.Cratis.Kernel.Grains.Observation.for_ObserverWorker.when_handling;
 
-public class and_subscriber_is_null : given.an_observer_worker
+public class and_subscriber_is_unsubscribed : given.an_observer_worker
 {
     AppendedEvent @event;
     EventSequenceNumber expected_sequence_number;
@@ -11,7 +11,7 @@ public class and_subscriber_is_null : given.an_observer_worker
     void Establish()
     {
         state.RunningState = ObserverRunningState.Active;
-        worker.SetSubscriberType(null!);
+        worker.SetCurrentSubscription(ObserverSubscription.Unsubscribed);
         @event = AppendedEvent.EmptyWithEventType(EventType.Unknown);
         expected_sequence_number = (ulong)Random.Shared.Next();
         state.NextEventSequenceNumber = expected_sequence_number;


### PR DESCRIPTION
### Fixed

- Fixing so that `LastHandled`get set during catch-up if the `LastHandled` is less than the current sequence number on the event.
- Read the state when subscribing an observer. Since we have worker grains (CatchUp) that will update parts of the state, we need to be sure we have the correct state when subscribing. This could be because a client is disconnected and then reconnected while a catchup is running.
- Improving reliability on state persistence by making sure we do the tasks on unsubscribe / deactivate in the correct order.
- Encapuslating observer subscription and adding a method for getting current subscription on the `IObserverSupervisor`.