### PR TITLE
Fix/identity-rerender

### DIFF
--- a/Samples/Banking/docker-compose.yml
+++ b/Samples/Banking/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - host.docker.internal:host-gateway
 
   ingress-middleware:
-    image: aksioinsurtech/ingressmiddleware:3.3.2-development
+    image: aksioinsurtech/ingressmiddleware:3.3.11-development
     ports:
       - 8091:80
     volumes:

--- a/Source/ApplicationModel/Frontend/identity/IdentityProvider.tsx
+++ b/Source/ApplicationModel/Frontend/identity/IdentityProvider.tsx
@@ -31,21 +31,21 @@ function getCookie(name: string) {
 export const IdentityProvider = (props: IdentityProviderProps) => {
     const [context, setContext] = useState<IIdentityContext>(defaultIdentityContext);
     const identityCookie = getCookie(cookieName);
-    if (identityCookie.length == 2) {
-        const json = atob(identityCookie[1]);
-        setContext({
-            details: JSON.parse(json.toString())
-        });
-    } else {
-        useEffect(() => {
+    useEffect(() => {
+        if (identityCookie.length == 2) {
+            const json = atob(identityCookie[1]);
+            setContext({
+                details: JSON.parse(json.toString())
+            });
+        } else {
             fetch('/.aksio/me').then(async response => {
                 const json = await response.json();
                 setContext({
                     details: json
                 });
             });
-        }, []);
-    }
+        }
+    }, []);
 
     return (
         <IdentityProviderContext.Provider value={context}>


### PR DESCRIPTION
### Fixed

- The ´useIdentity()` hook is now fixed to not go into an endless re-render loop when the identity cookie is available.
