### PR TITLE
Fix/results

### DIFF
--- a/Documentation/application-model/cqrs/toc.yml
+++ b/Documentation/application-model/cqrs/toc.yml
@@ -1,2 +1,4 @@
 - name: Queries
   href: queries.md
+- name: Without wrappers
+  href: without-wrappers.md

--- a/Documentation/application-model/cqrs/without-wrappers.md
+++ b/Documentation/application-model/cqrs/without-wrappers.md
@@ -1,0 +1,57 @@
+# Without wrappers
+
+When using either Commands or [Queries](./queries.md), the result is wrapped in a more descriptive
+structure that will include the result returned by your controller action.This behavior is not an
+opt-in on a per controller or action level, making it a cross cutting always on behavior.
+
+If you need controller based endpoints that do not have the encapsulation of the `CommandResult` or the
+`QueryResult` structures, you can use an attribute called `[AspNetResult]`.
+
+The attribute can be used on a controller or a specific action. Once used, the result is kept as is from
+the action called.
+
+> Important note: The behavior of not allowing an invalid state is still kept intact, meaning that if you
+> have validation that kicks in and makes the `ModelState`invalid, both the command and the query action
+> filters will not call the action.
+
+To keep the original result on a controller level, place the attribute before the controller:
+
+```csharp
+[Route("/api/accounts/debit")]
+[AspNetResult]  // <-
+public class Accounts : Controller
+{
+    [HttpGet("starting-with")]
+    public async Task<IEnumerable<DebitAccount>> StartingWith([FromQuery] string? filter)
+    {
+        /* Code that gets the data and returns it */
+    }
+
+    [HttpGet("latest-transactions/{accountId}")]
+    public DebitAccountLatestTransactions LatestTransactions([FromRoute] AccountId accountId)
+    {
+        /* Code that gets the data and returns it */
+    }
+}
+```
+
+To keep the original result on an action level, place the attribute before the action:
+
+```csharp
+[Route("/api/accounts/debit")]
+public class Accounts : Controller
+{
+    [HttpGet("starting-with")]
+    [AspNetResult]  // <-
+    public async Task<IEnumerable<DebitAccount>> StartingWith([FromQuery] string? filter)
+    {
+        /* Code that gets the data and returns it */
+    }
+
+    [HttpGet("latest-transactions/{accountId}")]
+    public DebitAccountLatestTransactions LatestTransactions([FromRoute] AccountId accountId)
+    {
+        /* Code that gets the data and returns it */
+    }
+}
+```

--- a/Samples/Banking/Bank/Read/Accounts/Debit/Accounts.cs
+++ b/Samples/Banking/Bank/Read/Accounts/Debit/Accounts.cs
@@ -27,6 +27,7 @@ public class Accounts : Controller
     {
         return _accountsCollection.Observe();
     }
+
     [HttpGet("starting-with")]
     public async Task<IEnumerable<DebitAccount>> StartingWith([FromQuery] string? filter)
     {

--- a/Source/ApplicationModel/CQRS/Commands/AspNetResultAttribute.cs
+++ b/Source/ApplicationModel/CQRS/Commands/AspNetResultAttribute.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Aksio.Cratis.Applications.Commands;
+
+/// <summary>
+/// Represents an attribute that indicates that the result of actions in a controller should be returned as an ASP.NET result.
+/// </summary>
+/// <remarks>
+/// Can be used for an entire controller or individual actions.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class AspNetResultAttribute : Attribute, IFilterMetadata
+{
+}

--- a/Source/ApplicationModel/CQRS/Commands/AspNetResultExtensions.cs
+++ b/Source/ApplicationModel/CQRS/Commands/AspNetResultExtensions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Applications.Commands;
+
+namespace Microsoft.AspNetCore.Mvc.Filters;
+
+/// <summary>
+/// Extensions for <see cref="ActionExecutingContext"/>.
+/// </summary>
+public static class AspNetResultExtensions
+{
+    /// <summary>
+    /// Check if an action has the with <see cref="AspNetResultAttribute"/> as filter.
+    /// </summary>
+    /// <param name="context"><see cref="ActionExecutingContext"/> to check.</param>
+    /// <returns>True if it has, false if not.</returns>
+    public static bool IsAspNetResult(this ActionExecutingContext context)
+        => context.Filters.Any(_ => _ is AspNetResultAttribute);
+}

--- a/Source/ApplicationModel/CQRS/Commands/CommandActionFilter.cs
+++ b/Source/ApplicationModel/CQRS/Commands/CommandActionFilter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Net;
 using Aksio.Cratis.Applications.Validation;
 using Aksio.Cratis.Commands;
 using Aksio.Cratis.Execution;
@@ -38,6 +39,8 @@ public class CommandActionFilter : IAsyncActionFilter
             {
                 result = await next();
 
+                if (context.IsAspNetResult()) return;
+
                 if (result.Exception is not null)
                 {
                     var exception = result.Exception;
@@ -70,15 +73,15 @@ public class CommandActionFilter : IAsyncActionFilter
 
             if (!commandResult.IsAuthorized)
             {
-                context.HttpContext.Response.StatusCode = 401;   // Forbidden: https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized
+                context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Forbidden;            // Forbidden: https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized
             }
             else if (!commandResult.IsValid)
             {
-                context.HttpContext.Response.StatusCode = 409;   // Conflict: https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict
+                context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Conflict;             // Conflict: https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict
             }
             else if (commandResult.HasExceptions)
             {
-                context.HttpContext.Response.StatusCode = 500;  // Internal Server error: https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error
+                context.HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;  // Internal Server error: https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error
             }
 
             var actualResult = new ObjectResult(commandResult);

--- a/Source/ApplicationModel/CQRS/Queries/QueryActionFilter.cs
+++ b/Source/ApplicationModel/CQRS/Queries/QueryActionFilter.cs
@@ -49,6 +49,8 @@ public class QueryActionFilter : IAsyncActionFilter
             {
                 result = await next();
 
+                if (context.IsAspNetResult()) return;
+
                 if (result.Exception is not null)
                 {
                     var exception = result.Exception;


### PR DESCRIPTION
### Added

- Added attribute `[AspNetResult]` to let controllers skip the wrapping of results into a `CommandResult` or a `QueryResult`.
