### PR TITLE
Fix/dead-silo-scavenger

### DIFF
--- a/Source/Kernel/Grains.Interfaces/Silos/IDeadSilosScavenger.cs
+++ b/Source/Kernel/Grains.Interfaces/Silos/IDeadSilosScavenger.cs
@@ -8,11 +8,17 @@ namespace Aksio.Cratis.Kernel.Grains.Silos;
 /// <summary>
 /// Represents a scavenger that collects dead silos.
 /// </summary>
-public interface IDeadSilosScavenger : IGrainWithGuidKey
+public interface IDeadSilosScavenger : IGrainWithIntegerKey
 {
     /// <summary>
     /// Start the scavenger.
     /// </summary>
     /// <returns>Awaitable task.</returns>
     Task Start();
+
+    /// <summary>
+    /// Perform a clean up of any dead silos.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
+    Task CleanUp();
 }

--- a/Source/Kernel/Grains/Silos/BootProcedure.cs
+++ b/Source/Kernel/Grains/Silos/BootProcedure.cs
@@ -25,6 +25,6 @@ public class BootProcedure : IPerformBootProcedure
     /// <inheritdoc/>
     public void Perform()
     {
-        _grainFactory.GetGrain<IDeadSilosScavenger>(Guid.Empty).Start().Wait();
+        _grainFactory.GetGrain<IDeadSilosScavenger>(0).Start().Wait();
     }
 }

--- a/Source/Kernel/Grains/Silos/DeadSilosScavengerLogMessages.cs
+++ b/Source/Kernel/Grains/Silos/DeadSilosScavengerLogMessages.cs
@@ -7,6 +7,12 @@ namespace Aksio.Cratis.Kernel.Grains.Silos;
 
 internal static partial class DeadSilosScavengerLogMessages
 {
-    [LoggerMessage(1, LogLevel.Information, "Removing dead silo {SiloAddress} from cluster info")]
+    [LoggerMessage(1, LogLevel.Information, "Looking for dead silos")]
+    internal static partial void LookForDeadSilos(this ILogger<DeadSilosScavenger> logger);
+
+    [LoggerMessage(2, LogLevel.Information, "Removing dead silo {SiloAddress} from cluster info")]
     internal static partial void RemovingDeadSiloFromClusterInfo(this ILogger<DeadSilosScavenger> logger, string siloAddress);
+
+    [LoggerMessage(3, LogLevel.Information, "No dead silos found")]
+    internal static partial void NoDeadSilos(this ILogger<DeadSilosScavenger> logger);
 }

--- a/Source/Kernel/Grains/Silos/DeadSilosScavengerStartupTask.cs
+++ b/Source/Kernel/Grains/Silos/DeadSilosScavengerStartupTask.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Orleans;
+using Orleans.Runtime;
+
+namespace Aksio.Cratis.Kernel.Grains.Silos;
+
+/// <summary>
+/// Represents a startup task for when the Silo is active for performing dead silos scavenging.
+/// </summary>
+public class DeadSilosScavengerStartupTask : ILifecycleParticipant<ISiloLifecycle>
+{
+    readonly IGrainFactory _grainFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeadSilosScavengerStartupTask"/> class.
+    /// </summary>
+    /// <param name="grainFactory">The <see cref="IGrainFactory"/> for working with grains.</param>
+    public DeadSilosScavengerStartupTask(IGrainFactory grainFactory)
+    {
+        _grainFactory = grainFactory;
+    }
+
+    /// <inheritdoc/>
+    public void Participate(ISiloLifecycle lifecycle)
+    {
+        lifecycle.Subscribe(
+            nameof(DeadSilosScavengerStartupTask),
+            ServiceLifecycleStage.Active,
+            CleanUp,
+            ctx => Task.CompletedTask);
+    }
+
+    Task CleanUp(CancellationToken cancellationToken) => _grainFactory.GetGrain<IDeadSilosScavenger>(0).CleanUp();
+}

--- a/Source/Kernel/Server/Startup.cs
+++ b/Source/Kernel/Server/Startup.cs
@@ -4,6 +4,9 @@
 #pragma warning disable SA1600
 
 using Aksio.Cratis.Kernel.Grains.Clients;
+using Aksio.Cratis.Kernel.Grains.Silos;
+using Orleans;
+using Orleans.Runtime;
 
 namespace Aksio.Cratis.Kernel.Server;
 
@@ -11,6 +14,7 @@ public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddTransient<ILifecycleParticipant<ISiloLifecycle>>(serviceProvider => serviceProvider.GetService<DeadSilosScavengerStartupTask>()!);
         services.AddHttpClient(ConnectedClients.ConnectedClientsHttpClient).ConfigurePrimaryHttpMessageHandler(_ => new HttpClientHandler
         {
             #pragma warning disable MA0039 // Allowing self-signed certificates for clients connecting to the Kernel


### PR DESCRIPTION
### Fixed

- Making dead silo scavenger a `StatelessWorker` with 1 instance per silo. This guarantees that we have at least one scavenger running that will clean up any dead silos.
- Adding a lifecycle participant that performs a cleanup of dead silos when the Orleans Silo has become active.
