### PR TITLE
Fix/observer-lifecycle

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,6 +86,7 @@
         "Swashbuckle",
         "tinycolor",
         "typeparam",
+        "Unmap",
         "upcaster",
         "upserted",
         "Xunit"

--- a/Source/Kernel/Grains.Interfaces/Observation/ObserverState.cs
+++ b/Source/Kernel/Grains.Interfaces/Observation/ObserverState.cs
@@ -80,7 +80,7 @@ public class ObserverState
     /// </summary>
     public IEnumerable<FailedPartition> FailedPartitions
     {
-        get => _failedPartitions.Where(_ => _.Partition is not null && _.Partition != string.Empty);
+        get => _failedPartitions;
         set => _failedPartitions = new(value);
     }
 

--- a/Source/Kernel/Grains.Interfaces/Observation/ObserverState.cs
+++ b/Source/Kernel/Grains.Interfaces/Observation/ObserverState.cs
@@ -80,7 +80,7 @@ public class ObserverState
     /// </summary>
     public IEnumerable<FailedPartition> FailedPartitions
     {
-        get => _failedPartitions;
+        get => _failedPartitions.Where(_ => _.Partition is not null && _.Partition != string.Empty);
         set => _failedPartitions = new(value);
     }
 

--- a/Source/Kernel/Grains/Observation/FailedPartitionSupervisor.cs
+++ b/Source/Kernel/Grains/Observation/FailedPartitionSupervisor.cs
@@ -70,6 +70,11 @@ public class FailedPartitionSupervisor : IChildStateProvider<FailedPartitionsSta
         string exceptionStackTrace,
         DateTimeOffset occurred)
     {
+        if (string.IsNullOrEmpty(partitionId))
+        {
+            return;
+        }
+
         if (_failedPartitions.Any(_ => _.Partition == partitionId))
             return;
         await StartRecovery(partitionId, sequenceNumber, exceptionMessages, exceptionStackTrace, occurred);

--- a/Source/Kernel/Grains/Observation/ObserverSupervisor.Subscribing.cs
+++ b/Source/Kernel/Grains/Observation/ObserverSupervisor.Subscribing.cs
@@ -51,7 +51,7 @@ public partial class ObserverSupervisor
             return;
         }
 
-        await _failedPartitionSupervisor.TryRecoveringAnyFailedPartitions();
+        TryRecoveringAnyFailedPartitions();
 
         await UnsubscribeStream();
 

--- a/Source/Kernel/Grains/Observation/ObserverSupervisor.cs
+++ b/Source/Kernel/Grains/Observation/ObserverSupervisor.cs
@@ -76,6 +76,9 @@ public partial class ObserverSupervisor : ObserverWorker, IObserverSupervisor
     {
         _observerId = this.GetPrimaryKey(out var keyAsString);
 
+        // Keep the Grain alive forever: Confirmed here: https://github.com/dotnet/orleans/issues/1721#issuecomment-216566448
+        DelayDeactivation(TimeSpan.MaxValue);
+
         _observerKey = ObserverKey.Parse(keyAsString);
         _eventSequenceId = _observerKey.EventSequenceId;
         State.EventSequenceId = _eventSequenceId;

--- a/Source/Kernel/MongoDB/Observation/ObserverStateClassMap.cs
+++ b/Source/Kernel/MongoDB/Observation/ObserverStateClassMap.cs
@@ -19,5 +19,6 @@ public class ObserverStateClassMap : IBsonClassMapFor<ObserverState>
     {
         classMap.AutoMap();
         classMap.MapIdProperty(_ => _.Id);
+        classMap.UnmapProperty(_ => _.FailedPartitions);
     }
 }

--- a/Source/Kernel/MongoDB/Observation/ObserverStorageProvider.cs
+++ b/Source/Kernel/MongoDB/Observation/ObserverStorageProvider.cs
@@ -71,16 +71,17 @@ public class ObserverStorageProvider : IGrainStorage
 
         var key = GetKeyFrom(observerKey, observerId);
         var cursor = await Collection.FindAsync(_ => _.Id == key);
-        grainState.State = await cursor.FirstOrDefaultAsync() ?? new ObserverState
+        var state = await cursor.FirstOrDefaultAsync() ?? new ObserverState
         {
             Id = key,
             EventSequenceId = eventSequenceId,
             ObserverId = observerId,
             NextEventSequenceNumber = EventSequenceNumber.First,
             LastHandled = EventSequenceNumber.First,
-            RunningState = ObserverRunningState.New,
-            FailedPartitions = failedPartitions
+            RunningState = ObserverRunningState.New
         };
+        state.FailedPartitions = failedPartitions;
+        grainState.State = state;
     }
 
     /// <inheritdoc/>

--- a/Source/Kernel/Shared/Observation/RecoverFailedPartitionState.cs
+++ b/Source/Kernel/Shared/Observation/RecoverFailedPartitionState.cs
@@ -25,7 +25,7 @@ public class RecoverFailedPartitionState
     /// <summary>
     /// Gets or sets the partition that is failed.
     /// </summary>
-    public EventSourceId Partition { get; set; } = EventSourceId.Unspecified;
+    public EventSourceId Partition { get; set; } = EventSourceId.Unspecified;
 
     /// <summary>
     /// Gets or sets the <see cref="EventSequenceId"/> the failed partition is on.
@@ -176,7 +176,7 @@ public class RecoverFailedPartitionState
     /// <returns><see cref="TimeSpan"/> representing time to next attempt.</returns>
     public TimeSpan GetNextAttemptSchedule()
     {
-        if(CurrentError == InitialError && NumberOfAttemptsOnCurrentError == 0)
+        if (CurrentError == InitialError && NumberOfAttemptsOnCurrentError == 0)
         {
             return TimeSpan.Zero;
         }
@@ -220,5 +220,8 @@ public class RecoverFailedPartitionState
     /// Indicates whether the state has been initialized.
     /// </summary>
     /// <returns>True if initialized, false otherwise.</returns>
-    public bool HasBeenInitialized() => CurrentError != EventSequenceNumber.Unavailable;
+    public bool HasBeenInitialized() =>
+        CurrentError != EventSequenceNumber.Unavailable &&
+        !string.IsNullOrEmpty(Partition) &&
+        Messages is not null;
 }


### PR DESCRIPTION
### Fixed

- Keeping observers alive forever by telling Orleans to never deactivate them (only the logical unpartitioned observer). (#770)
- Fixing how failed partitions state is rehydrated for observer state to be rehydrated from the actual collection of failed partitions.
- Delaying recovery of partitions through a timer that starts immediately. This fixes so that we don't end up in dead-lock scenarios due to recovery grain calling the supervisor during start up.
