### PR TITLE
Using relaxed Json escaping for identity details result

### DIFF
--- a/Source/ApplicationModel/Applications/Identity/IdentityProviderEndpointExtensions.cs
+++ b/Source/ApplicationModel/Applications/Identity/IdentityProviderEndpointExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aksio.Cratis.Applications.Identity;
@@ -76,7 +77,13 @@ public static class IdentityProviderEndpointExtensions
                         {
                             response.StatusCode = 403;
                         }
-                        await response.WriteAsJsonAsync(result.Details, serializerOptions);
+
+                        response.ContentType = "application/json; charset=utf-8";
+                        var options = new JsonSerializerOptions(serializerOptions)
+                        {
+                            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+                        };
+                        await response.WriteAsJsonAsync(result.Details, options);
                     }
                 }
             });


### PR DESCRIPTION
### Fixed

- Fixing so that results from the `.aksio/me` identity details endpoint does not escape JSON result during serialization.
