### PR TITLE
Fix/json-options

### DIFF
--- a/Source/ApplicationModel/Applications/ServiceCollectionExtensions.cs
+++ b/Source/ApplicationModel/Applications/ServiceCollectionExtensions.cs
@@ -50,8 +50,6 @@ public static class ServiceCollectionExtensions
                 }
             });
 
-        services.AddSingleton(Globals.JsonSerializerOptions!);
-
         foreach (var controllerAssembly in types.ProjectReferencedAssemblies.Where(_ => _.DefinedTypes.Any(type => type.Implements(typeof(Controller)))))
         {
             controllerBuilder.PartManager.ApplicationParts.Add(new AssemblyPart(controllerAssembly));

--- a/Source/Clients/DotNET/Clients/ClientServiceCollectionExtensions.cs
+++ b/Source/Clients/DotNET/Clients/ClientServiceCollectionExtensions.cs
@@ -28,9 +28,9 @@ public static class ClientServiceCollectionExtensions
     {
         services.AddSingleton(_ =>
         {
-            var configuration = _.GetRequiredService<ClientConfiguration>();
             var httpClientFactory = _.GetRequiredService<IHttpClientFactory>();
-            var loadBalancer = _.GetRequiredService<ILoadBalancer>();
+            var configuration = _.GetService<ClientConfiguration>() ?? new ClientConfiguration();
+            var loadBalancer = _.GetService<ILoadBalancer>() ?? new LoadBalancer(httpClientFactory);
             var serializerOptions = _.GetRequiredService<JsonSerializerOptions>();
             serializerOptions = new JsonSerializerOptions(serializerOptions);
             var orleansAzureTableClientLogger = _.GetRequiredService<ILogger<OrleansAzureTableStoreKernelClient>>();

--- a/Source/Clients/DotNET/Hosting/ClientBuilder.cs
+++ b/Source/Clients/DotNET/Hosting/ClientBuilder.cs
@@ -8,6 +8,7 @@ using Aksio.Cratis.Events;
 using Aksio.Cratis.EventSequences;
 using Aksio.Cratis.Execution;
 using Aksio.Cratis.Extensions.MongoDB;
+using Aksio.Cratis.Json;
 using Aksio.Cratis.Observation;
 using Aksio.Cratis.Schemas;
 using Aksio.Cratis.Types;
@@ -82,6 +83,7 @@ public class ClientBuilder : IClientBuilder
         logger.ConfiguringServices();
         services
             .AddCratisClient()
+            .AddSingleton(Globals.JsonSerializerOptions!)
             .AddTransient(typeof(IInstancesOf<>), typeof(InstancesOf<>))
             .AddTransient(typeof(IImplementationsOf<>), typeof(ImplementationsOf<>))
             .AddTransient<IEventStore, EventStore>()


### PR DESCRIPTION
### Fixed

- Moving registration of IoC bindings for `JsonSerializerOptions` to the client setup - a step towards making #789 a reality.
- Putting in defaults for `ILoadBalancer` in case it is not configured - a step towards making #789 a reality.
- Putting in defaults for `ClientConfiguration` in case it is not configured - a step towards making #789 a reality.
