### PR TITLE
Adding a scavenger job to clean up dead silos

### DIFF
--- a/Source/Kernel/Grains.Interfaces/Silos/IDeadSilosScavenger.cs
+++ b/Source/Kernel/Grains.Interfaces/Silos/IDeadSilosScavenger.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Orleans;
+
+namespace Aksio.Cratis.Kernel.Grains.Silos;
+
+/// <summary>
+/// Represents a scavenger that collects dead silos.
+/// </summary>
+public interface IDeadSilosScavenger : IGrainWithGuidKey
+{
+    /// <summary>
+    /// Start the scavenger.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
+    Task Start();
+}

--- a/Source/Kernel/Grains/Silos/BootProcedure.cs
+++ b/Source/Kernel/Grains/Silos/BootProcedure.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Boot;
+using Orleans;
+
+namespace Aksio.Cratis.Kernel.Grains.Silos;
+
+/// <summary>
+/// Represents a <see cref="IPerformBootProcedure"/> that initializes related work for Silos.
+/// </summary>
+public class BootProcedure : IPerformBootProcedure
+{
+    readonly IGrainFactory _grainFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BootProcedure"/> class.
+    /// </summary>
+    /// <param name="grainFactory">The <see cref="IGrainFactory"/> for working with grains.</param>
+    public BootProcedure(IGrainFactory grainFactory)
+    {
+        _grainFactory = grainFactory;
+    }
+
+    /// <inheritdoc/>
+    public void Perform()
+    {
+        _grainFactory.GetGrain<IDeadSilosScavenger>(Guid.Empty).Start().Wait();
+    }
+}

--- a/Source/Kernel/Grains/Silos/DeadSilosScavenger.cs
+++ b/Source/Kernel/Grains/Silos/DeadSilosScavenger.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Kernel.Configuration;
+using Aksio.Cratis.Kernel.Orleans.Configuration;
+using Azure.Data.Tables;
+using Microsoft.Extensions.Logging;
+using Orleans;
+
+namespace Aksio.Cratis.Kernel.Grains.Silos;
+
+/// <summary>
+/// Represents an implementation of <see cref="IDeadSilosScavenger"/>.
+/// </summary>
+public class DeadSilosScavenger : Grain, IDeadSilosScavenger
+{
+    readonly KernelConfiguration _configuration;
+    readonly ILogger<DeadSilosScavenger> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeadSilosScavenger"/> class.
+    /// </summary>
+    /// <param name="configuration"><see cref="KernelConfiguration"/> holding the configuration.</param>
+    /// <param name="logger"><see cref="ILogger"/> for logging.</param>
+    public DeadSilosScavenger(
+        KernelConfiguration configuration,
+        ILogger<DeadSilosScavenger> logger)
+    {
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public Task Start()
+    {
+        if (_configuration.Cluster.Options is AzureStorageClusterOptions options)
+        {
+            RegisterTimer(_ => CleanUpDeadSilos(options), null!, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    async Task CleanUpDeadSilos(AzureStorageClusterOptions options)
+    {
+        var client = new TableClient(
+            options.ConnectionString,
+            options.TableName);
+
+        var result = client.QueryAsync<OrleansSiloInfo>(filter: "Status eq 'Dead'");
+        await foreach (var page in result.AsPages())
+        {
+            foreach (var entity in page.Values)
+            {
+                _logger.RemovingDeadSiloFromClusterInfo(entity.Address);
+                await client.DeleteEntityAsync(entity.PartitionKey, entity.RowKey, entity.ETag);
+            }
+        }
+    }
+}

--- a/Source/Kernel/Grains/Silos/DeadSilosScavengerLogMessages.cs
+++ b/Source/Kernel/Grains/Silos/DeadSilosScavengerLogMessages.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Aksio.Cratis.Kernel.Grains.Silos;
+
+internal static partial class DeadSilosScavengerLogMessages
+{
+    [LoggerMessage(1, LogLevel.Information, "Removing dead silo {SiloAddress} from cluster info")]
+    internal static partial void RemovingDeadSiloFromClusterInfo(this ILogger<DeadSilosScavenger> logger, string siloAddress);
+}

--- a/Source/Kernel/Grains/Silos/OrleansSiloInfo.cs
+++ b/Source/Kernel/Grains/Silos/OrleansSiloInfo.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Azure;
+using Azure.Data.Tables;
+
+namespace Aksio.Cratis.Kernel.Grains.Silos;
+
+/// <summary>
+/// Represents the silo info found in Azure Storage.
+/// </summary>
+public class OrleansSiloInfo : ITableEntity
+{
+    /// <inheritdoc/>
+    public string PartitionKey { get; set; } = string.Empty;
+
+    /// <inheritdoc/>
+    public string RowKey { get; set; } = string.Empty;
+
+    /// <inheritdoc/>
+    public DateTimeOffset? Timestamp { get; set; }
+
+    /// <inheritdoc/>
+    public ETag ETag { get; set; }
+
+    /// <summary>
+    /// Gets the host name of the silo.
+    /// </summary>
+    public string Address { get; set; } = string.Empty;
+}


### PR DESCRIPTION
### Fixed

- Scavenger job that cleans up dead silos when using Azure Table Store. Fixing #624.
