### PR TITLE
Adding a mechanism for when kernel becomes unavailable

### DIFF
--- a/Source/Clients/DotNET/Clients/OrleansAzureTableStoreKernelClient.cs
+++ b/Source/Clients/DotNET/Clients/OrleansAzureTableStoreKernelClient.cs
@@ -70,6 +70,13 @@ public class OrleansAzureTableStoreKernelClient : ClusteredKernelClient
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc/>
+    protected override Task OnKernelUnavailable()
+    {
+        RefreshSilos();
+        return Task.CompletedTask;
+    }
+
     void RefreshSilos()
     {
         _clientLogger.GettingSilosFromStorage();

--- a/Source/Clients/DotNET/Clients/RestKernelClient.cs
+++ b/Source/Clients/DotNET/Clients/RestKernelClient.cs
@@ -104,6 +104,7 @@ public abstract class RestKernelClient : IClient, IDisposable
                 {
                 }
                 _logger.KernelUnavailable();
+                await OnKernelUnavailable();
                 await _taskFactory.Delay(2000);
             }
 
@@ -192,6 +193,12 @@ public abstract class RestKernelClient : IClient, IDisposable
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected virtual Task OnDisconnected() => Task.CompletedTask;
+
+    /// <summary>
+    /// Gets called if the kernel is unavailable.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    protected virtual Task OnKernelUnavailable() => Task.CompletedTask;
 
     async Task<CommandResult> PerformCommandInternal(string route, object? command = null, bool logResult = true)
     {


### PR DESCRIPTION
### Fixed

- Adding a `OnKernelUnavaialable()` virtual method for `RestKernelClient` implemented by the `OlreansAzureTableStoreKernelClient` which will refresh silo information before a retry.
