### PR TITLE
Fix/redact-replay

### DIFF
--- a/Source/Clients/DotNET/Clients/IClient.cs
+++ b/Source/Clients/DotNET/Clients/IClient.cs
@@ -27,6 +27,12 @@ public interface IClient
     Task Connect();
 
     /// <summary>
+    /// Disconnect from the kernel.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
+    Task Disconnect();
+
+    /// <summary>
     /// Perform a command.
     /// </summary>
     /// <param name="route">Route of the command.</param>

--- a/Source/Clients/DotNET/Clients/InsideKernelClient.cs
+++ b/Source/Clients/DotNET/Clients/InsideKernelClient.cs
@@ -74,6 +74,9 @@ public class InsideKernelClient : IClient
     public Task Connect() => _innerClient.Connect();
 
     /// <inheritdoc/>
+    public Task Disconnect() => _innerClient.Disconnect();
+
+    /// <inheritdoc/>
     public Task<CommandResult> PerformCommand(string route, object? command = null, object? metadata = default) => _innerClient.PerformCommand(route, command, metadata);
 
     /// <inheritdoc/>

--- a/Source/Clients/DotNET/Clients/RestKernelClient.cs
+++ b/Source/Clients/DotNET/Clients/RestKernelClient.cs
@@ -121,6 +121,15 @@ public abstract class RestKernelClient : IClient, IDisposable
     }
 
     /// <inheritdoc/>
+    public async Task Disconnect()
+    {
+        _timer?.Dispose();
+        _timer = null;
+
+        await PerformCommandInternal($"/api/clients/{_microserviceId}/disconnect", ConnectionId);
+    }
+
+    /// <inheritdoc/>
     public async Task<CommandResult> PerformCommand(string route, object? command = null, object? metadata = default)
     {
         metadata ??= new object();

--- a/Source/Kernel/Domain/Clients/ConnectedClients.cs
+++ b/Source/Kernel/Domain/Clients/ConnectedClients.cs
@@ -53,7 +53,7 @@ public class ConnectedClients : Controller
     }
 
     /// <summary>
-    /// Accepts client connections over Web Sockets.
+    /// Connect a client.
     /// </summary>
     /// <param name="microserviceId">The <see cref="MicroserviceId"/> that is connecting.</param>
     /// <param name="connectionId">The unique identifier of the connection.</param>
@@ -79,5 +79,23 @@ public class ConnectedClients : Controller
             uri,
             clientInformation.ClientVersion,
             clientInformation.IsRunningWithDebugger);
+    }
+
+    /// <summary>
+    /// Disconnect a client.
+    /// </summary>
+    /// <param name="microserviceId"></param>
+    /// <param name="connectionId"></param>
+    /// <returns>Awaitable task.</returns>
+    [HttpPost("connect/{connectionId}")]
+    public async Task Disconnect(
+        [FromRoute] MicroserviceId microserviceId,
+        [FromRoute] ConnectionId connectionId)
+    {
+        _logger.ClientDisconnected(microserviceId, connectionId);
+        var connectedClients = _grainFactory.GetGrain<IConnectedClients>(microserviceId);
+        await connectedClients.OnClientDisconnected(
+            connectionId,
+            "Explicit disconnect");
     }
 }

--- a/Source/Kernel/Domain/Clients/ConnectedClients.cs
+++ b/Source/Kernel/Domain/Clients/ConnectedClients.cs
@@ -84,8 +84,8 @@ public class ConnectedClients : Controller
     /// <summary>
     /// Disconnect a client.
     /// </summary>
-    /// <param name="microserviceId"></param>
-    /// <param name="connectionId"></param>
+    /// <param name="microserviceId">The <see cref="MicroserviceId"/> that is connecting.</param>
+    /// <param name="connectionId">The unique identifier of the connection.</param>
     /// <returns>Awaitable task.</returns>
     [HttpPost("connect/{connectionId}")]
     public async Task Disconnect(

--- a/Source/Kernel/Grains/Observation/ObserverSupervisor.Rewinding.cs
+++ b/Source/Kernel/Grains/Observation/ObserverSupervisor.Rewinding.cs
@@ -34,8 +34,6 @@ public partial class ObserverSupervisor
     public async Task RewindPartitionTo(EventSourceId partition, EventSequenceNumber sequenceNumber)
     {
         _rewindingPartition = true;
-        State.NextEventSequenceNumber = sequenceNumber;
-        await WriteStateAsync();
         var events = await _eventSequenceStorageProvider().GetFromSequenceNumber(_eventSequenceId, sequenceNumber, partition, State.EventTypes);
         while (await events.MoveNext())
         {

--- a/Source/Workbench/API/clients/Disconnect.ts
+++ b/Source/Workbench/API/clients/Disconnect.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  **DO NOT EDIT** - This file is an automatically generated file.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Validator } from '@aksio/cratis-applications-frontend/validation';
+import Handlebars from 'handlebars';
+
+const routeTemplate = Handlebars.compile('/api/clients/{{microserviceId}}/connect/{{connectionId}}');
+
+export interface IDisconnect {
+    microserviceId?: string;
+    connectionId?: string;
+}
+
+export class DisconnectValidator extends CommandValidator {
+    readonly properties: CommandPropertyValidators = {
+        microserviceId: new Validator(),
+        connectionId: new Validator(),
+    };
+}
+
+export class Disconnect extends Command<IDisconnect> implements IDisconnect {
+    readonly route: string = '/api/clients/{{microserviceId}}/connect/{{connectionId}}';
+    readonly routeTemplate: Handlebars.TemplateDelegate = routeTemplate;
+    readonly validation: CommandValidator = new DisconnectValidator();
+
+    private _microserviceId!: string;
+    private _connectionId!: string;
+
+    constructor() {
+        super(Object, false);
+    }
+
+    get requestArguments(): string[] {
+        return [
+            'microserviceId',
+            'connectionId',
+        ];
+    }
+
+    get properties(): string[] {
+        return [
+            'microserviceId',
+            'connectionId',
+        ];
+    }
+
+    get microserviceId(): string {
+        return this._microserviceId;
+    }
+
+    set microserviceId(value: string) {
+        this._microserviceId = value;
+        this.propertyChanged('microserviceId');
+    }
+    get connectionId(): string {
+        return this._connectionId;
+    }
+
+    set connectionId(value: string) {
+        this._connectionId = value;
+        this.propertyChanged('connectionId');
+    }
+
+    static use(initialValues?: IDisconnect): [Disconnect, SetCommandValues<IDisconnect>, ClearCommandValues] {
+        return useCommand<Disconnect, IDisconnect>(Disconnect, initialValues);
+    }
+}


### PR DESCRIPTION
### Added

- Support for disconnecting explicltly a client.

### Fixed

- When doing redact it uses the `RewindPartitionTo()` method on observers, this was faulty and did a full replay of the observer - which it shouldn't.
