### PR TITLE
Fix/use-identity

### DIFF
--- a/Documentation/application-model/frontend/identity.md
+++ b/Documentation/application-model/frontend/identity.md
@@ -54,6 +54,32 @@ export const SomeComponent = () => {
 > Note: As you can see, the `details` type will be of type `any` in the context. This means that if your type is
 > a specific type, you'll need to cast it to that type before using it.
 
+### Refreshing
+
+Sometimes you need to refresh the identity due to backend changes. On the `IIdentityContext` that represents
+the context you find a method called `refresh()`. Calling this will invalidate the cookie and also just call
+the backend to get the current identity details.
+
+```typescript
+import { IdentityProviderContext } from '@aksio/cratis-applications-frontend/identity';
+
+export const SomeComponent = () => {
+    return (
+        <IdentityProviderContext.Consumer>
+            {(identity) => {
+                const actualDetails = identity.details as Identity;
+                return (
+                    <h1>{actualDetails.firstName} {actualDetails.firstName}</h1>
+
+                    {/* Refresh button */}
+                    <button onClick={() => identity.refresh()}>Refresh identity</button>
+                );
+            }}
+        </IdentityProviderContext.Consumer>
+    );
+};
+```
+
 ## useIdentity() hook
 
 Anywhere within your application you can then access the identity by adding using the `useIdentity()` hook:
@@ -89,6 +115,31 @@ export const Home = () => {
 
     return (
         <h3>User: {identity.details.firstName} {identity.details.lastName}</h3>
+    );
+};
+```
+
+### Refreshing with hook
+
+Since the `useIdentity()` returns an instance of the `IIdentityContext`. So for refreshing with a hook, its easily
+accessible:
+
+```typescript
+import { useIdentity } from '@aksio/cratis-applications-frontend/identity';
+
+type Identity = {
+    firstName: string;
+    lastName: string;
+};
+
+export const Home = () => {
+    const identity = useIdentity<Identity>();
+
+    return (
+        <h3>User: {identity.details.firstName} {identity.details.lastName}</h3>
+
+        {/* Refresh button */}
+        <button onClick={() => identity.refresh()}>Refresh identity</button>
     );
 };
 ```

--- a/Samples/Banking/Bank/Web/Home.tsx
+++ b/Samples/Banking/Bank/Web/Home.tsx
@@ -18,6 +18,7 @@ export const Home = () => {
             This microservice comes with a default Aksio setup.<br />
             <br />
             <h3>User: {identity.details.firstName} {identity.details.lastName}</h3>
+            <button onClick={() => identity.refresh()}>Refresh identity</button>
             <h2>Projects</h2>
             <ul>
                 <li>Concepts - used for holding reusable domain concepts.</li>

--- a/Source/ApplicationModel/Frontend/identity/IIdentityContext.ts
+++ b/Source/ApplicationModel/Frontend/identity/IIdentityContext.ts
@@ -14,4 +14,9 @@ export interface IIdentityContext<TDetails = {}> {
      * Whether the details are set.
      */
     isSet: boolean;
+
+    /**
+     * Refreshes the identity context.
+     */
+    refresh(): void;
 }

--- a/Source/ApplicationModel/Frontend/identity/IdentityProvider.tsx
+++ b/Source/ApplicationModel/Frontend/identity/IdentityProvider.tsx
@@ -7,7 +7,8 @@ import { useState, useEffect } from 'react';
 
 const defaultIdentityContext: IIdentityContext = {
     details: {},
-    isSet: false
+    isSet: false,
+    refresh() { }
 };
 
 export const IdentityProviderContext = React.createContext<IIdentityContext>(defaultIdentityContext);
@@ -29,24 +30,34 @@ function getCookie(name: string) {
     return [];
 }
 
+function clearCookie(name: string) {
+    document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+}
+
 export const IdentityProvider = (props: IdentityProviderProps) => {
     const [context, setContext] = useState<IIdentityContext>(defaultIdentityContext);
+    const refresh = () => {
+        clearCookie(cookieName);
+        fetch('/.aksio/me').then(async response => {
+            const json = await response.json();
+            setContext({
+                details: json,
+                isSet: true,
+                refresh
+            });
+        });
+    };
     const identityCookie = getCookie(cookieName);
     useEffect(() => {
         if (identityCookie.length == 2) {
             const json = atob(identityCookie[1]);
             setContext({
                 details: JSON.parse(json.toString()),
-                isSet: true
+                isSet: true,
+                refresh
             });
         } else {
-            fetch('/.aksio/me').then(async response => {
-                const json = await response.json();
-                setContext({
-                    details: json,
-                    isSet: true
-                });
-            });
+            refresh();
         }
     }, []);
 

--- a/Source/ApplicationModel/Tooling/ProxyGenerator/Syntax/ClassDeclarationSyntaxExtensions.cs
+++ b/Source/ApplicationModel/Tooling/ProxyGenerator/Syntax/ClassDeclarationSyntaxExtensions.cs
@@ -37,9 +37,9 @@ public static class ClassDeclarationSyntaxExtensions
             parent = parent.Parent;
         }
 
-        var nameSpace = parent as NamespaceDeclarationSyntax;
-        Contract.Assert(nameSpace != null);
-        var stringBuilder = new StringBuilder().Append(nameSpace!.Name).Append(NamespaceClassDelimiter);
+        var @namespace = parent as NamespaceDeclarationSyntax;
+        Contract.Assert(@namespace != null);
+        var stringBuilder = new StringBuilder().Append(@namespace!.Name).Append(NamespaceClassDelimiter);
         items.Reverse();
         items.ForEach(i => stringBuilder.Append(i).Append(NestedClassDelimiter));
         stringBuilder.Append(source.Identifier.Text);


### PR DESCRIPTION
### Added

- Introducing a refresh method on the `IIdentityContext` returned from the `useIdentity()` or use the context directly. This enables you to refresh the identity if there are changes in the backend.

