### PR TITLE
Fix/mongo

### DIFF
--- a/Source/ApplicationModel/CQRS.MongoDB/MongoDBCollectionExtensions.cs
+++ b/Source/ApplicationModel/CQRS.MongoDB/MongoDBCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq.Expressions;
 using System.Reflection;
 using Aksio.Cratis.Concepts;
 using MongoDB.Bson;
@@ -34,6 +35,24 @@ public static class MongoDBCollectionExtensions
     /// <returns>Async Task holding <see cref="ClientObservable{T}"/> with a collection of the type for the collection.</returns>
     public static async Task<ClientObservable<IEnumerable<TDocument>>> Observe<TDocument>(
         this IMongoCollection<TDocument> collection,
+        Expression<Func<TDocument, bool>>? filter,
+        FindOptions<TDocument, TDocument>? options = null)
+    {
+        filter ??= _ => true;
+        return await collection.Observe<TDocument, IEnumerable<TDocument>>(() => collection.FindAsync(filter, options), (cursor, observable) =>
+            observable.OnNext(cursor.ToList()));
+    }
+
+    /// <summary>
+    /// Create an observable query that will observe the collection for changes matching the filter criteria.
+    /// </summary>
+    /// <param name="collection"><see cref="IMongoCollection{T}"/> to extend.</param>
+    /// <param name="filter">Optional filter.</param>
+    /// <param name="options">Optional options.</param>
+    /// <typeparam name="TDocument">Type of document in the collection.</typeparam>
+    /// <returns>Async Task holding <see cref="ClientObservable{T}"/> with a collection of the type for the collection.</returns>
+    public static async Task<ClientObservable<IEnumerable<TDocument>>> Observe<TDocument>(
+        this IMongoCollection<TDocument> collection,
         FilterDefinition<TDocument>? filter = null,
         FindOptions<TDocument, TDocument>? options = null)
     {
@@ -41,6 +60,23 @@ public static class MongoDBCollectionExtensions
         return await collection.Observe<TDocument, IEnumerable<TDocument>>(
             () => collection.FindAsync(filter, options),
             (documents, observable) => observable.OnNext(documents));
+    }
+
+    /// <summary>
+    /// Create an observable query that will observe the collection for changes matching the filter criteria.
+    /// </summary>
+    /// <param name="collection"><see cref="IMongoCollection{T}"/> to extend.</param>
+    /// <param name="filter">Optional filter.</param>
+    /// <param name="options">Optional options.</param>
+    /// <typeparam name="TDocument">Type of document in the collection.</typeparam>
+    /// <returns>Async Task holding <see cref="ClientObservable{T}"/> with a collection of the type for the collection.</returns>
+    public static async Task<ClientObservable<TDocument>> ObserveSingle<TDocument>(
+        this IMongoCollection<TDocument> collection,
+        Expression<Func<TDocument, bool>>? filter,
+        FindOptions<TDocument, TDocument>? options = null)
+    {
+        filter ??= _ => true;
+        return await collection.ObserveSingle(() => collection.FindAsync(filter, options));
     }
 
     /// <summary>


### PR DESCRIPTION
### Fixed

- Bringing back `Expression` overloads for `Observe()` methods on the `MongoDBCollectionExtensions`. This was unintended in previous build, based on an assumption that the implicit operators for `FilterDefinition` would take care of the conversion.
