### PR TITLE
Supporting parsing of input without generation info

### DIFF
--- a/Source/Kernel/MongoDB/EventSequences/MongoDBEventSequenceStorage.cs
+++ b/Source/Kernel/MongoDB/EventSequences/MongoDBEventSequenceStorage.cs
@@ -158,7 +158,7 @@ public class MongoDBEventSequenceStorage : IEventSequenceStorage
         {
             foreach (var @event in cursor.Current)
             {
-                if (@event.Metadata.Type == GlobalEventTypes.Redaction)
+                if (@event.Metadata.Type.Id == GlobalEventTypes.Redaction)
                 {
                     _logger.RedactionAlreadyApplied(eventSequenceId, @event.Metadata.SequenceNumber);
                     continue;

--- a/Source/Kernel/Shared/Events/EventType.cs
+++ b/Source/Kernel/Shared/Events/EventType.cs
@@ -46,6 +46,10 @@ public record EventType(EventTypeId Id, EventGeneration Generation, bool IsPubli
     public static EventType Parse(string input)
     {
         var segments = input.Split('+');
+        if (segments.Length == 1)
+        {
+            return new(segments[0], EventGeneration.First);
+        }
         return new(segments[0], uint.Parse(segments[1]));
     }
 }


### PR DESCRIPTION
### Fixed

- `EventType` now supports parsing string representation without generation info, defaulting to `EventGeneration.First` for that scenario.
- When checking if redaction has already happened, we now check only the `Id` part - we don't care about which generation at that point.
