### PR TITLE
Adding needed API for getting observer CLR type from observer id

### DIFF
--- a/Source/Clients/DotNET/Observation/IObserversRegistrar.cs
+++ b/Source/Clients/DotNET/Observation/IObserversRegistrar.cs
@@ -33,4 +33,11 @@ public interface IObserversRegistrar
     /// <param name="observerType">The <see cref="ObserverType"/> to get for.</param>
     /// <returns><see cref="ObserverHandler"/>.</returns>
     ObserverHandler GetByType(Type observerType);
+
+    /// <summary>
+    /// Get the CLR type for a specific observer.
+    /// </summary>
+    /// <param name="observerId"><see cref="ObserverId"/> to get for.</param>
+    /// <returns>The type.</returns>
+    Type GetClrType(ObserverId observerId);
 }

--- a/Source/Clients/DotNET/Observation/ObserversRegistrar.cs
+++ b/Source/Clients/DotNET/Observation/ObserversRegistrar.cs
@@ -80,6 +80,14 @@ public class ObserversRegistrar : IObserversRegistrar
     }
 
     /// <inheritdoc/>
+    public Type GetClrType(ObserverId observerId)
+    {
+        var observer = _handlers.SingleOrDefault(_ => _.Value.ObserverId == observerId);
+        ObserverDoesNotExist.ThrowIfDoesNotExist(observerId, observer.Value);
+        return observer.Key;
+    }
+
+    /// <inheritdoc/>
     public async Task Initialize()
     {
         _logger.RegisterObservers();


### PR DESCRIPTION
### Fixed

- Added missing API for getting an observer CLR type by its observer id.
