### PR TITLE
Fix/replays

### DIFF
--- a/Source/Extensions/Specifications/Projections/ProjectionSpecificationContext.cs
+++ b/Source/Extensions/Specifications/Projections/ProjectionSpecificationContext.cs
@@ -109,7 +109,7 @@ public class ProjectionSpecificationContext<TModel> : IHaveEventLog, IDisposable
             }
         }
 
-        var result = await _sink.FindOrDefault(new(modelId, ArrayIndexers.NoIndexers));
+        var result = await _sink.FindOrDefault(new(modelId, ArrayIndexers.NoIndexers), false);
         var json = JsonSerializer.Serialize(result, Globals.JsonSerializerOptions);
         return new(JsonSerializer.Deserialize<TModel>(json, Globals.JsonSerializerOptions)!, Array.Empty<PropertyPath>(), projectedEventsCount);
     }

--- a/Source/Fundamentals/Web/WebApplicationBuilderExtensions.cs
+++ b/Source/Fundamentals/Web/WebApplicationBuilderExtensions.cs
@@ -38,6 +38,10 @@ public static class WebApplicationBuilderExtensions
             {
                 await context.Response.SendFileAsync(fileInfo);
             }
+            else
+            {
+                context.Response.StatusCode = 404;
+            }
         });
     }
 }

--- a/Source/Kernel/Engines/Projections/IProjectionSink.cs
+++ b/Source/Kernel/Engines/Projections/IProjectionSink.cs
@@ -27,16 +27,18 @@ public interface IProjectionSink
     /// Find a model by key, or return an empty object if not found.
     /// </summary>
     /// <param name="key">Key of the model to find.</param>
+    /// <param name="isReplaying">Whether or not we're in replay mode.</param>
     /// <returns>A model instance with the data from the source, or an empty object.</returns>
-    Task<ExpandoObject?> FindOrDefault(Key key);
+    Task<ExpandoObject?> FindOrDefault(Key key, bool isReplaying);
 
     /// <summary>
     /// Update or insert model based on key.
     /// </summary>
     /// <param name="key">Key of the model to upsert.</param>
     /// <param name="changeset">All changes in the form of a <see cref="Changeset{Event, ExpandoObject}"/>.</param>
+    /// <param name="isReplaying">Whether or not we're in replay mode.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task ApplyChanges(Key key, IChangeset<AppendedEvent, ExpandoObject> changeset);
+    Task ApplyChanges(Key key, IChangeset<AppendedEvent, ExpandoObject> changeset, bool isReplaying);
 
     /// <summary>
     /// Enter replay state.
@@ -51,12 +53,13 @@ public interface IProjectionSink
     Task EndReplay();
 
     /// <summary>
-    /// Prepare the store for an initial run.
+    /// Prepare the sink for an initial run.
     /// </summary>
     /// <remarks>
-    /// Typically the store will clear out any existing data. This is to be able to guarantee
+    /// Typically the sink will clear out any existing data. This is to be able to guarantee
     /// the idempotency of the projection.
     /// </remarks>
+    /// <param name="isReplaying">Whether or not we're in replay mode.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task PrepareInitialRun();
+    Task PrepareInitialRun(bool isReplaying);
 }

--- a/Source/Kernel/Engines/Projections/InMemory/InMemoryProjectionSink.cs
+++ b/Source/Kernel/Engines/Projections/InMemory/InMemoryProjectionSink.cs
@@ -53,7 +53,7 @@ public class InMemoryProjectionSink : IProjectionSink, IDisposable
     }
 
     /// <inheritdoc/>
-    public Task<ExpandoObject?> FindOrDefault(Key key)
+    public Task<ExpandoObject?> FindOrDefault(Key key, bool isReplaying)
     {
         var collection = Collection;
         var keyValue = GetActualKeyValue(key);
@@ -72,7 +72,7 @@ public class InMemoryProjectionSink : IProjectionSink, IDisposable
     }
 
     /// <inheritdoc/>
-    public Task ApplyChanges(Key key, IChangeset<AppendedEvent, ExpandoObject> changeset)
+    public Task ApplyChanges(Key key, IChangeset<AppendedEvent, ExpandoObject> changeset, bool isReplaying)
     {
         var state = changeset.InitialState.Clone();
         var collection = Collection;
@@ -104,7 +104,7 @@ public class InMemoryProjectionSink : IProjectionSink, IDisposable
     }
 
     /// <inheritdoc/>
