### PR TITLE
Fix/bugs

### DIFF
--- a/Documentation/clients/dotnet/events/observers.md
+++ b/Documentation/clients/dotnet/events/observers.md
@@ -17,13 +17,14 @@ The methods you add onto the class will be discovered by convention and the syst
 signatures, name of the method(s) can be anything:
 
 ```csharp
-void SynchronousMethodWithoutContext(MyEvent @event);
-void SynchronousMethodWithContext(MyEvent @event, EventContext context);
-Task AsynchronousMethodWithoutContext(MyEvent @event);
-Task AsynchronousMethodWithContext(MyEvent @event, EventContext context);
+public void SynchronousMethodWithoutContext(MyEvent @event);
+public void SynchronousMethodWithContext(MyEvent @event, EventContext context);
+public Task AsynchronousMethodWithoutContext(MyEvent @event);
+public Task AsynchronousMethodWithContext(MyEvent @event, EventContext context);
 ```
 
-> Note: Both public and non-public methods are supported.
+> Note: Only public methods are supported without any return types. Also worth noting is that you can't have
+> two methods handling the same event as the system would not know how to recover if one of them fails.
 
 ## Middlewares
 

--- a/Source/Clients/DotNET/Clients/ClientLifecycle.cs
+++ b/Source/Clients/DotNET/Clients/ClientLifecycle.cs
@@ -3,6 +3,7 @@
 
 using Aksio.Cratis.Execution;
 using Aksio.Cratis.Types;
+using Microsoft.Extensions.Logging;
 
 namespace Aksio.Cratis.Clients;
 
@@ -13,20 +14,25 @@ namespace Aksio.Cratis.Clients;
 public class ClientLifecycle : IClientLifecycle
 {
     readonly IInstancesOf<IParticipateInClientLifecycle> _participants;
+    readonly ILogger<ClientLifecycle> _logger;
 
     /// <inheritdoc/>
     public bool IsConnected { get; private set; }
 
     /// <inheritdoc/>
-    public ConnectionId ConnectionId { get; private set; }
+    public ConnectionId ConnectionId { get; private set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ClientLifecycle"/>.
     /// </summary>
     /// <param name="participants">The participants of the client lifecycle.</param>
-    public ClientLifecycle(IInstancesOf<IParticipateInClientLifecycle> participants)
+    /// <param name="logger">Logger for logging.</param>
+    public ClientLifecycle(
+        IInstancesOf<IParticipateInClientLifecycle> participants,
+        ILogger<ClientLifecycle> logger)
     {
         _participants = participants;
+        _logger = logger;
         ConnectionId = ConnectionId.New();
     }
 
@@ -34,14 +40,34 @@ public class ClientLifecycle : IClientLifecycle
     public async Task Connected()
     {
         IsConnected = true;
-        await Parallel.ForEachAsync(_participants, (participant, _) => new ValueTask(participant.ClientConnected()));
+        await Parallel.ForEachAsync(_participants, async (participant, _) =>
+        {
+            try
+            {
+                await new ValueTask(participant.ClientConnected());
+            }
+            catch (Exception ex)
+            {
+                _logger.ParticipantFailedDuringConnected(participant!.GetType().FullName ?? participant!.GetType().Name, ex);
+            }
+        });
     }
 
     /// <inheritdoc/>
     public async Task Disconnected()
     {
         IsConnected = false;
-        await Parallel.ForEachAsync(_participants, (participant, _) => new ValueTask(participant.ClientDisconnected()));
+        await Parallel.ForEachAsync(_participants, async (participant, _) =>
+        {
+            try
+            {
+                await new ValueTask(participant.ClientDisconnected());
+            }
+            catch (Exception ex)
+            {
+                _logger.ParticipantFailedDuringDisconnected(participant!.GetType().FullName ?? participant!.GetType().Name, ex);
+            }
+        });
         ConnectionId = ConnectionId.New();
     }
 }

--- a/Source/Clients/DotNET/Clients/ClientLifecycleLogMessages.cs
+++ b/Source/Clients/DotNET/Clients/ClientLifecycleLogMessages.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Aksio.Cratis.Clients;
+
+internal static partial class ClientLifecycleLogMessages
+{
+    [LoggerMessage(1, LogLevel.Error, "During the connected lifecycle event, the participant '{Participant}' failed")]
+    internal static partial void ParticipantFailedDuringConnected(this ILogger<ClientLifecycle> logger, string participant, Exception exception);
+
+    [LoggerMessage(2, LogLevel.Error, "During the disconnected lifecycle event, the participant '{Participant}' failed")]
+    internal static partial void ParticipantFailedDuringDisconnected(this ILogger<ClientLifecycle> logger, string participant, Exception exception);
+}

--- a/Source/Clients/DotNET/Observation/ObserverInvoker.cs
+++ b/Source/Clients/DotNET/Observation/ObserverInvoker.cs
@@ -34,9 +34,7 @@ public class ObserverInvoker : IObserverInvoker
         _middlewares = middlewares;
         _targetType = targetType;
 
-        // TODO: Make a choice; can we have multiple methods handling the same event -
-        // if so, make this either throw an exception if duplicates, or array of methods if allowed
-        _methodsByEventTypeId = targetType.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+        _methodsByEventTypeId = targetType.GetMethods(BindingFlags.Instance | BindingFlags.Public)
                                         .Where(_ => IsObservingMethod(_))
                                         .ToDictionary(_ => _eventTypes.GetEventTypeFor(_.GetParameters()[0].ParameterType), _ => _);
     }
