### PR TITLE
Fix/array-item-type

### DIFF
--- a/Source/ApplicationModel/Tooling/ProxyGenerator/SourceGenerator.cs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/SourceGenerator.cs
@@ -486,6 +486,7 @@ public class SourceGenerator : ISourceGenerator
                 var hasDerivatives = false;
                 var derivatives = new List<string>();
                 var actualType = propertyType;
+                var actualTypeName = propertyType.Name;
                 var constructorType = actualType.Name;
 
                 if (propertyType.TypeKind == TypeKind.Enum)
@@ -498,7 +499,15 @@ public class SourceGenerator : ISourceGenerator
                     if (namedType.TypeArguments != default && namedType.TypeArguments.Length > 0)
                     {
                         actualType = ((INamedTypeSymbol)propertyType).TypeArguments[0];
+                        actualTypeName = actualType.Name;
                         constructorType = actualType.Name;
+                        if (actualType.IsKnownType())
+                        {
+                            targetType = actualType.GetTypeScriptType(out additionalImportStatements);
+                            additionalImportStatements.ForEach(_ => typeImportStatements.Add(_));
+                            actualTypeName = targetType.Type;
+                            constructorType = targetType.Constructor;
+                        }
                     }
                 }
 
@@ -533,7 +542,7 @@ public class SourceGenerator : ISourceGenerator
                     typeImportStatements,
                     useRouteAsPath,
                     baseApiRoute));
-                propertyDescriptors.Add(new PropertyDescriptor(property.Name, actualType.Name, constructorType, isEnumerable, isNullable, hasDerivatives, derivatives));
+                propertyDescriptors.Add(new PropertyDescriptor(property.Name, actualTypeName, constructorType, isEnumerable, isNullable, hasDerivatives, derivatives));
             }
             else
             {

--- a/Source/Clients/DotNET/Hosting/ClientBuilder.cs
+++ b/Source/Clients/DotNET/Hosting/ClientBuilder.cs
@@ -8,7 +8,6 @@ using Aksio.Cratis.Events;
 using Aksio.Cratis.EventSequences;
 using Aksio.Cratis.Execution;
 using Aksio.Cratis.Extensions.MongoDB;
-using Aksio.Cratis.Json;
 using Aksio.Cratis.Observation;
 using Aksio.Cratis.Schemas;
 using Aksio.Cratis.Types;

--- a/Source/Clients/DotNET/Tenants/TenantConfiguration.cs
+++ b/Source/Clients/DotNET/Tenants/TenantConfiguration.cs
@@ -25,7 +25,7 @@ public class TenantConfiguration : ITenantConfiguration
     /// <inheritdoc/>
     public async Task<ConfigurationForTenant> GetAllFor(TenantId tenantId)
     {
-        var result = await _client.PerformQuery<ConfigurationForTenant>("/api/configuration/tenants/{tenantId}");
-        return result.Data;
+        var result = await _client.PerformQuery<Dictionary<string, string>>($"/api/configuration/tenants/{tenantId}");
+        return new(result.Data);
     }
 }

--- a/Source/Kernel/Domain/EventSequences/EventSequence.cs
+++ b/Source/Kernel/Domain/EventSequences/EventSequence.cs
@@ -66,7 +66,7 @@ public class EventSequence : Controller
     /// <param name="redaction">The <see cref="RedactEvent"/> to redact.</param>
     /// <returns>Awaitable task.</returns>
     [HttpPost("redact-event")]
-    public async Task Redact(
+    public async Task RedactEvent(
         [FromRoute] MicroserviceId microserviceId,
         [FromRoute] EventSequenceId eventSequenceId,
         [FromRoute] TenantId tenantId,
@@ -86,7 +86,7 @@ public class EventSequence : Controller
     /// <param name="redaction">The redaction filter to use.</param>
     /// <returns>Awaitable task.</returns>
     [HttpPost("redact-events")]
-    public async Task Redact(
+    public async Task RedactEvents(
         [FromRoute] MicroserviceId microserviceId,
         [FromRoute] EventSequenceId eventSequenceId,
         [FromRoute] TenantId tenantId,

--- a/Source/Kernel/Grains/Configuration/Tenants/TenantConfiguration.cs
+++ b/Source/Kernel/Grains/Configuration/Tenants/TenantConfiguration.cs
@@ -30,5 +30,5 @@ public class TenantConfiguration : Grain<TenantConfigurationState>, ITenantConfi
     }
 
     /// <inheritdoc/>
-    public Task<TenantConfigurationState> All() => Task.FromResult(State);
+    public Task<IDictionary<string, string>> All() => Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string>(State));
 }


### PR DESCRIPTION
### Fixed

- Fixing proxy generator to output correct type for enumerable element when it is a known type. E.g. `ConceptAs<>` types.
- Fixing the redaction commands to not be overloads, as that produces same name on the proxies.
- Fixing tenant configuration to work - its been broken since we changed client type.
