### PR TITLE
Fix/bson

### DIFF
--- a/Source/Extensions/MongoDB/BsonValueExtensions.cs
+++ b/Source/Extensions/MongoDB/BsonValueExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
 using System.Globalization;
 using Aksio.Cratis.Concepts;
 using Aksio.Cratis.Types;
@@ -197,6 +198,16 @@ public static class BsonValueExtensions
         var type = (schemaProperty.Type == JsonObjectType.None && schemaProperty.HasReference) ?
                     schemaProperty.Reference.Type :
                     schemaProperty.Type;
+
+        if (type.HasFlag(JsonObjectType.Array) && value is IEnumerable enumerable)
+        {
+            var convertedArray = new BsonArray();
+            foreach (var item in enumerable)
+            {
+                convertedArray.Add(item.ToBsonValueBasedOnSchemaPropertyType(schemaProperty.Item));
+            }
+            return convertedArray;
+        }
 
         if (type.HasFlag(JsonObjectType.Null))
         {

--- a/Source/Kernel/Engines/Projections/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
+++ b/Source/Kernel/Engines/Projections/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Dynamic;
 using Aksio.Cratis.Events;
 using Aksio.Cratis.Properties;
+using Aksio.Cratis.Reflection;
 using Aksio.Cratis.Schemas;
 using Aksio.Cratis.Types;
 using NJsonSchema;
@@ -76,7 +77,7 @@ public class EventValueProviderExpressionResolvers : IEventValueProviderExpressi
             return TypeConversion.Convert(targetType, input);
         }
 
-        if (input is IEnumerable)
+        if (input.GetType().IsEnumerable())
         {
             var children = new List<object>();
             foreach (var child in (input as IEnumerable)!)


### PR DESCRIPTION
### Fixed

- MongoDB Projection sink now handles setting arrays directly without array indexers.
- Projections now support pulling array of primitives directly from the event and onto the target model.
