### PR TITLE
For improved devex; add an explicit call to /.aksio/me if no cookie

### DIFF
--- a/Samples/Banking/Bank/Web/webpack.config.js
+++ b/Samples/Banking/Bank/Web/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = (env, argv) => {
         config.resolve.alias.API = path.resolve('./API');
         config.devServer.port = 9100;
         config.devServer.proxy = {
-            '/graphql': 'http://localhost:5100',
+            '/.aksio/me': 'http://localhost:5100',
             '/api': {
                 target: 'http://localhost:5100',
                 ws: true

--- a/Source/ApplicationModel/Frontend/identity/IdentityProvider.tsx
+++ b/Source/ApplicationModel/Frontend/identity/IdentityProvider.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { IIdentityContext } from './IIdentityContext';
+import { useState, useEffect } from 'react';
 
 const defaultIdentityContext: IIdentityContext = {
     details: {}
@@ -28,13 +29,22 @@ function getCookie(name: string) {
 }
 
 export const IdentityProvider = (props: IdentityProviderProps) => {
-    let context: IIdentityContext = defaultIdentityContext;
+    const [context, setContext] = useState<IIdentityContext>(defaultIdentityContext);
     const identityCookie = getCookie(cookieName);
     if (identityCookie.length == 2) {
         const json = atob(identityCookie[1]);
-        context = {
+        setContext({
             details: JSON.parse(json.toString())
-        };
+        });
+    } else {
+        useEffect(() => {
+            fetch('/.aksio/me').then(async response => {
+                const json = await response.json();
+                setContext({
+                    details: json
+                });
+            });
+        }, []);
     }
 
     return (


### PR DESCRIPTION
### Fixed

- Fixed the frontend `IdentityContextProvider` to explicitly call the `/.aksio/me` endpoint if no cookie is there. This is to improve the devex. It does however require the `x-ms-client-*` headers to be set for the endpoint to work.