@@ -71,7 +69,7 @@ public class ObserverInvoker : IObserverInvoker
 
     bool IsObservingMethod(MethodInfo methodInfo)
     {
-        var isObservingMethod = methodInfo.ReturnType.IsAssignableTo(typeof(Task)) ||
+        var isObservingMethod = (methodInfo.ReturnType.IsAssignableTo(typeof(Task)) && !methodInfo.ReturnType.IsGenericType)  ||
                                 methodInfo.ReturnType == typeof(void);
 
         if (!isObservingMethod) return false;

--- a/Source/Clients/DotNET/Observation/ObserverInvoker.cs
+++ b/Source/Clients/DotNET/Observation/ObserverInvoker.cs
@@ -69,7 +69,7 @@ public class ObserverInvoker : IObserverInvoker
 
     bool IsObservingMethod(MethodInfo methodInfo)
     {
-        var isObservingMethod = (methodInfo.ReturnType.IsAssignableTo(typeof(Task)) && !methodInfo.ReturnType.IsGenericType)  ||
+        var isObservingMethod = (methodInfo.ReturnType.IsAssignableTo(typeof(Task)) && !methodInfo.ReturnType.IsGenericType) ||
                                 methodInfo.ReturnType == typeof(void);
 
         if (!isObservingMethod) return false;

--- a/Source/Clients/DotNET/Projections/AddChildBuilder.cs
+++ b/Source/Clients/DotNET/Projections/AddChildBuilder.cs
@@ -52,6 +52,13 @@ public class AddChildBuilder<TParentModel, TChildModel, TEvent> : IAddChildBuild
     }
 
     /// <inheritdoc/>
+    public IAddChildBuilder<TChildModel, TEvent> UsingParentCompositeKey<TKeyType>(Action<ICompositeKeyBuilder<TKeyType, TEvent>> builderCallback)
+    {
+        _fromBuilder!.UsingParentCompositeKey<TKeyType>(builderCallback);
+        return this;
+    }
+
+    /// <inheritdoc/>
     public IAddChildBuilder<TChildModel, TEvent> UsingParentKeyFromContext<TProperty>(Expression<Func<TEvent, TProperty>> keyAccessor)
     {
         _fromBuilder!.UsingParentKeyFromContext(keyAccessor);

--- a/Source/Clients/DotNET/Projections/IAddChildBuilder.cs
+++ b/Source/Clients/DotNET/Projections/IAddChildBuilder.cs
@@ -39,6 +39,7 @@ public interface IAddChildBuilder<TChildModel, TEvent>
 
     /// <summary>
     /// Define what composite key based on properties on the event represents the parent key. This is typically used in child relationships to identify the parent model to
+    /// work with.
     /// </summary>
     /// <typeparam name="TKeyType">Type of key.</typeparam>
     /// <param name="builderCallback">Builder callback for building the composite key.</param>

--- a/Source/Clients/DotNET/Projections/IAddChildBuilder.cs
+++ b/Source/Clients/DotNET/Projections/IAddChildBuilder.cs
@@ -38,6 +38,14 @@ public interface IAddChildBuilder<TChildModel, TEvent>
     IAddChildBuilder<TChildModel, TEvent> UsingParentKey<TProperty>(Expression<Func<TEvent, TProperty>> keyAccessor);
 
     /// <summary>
+    /// Define what composite key based on properties on the event represents the parent key. This is typically used in child relationships to identify the parent model to
+    /// </summary>
+    /// <typeparam name="TKeyType">Type of key.</typeparam>
+    /// <param name="builderCallback">Builder callback for building the composite key.</param>
+    /// <returns>Builder continuation.</returns>
+    IAddChildBuilder<TChildModel, TEvent> UsingParentCompositeKey<TKeyType>(Action<ICompositeKeyBuilder<TKeyType, TEvent>> builderCallback);
+
+    /// <summary>
     /// Define what property on the event represents the parent key based on a property in the <see cref="EventContext"/>. This is typically used in child relationships to identify the parent model to
     /// work with.
     /// </summary>

--- a/Source/Clients/DotNET/Projections/IModelPropertiesBuilder.cs
+++ b/Source/Clients/DotNET/Projections/IModelPropertiesBuilder.cs
@@ -42,6 +42,7 @@ public interface IModelPropertiesBuilder<TModel, TEvent, TBuilder>
 
     /// <summary>
     /// Define what composite key based on properties on the event represents the parent key. This is typically used in child relationships to identify the parent model to
+    /// work with.
     /// </summary>
     /// <typeparam name="TKeyType">Type of key.</typeparam>
     /// <param name="builderCallback">Builder callback for building the composite key.</param>

--- a/Source/Clients/DotNET/Projections/IModelPropertiesBuilder.cs
+++ b/Source/Clients/DotNET/Projections/IModelPropertiesBuilder.cs
@@ -41,6 +41,14 @@ public interface IModelPropertiesBuilder<TModel, TEvent, TBuilder>
     TBuilder UsingParentKey<TProperty>(Expression<Func<TEvent, TProperty>> keyAccessor);
 
     /// <summary>
+    /// Define what composite key based on properties on the event represents the parent key. This is typically used in child relationships to identify the parent model to
+    /// </summary>
+    /// <typeparam name="TKeyType">Type of key.</typeparam>
+    /// <param name="builderCallback">Builder callback for building the composite key.</param>
+    /// <returns>Builder continuation.</returns>
+    TBuilder UsingParentCompositeKey<TKeyType>(Action<ICompositeKeyBuilder<TKeyType, TEvent>> builderCallback);
+
+    /// <summary>
     /// Define what property on the event represents the parent key based on a property in the <see cref="EventContext"/>. This is typically used in child relationships to identify the parent model to
     /// work with.
     /// </summary>

--- a/Source/Clients/DotNET/Projections/ModelPropertiesBuilder.cs
+++ b/Source/Clients/DotNET/Projections/ModelPropertiesBuilder.cs
@@ -56,6 +56,15 @@ public class ModelPropertiesBuilder<TModel, TEvent, TBuilder, TParentBuilder> : 
     }
 
     /// <inheritdoc/>
+    public TBuilder UsingParentCompositeKey<TKeyType>(Action<ICompositeKeyBuilder<TKeyType, TEvent>> builderCallback)
+    {
+        var compositeKeyBuilder = new CompositeKeyBuilder<TKeyType, TEvent>();
+        builderCallback(compositeKeyBuilder);
+        _parentKey = compositeKeyBuilder;
+        return (this as TBuilder)!;
+    }
+
+    /// <inheritdoc/>
     public TBuilder UsingParentKeyFromContext<TProperty>(Expression<Func<TEvent, TProperty>> keyAccessor)
     {
         _parentKey = new KeyBuilder(new EventContextPropertyExpression(keyAccessor.GetPropertyPath()));

--- a/Source/Kernel/Grains.Interfaces/Observation/ObserverState.cs
+++ b/Source/Kernel/Grains.Interfaces/Observation/ObserverState.cs
@@ -85,23 +85,9 @@ public class ObserverState
     }
 
     /// <summary>
-    /// Gets or sets the failed partitions for the observer.
-    /// </summary>
-    public IEnumerable<RecoveringFailedObserverPartition> RecoveringPartitions
-    {
-        get => _partitionsBeingRecovered;
-        set => _partitionsBeingRecovered = new(value);
-    }
-
-    /// <summary>
     /// Gets whether or not there are any failed partitions.
     /// </summary>
     public bool HasFailedPartitions => _failedPartitions.Count > 0;
-
-    /// <summary>
-    /// Gets whether or not there are any partitions being recovered.
-    /// </summary>
-    public bool IsRecoveringAnyPartition => _partitionsBeingRecovered.Count > 0;
 
     /// <summary>
     /// Gets whether or not the observer is in disconnected state. Meaning that there is no subscriber to it.
@@ -109,7 +95,6 @@ public class ObserverState
     public bool IsDisconnected => RunningState == ObserverRunningState.Disconnected;
 
     List<FailedPartition> _failedPartitions = new();
-    List<RecoveringFailedObserverPartition> _partitionsBeingRecovered = new();
 
     /// <summary>
     /// Add a failed partition.

--- a/Source/Workbench/API/events/store/observers/ObserverState.ts
+++ b/Source/Workbench/API/events/store/observers/ObserverState.ts
@@ -8,7 +8,6 @@ import { EventType } from './EventType';
 import { ObserverType } from './ObserverType';
 import { ObserverRunningState } from './ObserverRunningState';
 import { FailedPartition } from './FailedPartition';
-import { RecoveringFailedObserverPartition } from './RecoveringFailedObserverPartition';
 
 export class ObserverState {
 
@@ -42,14 +41,8 @@ export class ObserverState {
     @field(FailedPartition, true)
     failedPartitions!: FailedPartition[];
 
-    @field(RecoveringFailedObserverPartition, true)
-    recoveringPartitions!: RecoveringFailedObserverPartition[];
-
     @field(Boolean)
     hasFailedPartitions!: boolean;
-
-    @field(Boolean)
-    isRecoveringAnyPartition!: boolean;
 
     @field(Boolean)
     isDisconnected!: boolean;


### PR DESCRIPTION
### Added

- Adding support for composite keys for parent key definition for child definitions in projections.

### Fixed

- Adding logging of errors for a client lifecycle participant failure. (#768)
- Removing residues of recovering partitions on the observer state.
- Fixing observer method convention to not include methods that return a generic `Task<>`. (#767)
- Fixing observer method convention to not include non-public methods. (#767)