-    public Task PrepareInitialRun()
+    public Task PrepareInitialRun(bool isReplaying)
     {
         Collection.Clear();
         return Task.CompletedTask;

--- a/Source/Kernel/Engines/Projections/Pipelines/ProjectionPipeline.cs
+++ b/Source/Kernel/Engines/Projections/Pipelines/ProjectionPipeline.cs
@@ -66,6 +66,7 @@ public class ProjectionPipeline : IProjectionPipeline
         {
             await Sink.BeginReplay();
         }
+        var isReplaying = @event.Context.ObservationState.HasFlag(EventObservationState.Replay);
 
         _logger.HandlingEvent(@event.Metadata.SequenceNumber);
         var correlationId = CorrelationId.New();
@@ -73,14 +74,14 @@ public class ProjectionPipeline : IProjectionPipeline
         var key = await keyResolver(_eventProvider, @event);
         key = EnsureCorrectTypeForArrayIndexersOnKey(key);
         _logger.GettingInitialValues(@event.Metadata.SequenceNumber);
-        var initialState = await Sink.FindOrDefault(key);
+        var initialState = await Sink.FindOrDefault(key, isReplaying);
         initialState ??= Projection.InitialModelState;
         var changeset = new Changeset<AppendedEvent, ExpandoObject>(_objectsComparer, @event, initialState);
         var context = new ProjectionEventContext(key, @event, changeset);
         await HandleEventFor(Projection, context);
         if (changeset.HasChanges)
         {
-            await Sink.ApplyChanges(key, changeset);
+            await Sink.ApplyChanges(key, changeset, isReplaying);
             await _changesetStorage.Save(correlationId, changeset);
             _logger.SavingResult(@event.Metadata.SequenceNumber);
         }

--- a/Source/Kernel/Grains/Observation/Replay.cs
+++ b/Source/Kernel/Grains/Observation/Replay.cs
@@ -108,6 +108,7 @@ public class Replay : ObserverWorker, IReplay
             nextSequenceNumber = EventSequenceNumber.First;
         }
 
+        var tailSequenceNumber = await provider.GetTailSequenceNumber(_observerKey!.EventSequenceId!, State.EventTypes);
         var headSequenceNumber = await EventSequenceStorageProvider.GetHeadSequenceNumber(State.EventSequenceId, State.EventTypes);
         using var cursor = await provider.GetFromSequenceNumber(_observerKey!.EventSequenceId!, nextSequenceNumber, eventTypes: State.EventTypes);
         while (await cursor.MoveNext())
@@ -123,7 +124,7 @@ public class Replay : ObserverWorker, IReplay
                     state |= EventObservationState.HeadOfReplay;
                 }
 
-                if (@event.Metadata.SequenceNumber == State.LastHandled)
+                if (@event.Metadata.SequenceNumber == tailSequenceNumber)
                 {
                     state |= EventObservationState.TailOfReplay;
                 }

--- a/Source/Kernel/Grains/Projections/Outbox/OutboxProjectionSink.cs
+++ b/Source/Kernel/Grains/Projections/Outbox/OutboxProjectionSink.cs
@@ -63,7 +63,7 @@ public class OutboxProjectionSink : IProjectionSink, IDisposable
     }
 
     /// <inheritdoc/>
-    public async Task ApplyChanges(Key key, IChangeset<AppendedEvent, ExpandoObject> changeset)
+    public async Task ApplyChanges(Key key, IChangeset<AppendedEvent, ExpandoObject> changeset, bool isReplaying)
     {
         var state = changeset.InitialState.Clone();
         foreach (var change in changeset.Changes)
@@ -95,7 +95,7 @@ public class OutboxProjectionSink : IProjectionSink, IDisposable
     }
 
     /// <inheritdoc/>
-    public async Task<ExpandoObject?> FindOrDefault(Key key)
+    public async Task<ExpandoObject?> FindOrDefault(Key key, bool isReplaying)
     {
         if (_replaying) return new ExpandoObject();
 
@@ -112,5 +112,5 @@ public class OutboxProjectionSink : IProjectionSink, IDisposable
     }
 
     /// <inheritdoc/>
-    public Task PrepareInitialRun() => Task.CompletedTask;
+    public Task PrepareInitialRun(bool isReplaying) => Task.CompletedTask;
 }


### PR DESCRIPTION
### Fixed

- Replay worker fixed, observation state was never set to `TailOfReplay` unless the `LastHandled` event sequence number was the same as the tail. This is now fixed. The problem it caused was that projections never reached the end of replay and the temporary collections never renamed.
- Fixed the replay state across projections and projection sink, so that it is not a global "isReplaying" that can change and especially since lifecycle of sinks could be transient. This results now in correct projection replays to the correct collections.
- Fixed the `RunAsSinglePageApplication()` - catch all middleware to return a 404 if there are no files matching.
