### PR TITLE
Fix/conversion

### DIFF
--- a/Source/Fundamentals/Json/ExpandoObjectConverter.cs
+++ b/Source/Fundamentals/Json/ExpandoObjectConverter.cs
@@ -113,7 +113,7 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
         return ConvertToJsonNodeFromUnknownFormat(value, schemaProperty);
     }
 
-    object? ConvertFromJsonNode(JsonNode jsonNode, JsonSchemaProperty schemaProperty)
+    object? ConvertFromJsonNode(JsonNode jsonNode, JsonSchema schemaProperty)
     {
         if (jsonNode is JsonObject childObject)
         {
@@ -124,7 +124,7 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
 
         if (jsonNode is JsonArray array)
         {
-            return array.Select(_ => ConvertFromJsonNode(_!, schemaProperty)).ToArray();
+            return array.Select(_ => ConvertFromJsonNode(_!, schemaProperty.Item)).ToArray();
         }
 
         if (_typeFormats.IsKnown(schemaProperty.Format))
@@ -134,7 +134,7 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
         return ConvertJsonValueFromUnknownFormat(jsonNode, schemaProperty);
     }
 
-    object? ConvertJsonValueFromUnknownFormat(JsonNode jsonNode, JsonSchemaProperty schemaProperty)
+    object? ConvertJsonValueFromUnknownFormat(JsonNode jsonNode, JsonSchema schemaProperty)
     {
         if (jsonNode is null)
         {
@@ -225,18 +225,11 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
 
         if (value is JsonArray array)
         {
-            return array.Select(_ => ConvertUnknownSchemaTypeToClrType(value)).ToArray();
+            return array.Select(_ => ConvertUnknownSchemaTypeToClrType(_!)).ToArray();
         }
 
         var jsonValue = value.AsValue();
-
-        var element = value.GetValue<JsonElement>();
-        if (element.TryGetValue(out var result))
-        {
-            return result;
-        }
-
-        return null;
+        return value.GetValue<object>();
     }
 
     object? ConvertJsonValueToSchemaType(JsonNode jsonNode, JsonSchema schemaProperty)

--- a/Source/Fundamentals/Json/ExpandoObjectConverter.cs
+++ b/Source/Fundamentals/Json/ExpandoObjectConverter.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Dynamic;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aksio.Cratis.Schemas;
 using Aksio.Cratis.Types;

--- a/Source/Kernel/MongoDB/Projections/MongoDBProjectionSink.cs
+++ b/Source/Kernel/MongoDB/Projections/MongoDBProjectionSink.cs
@@ -399,9 +399,9 @@ public class MongoDBProjectionSink : IProjectionSink, IDisposable
                 case ArrayProperty:
                     {
                         var collectionIdentifier = currentPropertyPath.LastSegment.Value.ToCamelCase();
-                        var arrayIndexer = arrayIndexers.GetFor(currentPropertyPath);
-                        if (arrayIndexer is not null)
+                        if (arrayIndexers.HasFor(currentPropertyPath))
                         {
+                            var arrayIndexer = arrayIndexers.GetFor(currentPropertyPath);
                             propertyBuilder.AppendFormat("{0}.$[{1}]", segment.Value, collectionIdentifier);
                             var filter = new ExpandoObject();
                             ((IDictionary<string, object?>)filter).Add($"{collectionIdentifier}.{arrayIndexer.IdentifierProperty}", arrayIndexer.Identifier);

--- a/Specifications/Fundamentals/Json/for_ExpandoObjectConverter/TargetType.cs
+++ b/Specifications/Fundamentals/Json/for_ExpandoObjectConverter/TargetType.cs
@@ -52,4 +52,6 @@ public record TargetType(
     DateOnly DateOnlyValue,
     TimeOnly TimeOnlyValue,
     OtherType Reference,
-    IEnumerable<OtherType> Children);
+    IEnumerable<OtherType> Children,
+    IEnumerable<string> StringArray,
+    IEnumerable<int> IntArray);

--- a/Specifications/Fundamentals/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
+++ b/Specifications/Fundamentals/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
@@ -19,7 +19,7 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
             ["intValue"] = 43,
             ["floatValue"] = 43.43,
             ["doubleValue"] = 43.43,
-            ["guidValue"] = Guid.Parse("251b9fbe-83d4-4306-9a5d-9d0e7d4dd456"),
+            ["guidValue"] = Guid.Parse("251b9fbe-83d4-4306-9a5d-9d0e7d4dd456")
         };
 
         child = new JsonObject
@@ -45,7 +45,9 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
             ["dateOnlyValue"] = DateTime.Parse("2022-10-31T14:51:32.8450000Z"),
             ["timeOnlyValue"] = DateTime.Parse("2022-10-31T14:51:32.8450000Z"),
             ["reference"] = reference,
-            ["children"] = new JsonArray(child)
+            ["children"] = new JsonArray(child),
+            ["stringArray"] = new JsonArray { "first", "second" },
+            ["intArray"] = new JsonArray { 42, 43 }
         };
     }
 
@@ -75,6 +77,10 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
     [Fact] void should_set_top_level_date_only_value_to_hold_correct_value() => ((DateOnly)result.dateOnlyValue).ShouldEqual(DateOnly.FromDateTime(source["dateOnlyValue"].GetValue<DateTime>()));
     [Fact] void should_set_top_level_time_only_value_to_be_of_date_time_offset_type() => ((object)result.timeOnlyValue).ShouldBeOfExactType<TimeOnly>();
     [Fact] void should_set_top_level_time_only_value_to_hold_correct_value() => ((TimeOnly)result.timeOnlyValue).ShouldEqual(TimeOnly.FromDateTime(source["timeOnlyValue"].GetValue<DateTime>()));
+    [Fact] void should_set_top_level_string_array_first_item() => ((string)result.stringArray[0]).ShouldEqual("first");
+    [Fact] void should_set_top_level_string_array_second_item() => ((string)result.stringArray[1]).ShouldEqual("second");
+    [Fact] void should_set_top_level_int_array_first_item() => ((int)result.intArray[0]).ShouldEqual(42);
+    [Fact] void should_set_top_level_int_array_second_item() => ((int)result.intArray[1]).ShouldEqual(43);
 
     [Fact] void should_reference_level_int_value_to_be_of_int_type() => ((object)result.reference.intValue).ShouldBeOfExactType<int>();
     [Fact] void should_reference_level_int_value_to_hold_correct_value() => ((int)result.reference.intValue).ShouldEqual(reference["intValue"].GetValue<int>());


### PR DESCRIPTION
### Fixed

- Fixing so we don't crash if there are no array indexers when projecting with arrays, set the properties instead rather than try to update specific part of array.
- Fixing conversion to `ExpandoObject` when JSON holds arrays of string or numbers and schema matches. This became null before.
