### PR TITLE
Making it possible to call the Kernel out of execution context

### DIFF
--- a/Source/Clients/DotNET/Clients/RestKernelClient.cs
+++ b/Source/Clients/DotNET/Clients/RestKernelClient.cs
@@ -65,7 +65,7 @@ public abstract class RestKernelClient : IClient, IDisposable
         _jsonSerializerOptions = jsonSerializerOptions;
         _clientLifecycle = clientLifecycle;
         _logger = logger;
-        _microserviceId = _executionContextManager.Current.MicroserviceId;
+        _microserviceId = ExecutionContextManager.GlobalMicroserviceId;
         _connectCompletion = new TaskCompletionSource<bool>();
     }
 
@@ -224,7 +224,10 @@ public abstract class RestKernelClient : IClient, IDisposable
     HttpClient CreateReadyHttpClient()
     {
         var client = CreateHttpClient();
-        client.DefaultRequestHeaders.Add(ExecutionContextAppBuilderExtensions.TenantIdHeader, _executionContextManager.Current.TenantId.ToString());
+        if (_executionContextManager.IsInContext)
+        {
+            client.DefaultRequestHeaders.Add(ExecutionContextAppBuilderExtensions.TenantIdHeader, _executionContextManager.Current.TenantId.ToString());
+        }
         return client;
     }
 


### PR DESCRIPTION
### Fixed

- Fixing so that the client can call the Kernel API out of execution context. We're for the most part very specific on providing the necessary information on API routes.
