### PR TITLE
Adding the Serilog JSON Compact formatter

### DIFF
--- a/Source/ApplicationModel/Applications/Applications.csproj
+++ b/Source/ApplicationModel/Applications/Applications.csproj
@@ -28,6 +28,7 @@
 		<PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
 		<PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
 		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
+        <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.1-dev-00944" />
 		<PackageReference Include="serilog.aspnetcore" Version="4.0.0" />
 		<PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="$(Swashbuckle)" />


### PR DESCRIPTION
### Fixed

- Added the compact JSON formatter as it was missing as a dependency.
