### PR TITLE
Adding JSON log formatter based on the Serilog Compact Json Formatter

### DIFF
--- a/Source/ApplicationModel/Applications/Logging/EventIdHash.cs
+++ b/Source/ApplicationModel/Applications/Logging/EventIdHash.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Applications.Logging;
+
+/// <summary>
+/// Hash functions for message templates. See <see cref="Compute"/>.
+/// </summary>
+/// <remarks>
+/// Based on and adapted from https://github.com/serilog/serilog-formatting-compact.
+/// </remarks>
+public static class EventIdHash
+{
+    /// <summary>
+    /// Compute a 32-bit hash of the provided <paramref name="messageTemplate"/>. The
+    /// resulting hash value can be uses as an event id in lieu of transmitting the
+    /// full template string.
+    /// </summary>
+    /// <param name="messageTemplate">A message template.</param>
+    /// <returns>A 32-bit hash of the template.</returns>
+    public static uint Compute(string messageTemplate)
+    {
+        ArgumentNullException.ThrowIfNull(messageTemplate, nameof(messageTemplate));
+
+        // Jenkins one-at-a-time https://en.wikipedia.org/wiki/Jenkins_hash_function
+        unchecked
+        {
+            uint hash = 0;
+            for (var i = 0; i < messageTemplate.Length; ++i)
+            {
+                hash += messageTemplate[i];
+                hash += hash << 10;
+                hash ^= hash >> 6;
+            }
+            hash += hash << 3;
+            hash ^= hash >> 11;
+            hash += hash << 15;
+            return hash;
+        }
+    }
+}

--- a/Source/ApplicationModel/Applications/Logging/RenderedCompactJsonFormatter.cs
+++ b/Source/ApplicationModel/Applications/Logging/RenderedCompactJsonFormatter.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Json;
+
+namespace Aksio.Cratis.Applications.Logging;
+
+/// <summary>
+/// An <see cref="ITextFormatter"/> that writes events in a compact JSON format, for consumption in environments
+/// without message template support. Message templates are rendered into text and a hashed event id is included.
+/// </summary>
+/// <remarks>
+/// Based on and adapted from https://github.com/serilog/serilog-formatting-compact.
+/// </remarks>
+public class RenderedCompactJsonFormatter : ITextFormatter
+{
+    readonly JsonValueFormatter _valueFormatter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RenderedCompactJsonFormatter"/> class.
+    /// <see cref="LogEventPropertyValue"/>s on the event.
+    /// </summary>
+    /// <param name="valueFormatter">A value formatter, or null.</param>
+    public RenderedCompactJsonFormatter(JsonValueFormatter? valueFormatter = null)
+    {
+        _valueFormatter = valueFormatter ?? new JsonValueFormatter(typeTagName: "$type");
+    }
+
+    /// <summary>
+    /// Format the log event into the output.
+    /// </summary>
+    /// <param name="logEvent">The event to format.</param>
+    /// <param name="output">The output.</param>
+    /// <param name="valueFormatter">A value formatter for <see cref="LogEventPropertyValue"/>s on the event.</param>
+    /// <exception cref="ArgumentNullException">If any out the parameters are null.</exception>
+    public static void FormatEvent(LogEvent logEvent, TextWriter output, JsonValueFormatter valueFormatter)
+    {
+        ArgumentNullException.ThrowIfNull(logEvent, nameof(logEvent));
+        ArgumentNullException.ThrowIfNull(output, nameof(output));
+        ArgumentNullException.ThrowIfNull(valueFormatter, nameof(valueFormatter));
+
+        output.Write("{\"Time\":\"");
+        output.Write(logEvent.Timestamp.UtcDateTime.ToString("O"));
+        output.Write("\",\"Message\":");
+        var message = logEvent.MessageTemplate.Render(logEvent.Properties);
+        JsonValueFormatter.WriteQuotedJsonString(message, output);
+        output.Write(",\"MessageHash\":\"");
+        var id = EventIdHash.Compute(logEvent.MessageTemplate.Text);
+        output.Write(id.ToString("x8"));
+        output.Write('"');
+
+        if (logEvent.Level != LogEventLevel.Information)
+        {
+            output.Write(",\"Level\":\"");
+            output.Write(Enum.GetName(typeof(LogEventLevel), logEvent.Level));
+            output.Write('\"');
+        }
+
+        if (logEvent.Exception != null)
+        {
+            output.Write(",\"Exception\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.ToString(), output);
+        }
+
+        foreach (var property in logEvent.Properties)
+        {
+            var name = property.Key;
+            if (name.Length > 0 && name[0] == '@')
+            {
+                // Escape first '@' by doubling
+                name = '@' + name;
+            }
+
+            output.Write(',');
+            JsonValueFormatter.WriteQuotedJsonString(name, output);
+            output.Write(':');
+            valueFormatter.Format(property.Value, output);
+        }
+
+        output.Write('}');
+    }
+
+    /// <summary>
+    /// Format the log event into the output. Subsequent events will be newline-delimited.
+    /// </summary>
+    /// <param name="logEvent">The event to format.</param>
+    /// <param name="output">The output.</param>
+    public void Format(LogEvent logEvent, TextWriter output)
+    {
+        FormatEvent(logEvent, output, _valueFormatter);
+        output.WriteLine();
+    }
+}


### PR DESCRIPTION
### Added

- Added custom Serilog formatter for outputting a rendered compact JSON format, yet not as compact as the official one. Based on the official implementation found [here](https://github.com/serilog/serilog-formatting-compact/tree/dev/src/Serilog.Formatting.Compact/Formatting/Compact).

Usage:

```json
{
    "Serilog": {
        "Using": [
            "Serilog.Sinks.Console"
        ],
        "WriteTo": [
            {
                "Name": "Console",
                "Args": {
                    "formatter": "Aksio.Cratis.Applications.Logging.RenderedCompactJsonFormatter, Aksio.Cratis.Applications"
                }
            }
        ]
    }
}
```
