### PR TITLE
Checking strings against strings - not string against JSON object

### DIFF
--- a/Source/Kernel/Engines/Projections/Definitions/ProjectionDefinitions.cs
+++ b/Source/Kernel/Engines/Projections/Definitions/ProjectionDefinitions.cs
@@ -70,7 +70,7 @@ public class ProjectionDefinitions : IProjectionDefinitions
         }
         var incoming = _projectionSerializer.Serialize(projectionDefinition);
         var existing = _projectionSerializer.Serialize(_definitions[projectionDefinition.Identifier]);
-        return !incoming.ToString().Equals(existing);
+        return !incoming.ToString().Equals(existing.ToString());
     }
 
     async Task PopulateIfMissing(ProjectionId projectionId)


### PR DESCRIPTION
### Fixed

- Projection has changed fixed from doing `.Equals()` on JSON object against a JSON string to both being JSON strings.
