### PR TITLE
Fix/memory-leak

### DIFF
--- a/Documentation/clients/dotnet/model-names.md
+++ b/Documentation/clients/dotnet/model-names.md
@@ -25,6 +25,7 @@ The convention supports the following optional parameters on the constructor:
 | --------- | ----------- | ------- |
 | segmentsToSkip | Number of segments in the namespace to skip. | 0 |
 | separator | Character to use for separating namespace segments. | - |
+| prefix | Optional prefix to prepend collection names with. | [empty] |
 
 ## Custom convention
 

--- a/Documentation/configuration/kernel/telemetry.md
+++ b/Documentation/configuration/kernel/telemetry.md
@@ -1,17 +1,51 @@
 # Telemetry
 
-The Cratis Kernel is built on top of Orleans which offers telemetry which is helpful for monitoring.
-Within the `cratis.json` file you can configure the telemetry by adding the following key:
+The Cratis Kernel supports telemetry and has exporters for the following out of the box:
+
+* Open Telemetry
+* Azure Monitor (Application Insights)
+
+To add telemetry to the Kernel, all you have to do is configure the `telemetry` option of the `cratis.json`
+file:
+
+```json
+{
+    "telemetry": {
+        "type": "<type>",
+        "options": { }
+    }
+}
+```
+
+> Note: The options key holds a specific object that is for the type you configure.
+
+## Open Telemetry
+
+The configuration for Open Telemetry is as follows:
+
+```json
+{
+    "telemetry": {
+        "type": "open-telemetry",
+        "options": {
+            "endpoint": "<insert the url to export to>"
+        }
+    }
+}
+```
+
+## Azure Monitor (Application Insights)
+
+The configuration for Azure Monitor is as follows:
 
 ```json
 {
     "telemetry": {
         "type": "app-insights",
         "options": {
-            "key": "<insert the application insights instrumentation key>"
+            "key": "<insert the application insights instrumentation key>",
+            "connectionString": "<insert the application insights connection string>"
         }
     }
 }
 ```
-
-> Note: 29th of August, Cratis only supports Azure Application Insights.

--- a/Samples/Banking/Bank/Main/appsettings.Development.json
+++ b/Samples/Banking/Bank/Main/appsettings.Development.json
@@ -8,7 +8,7 @@
             "Override": {
                 "Aksio": "Information",
                 "Microsoft": "Warning",
-                "Microsoft.AspNetCore.HttpLogging": "Information",
+                "Microsoft.AspNetCore.HttpLogging": "Warning",
                 "Microsoft.Hosting.Lifetime": "Information",
                 "System": "Warning",
                 "Orleans": "Information",

--- a/Samples/Banking/Bank/Read/Accounts/Debit/Accounts.cs
+++ b/Samples/Banking/Bank/Read/Accounts/Debit/Accounts.cs
@@ -22,6 +22,9 @@ public class Accounts : Controller
         _accountsPerDayCollection = accountsPerDayCollection;
     }
 
+    [HttpGet("{accountId}")]
+    public Task<ClientObservable<DebitAccount>> SpecificDebitAccount([FromRoute] AccountId accountId) => _accountsCollection.ObserveById(accountId);
+
     [HttpGet]
     public Task<ClientObservable<IEnumerable<DebitAccount>>> AllAccounts()
     {

--- a/Samples/Banking/Bank/Web/API/accounts/debit/SpecificDebitAccount.ts
+++ b/Samples/Banking/Bank/Web/API/accounts/debit/SpecificDebitAccount.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  **DO NOT EDIT** - This file is an automatically generated file.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ObservableQueryFor, QueryResultWithState, useObservableQuery } from '@aksio/cratis-applications-frontend/queries';
+import { DebitAccount } from './DebitAccount';
+import Handlebars from 'handlebars';
+
+const routeTemplate = Handlebars.compile('/api/accounts/debit/{{accountId}}');
+
+export interface SpecificDebitAccountArguments {
+    accountId: string;
+}
+export class SpecificDebitAccount extends ObservableQueryFor<DebitAccount, SpecificDebitAccountArguments> {
+    readonly route: string = '/api/accounts/debit/{{accountId}}';
+    readonly routeTemplate: Handlebars.TemplateDelegate = routeTemplate;
+    readonly defaultValue: DebitAccount = {} as any;
+
+    constructor() {
+        super(DebitAccount, false);
+    }
+
+    get requestArguments(): string[] {
+        return [
+            'accountId',
+        ];
+    }
+
+    static use(args?: SpecificDebitAccountArguments): [QueryResultWithState<DebitAccount>] {
+        return useObservableQuery<DebitAccount, SpecificDebitAccount, SpecificDebitAccountArguments>(SpecificDebitAccount, args);
+    }
+}

--- a/Samples/Banking/Bank/Web/Accounts/Debit/DebitAccounts.tsx
+++ b/Samples/Banking/Bank/Web/Accounts/Debit/DebitAccounts.tsx
@@ -29,9 +29,11 @@ import { CommandScope, CommandScopeContext, useCommandScope } from '@aksio/crati
 import { DebitAccountsList } from './DebitAccountsList';
 import 'reflect-metadata';
 import { AllAccountHoldersWithAccounts } from 'API/accountholders/AllAccountHoldersWithAccounts';
+import { useNavigate } from 'react-router-dom';
 
 
 export const DebitAccounts = () => {
+    const navigate = useNavigate();
     const [accounts] = AllAccounts.use();
     const [openDebitAccount, setOpenDebitAccountValues] = OpenDebitAccount.use();
     const [holdersWithAccounts] = AllAccountHoldersWithAccounts.use();
@@ -75,6 +77,10 @@ export const DebitAccounts = () => {
             await command.execute();
         }
     });
+
+    const navigateToLedger = () => {
+        navigate(`/accounts/debit/${selectedItem.id}/ledger`);
+    }
 
     const searchFor = (filter: string) => {
         if (filter && filter !== '') {
@@ -126,6 +132,16 @@ export const DebitAccounts = () => {
                 onClick: () => showWithdrawAmountDialog({ okTitle: 'Withdraw' })
             }
         );
+
+        commandBarItems.push(
+            {
+                key: 'ledger',
+                name: 'Ledger',
+                iconProps: { iconName: 'Money' },
+                onClick: navigateToLedger
+            }
+        );
+
     }
 
     const selection = useMemo(

--- a/Samples/Banking/Bank/Web/Accounts/Debit/Ledger.tsx
+++ b/Samples/Banking/Bank/Web/Accounts/Debit/Ledger.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { useParams } from 'react-router-dom';
+import { SpecificDebitAccount } from '../../API/accounts/debit/SpecificDebitAccount';
+
+export const Ledger = () => {
+    const params = useParams();
+    const [account] = SpecificDebitAccount.use({ accountId: params.id! });
+
+    return (
+        <>
+            <h1>{account.data.name}</h1>
+        </>
+    );
+};

--- a/Samples/Banking/Bank/Web/App.tsx
+++ b/Samples/Banking/Bank/Web/App.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { default as styles } from './App.module.scss';
 import { Navigation } from './Navigation';
 import { Home } from './Home';
+import { Ledger } from './Accounts/Debit/Ledger';
 import { DebitAccounts } from './Accounts/Debit/DebitAccounts';
 import { AccountHolders } from './AccountHolders/AccountHolders';
 import { IdentityProvider } from '@aksio/cratis-applications-frontend/identity';
@@ -21,6 +22,7 @@ export const App = () => {
                         <Routes>
                             <Route path="/" element={<Home />} />
                             <Route path="/accounts/debit" element={<DebitAccounts />} />
+                            <Route path="/accounts/debit/:id/ledger" element={<Ledger />} />
                             <Route path="/integration" element={<AccountHolders />} />
                         </Routes>
                     </div>

--- a/Source/Extensions/MongoDB/MongoDBClientFactory.cs
+++ b/Source/Extensions/MongoDB/MongoDBClientFactory.cs
@@ -44,9 +44,14 @@ public class MongoDBClientFactory : IMongoDBClientFactory
 
     void ClusterConfigurator(ClusterBuilder builder)
     {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            builder
+                .Subscribe<CommandStartedEvent>(command => _logger.CommandStarted(command.RequestId, command.CommandName, command.Command.ToJson()))
+                .Subscribe<CommandSucceededEvent>(command => _logger.CommandSucceeded(command.RequestId, command.CommandName));
+        }
+
         builder
-            .Subscribe<CommandStartedEvent>(command => _logger.CommandStarted(command.RequestId, command.CommandName, command.Command.ToJson()))
-            .Subscribe<CommandFailedEvent>(command => _logger.CommandFailed(command.RequestId, command.CommandName, command.Failure.Message))
-            .Subscribe<CommandSucceededEvent>(command => _logger.CommandSucceeded(command.RequestId, command.CommandName));
+            .Subscribe<CommandFailedEvent>(command => _logger.CommandFailed(command.RequestId, command.CommandName, command.Failure.Message));
     }
 }

--- a/Source/Fundamentals/Json/ConceptAsJsonConverter.cs
+++ b/Source/Fundamentals/Json/ConceptAsJsonConverter.cs
@@ -27,6 +27,10 @@ public class ConceptAsJsonConverter<T> : JsonConverter<T>
                 break;
 
             case JsonTokenType.Number:
+                if (conceptValueType == typeof(byte))
+                {
+                    value = reader.GetByte();
+                }
                 if (conceptValueType == typeof(sbyte))
                 {
                     value = reader.GetSByte();
@@ -98,14 +102,72 @@ public class ConceptAsJsonConverter<T> : JsonConverter<T>
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
     {
         var actualValue = value?.GetConceptValue();
+        if (actualValue is null) return;
+
         var conceptValueType = typeof(T).GetConceptValueType();
         if (conceptValueType == typeof(DateOnly))
         {
-            writer.WriteStringValue(((DateOnly)actualValue!).ToString("O"));
+            writer.WriteStringValue(((DateOnly)actualValue).ToString("O"));
         }
         else if (conceptValueType == typeof(TimeOnly))
         {
-            writer.WriteStringValue(((TimeOnly)actualValue!).ToString("O"));
+            writer.WriteStringValue(((TimeOnly)actualValue).ToString("O"));
+        }
+        else if (conceptValueType == typeof(byte))
+        {
+            writer.WriteNumberValue((byte)actualValue);
+        }
+        else if (conceptValueType == typeof(sbyte))
+        {
+            writer.WriteNumberValue((sbyte)actualValue);
+        }
+        else if (conceptValueType == typeof(short))
+        {
+            writer.WriteNumberValue((short)actualValue);
+        }
+        else if (conceptValueType == typeof(ushort))
+        {
+            writer.WriteNumberValue((ushort)actualValue);
+        }
+        else if (conceptValueType == typeof(int))
+        {
+            writer.WriteNumberValue((int)actualValue);
+        }
+        else if (conceptValueType == typeof(uint))
+        {
+            writer.WriteNumberValue((uint)actualValue);
+        }
+        else if (conceptValueType == typeof(long))
+        {
+            writer.WriteNumberValue((long)actualValue);
+        }
+        else if (conceptValueType == typeof(ulong))
+        {
+            writer.WriteNumberValue((ulong)actualValue);
+        }
+        else if (conceptValueType == typeof(float))
+        {
+            writer.WriteNumberValue((float)actualValue);
+        }
+        else if (conceptValueType == typeof(double))
+        {
+            writer.WriteNumberValue((double)actualValue);
+        }
+        else if (conceptValueType == typeof(decimal))
+        {
+            writer.WriteNumberValue((decimal)actualValue);
+        }
+        else if (conceptValueType == typeof(bool))
+        {
+            writer.WriteBooleanValue((bool)actualValue);
+        }
+        else if (conceptValueType == typeof(Guid))
+        {
+            writer.WriteStringValue(actualValue.ToString());
+        }
+        else if (conceptValueType.IsEnum)
+        {
+            writer.WriteNumberValue((int)actualValue);
         }
         else
         {

--- a/Source/Fundamentals/Models/NamespacedModelNameConvention.cs
+++ b/Source/Fundamentals/Models/NamespacedModelNameConvention.cs
@@ -13,16 +13,19 @@ public class NamespacedModelNameConvention : IModelNameConvention
 {
     readonly int _segmentsToSkip;
     readonly char _separator;
+    readonly string _prefix;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NamespacedModelNameConvention"/> class.
     /// </summary>
     /// <param name="segmentsToSkip">Optionally number of segments in the namespace to skip. Defaults to 0.</param>
     /// <param name="separator">Optional separator character to use between namespace segments. Defaults to 0.</param>
-    public NamespacedModelNameConvention(int segmentsToSkip = 0, char separator = '-')
+    /// <param name="prefix">Optional prefix to prepend all collection names with.</param>
+    public NamespacedModelNameConvention(int segmentsToSkip = 0, char separator = '-', string prefix = "")
     {
         _segmentsToSkip = segmentsToSkip;
         _separator = separator;
+        _prefix = prefix;
     }
 
     /// <inheritdoc/>
@@ -30,6 +33,6 @@ public class NamespacedModelNameConvention : IModelNameConvention
     {
         var segments = type.Namespace?.Split('.') ?? Array.Empty<string>();
         var prefix = string.Join(_separator, segments.Skip(_segmentsToSkip).Select(_ => _.ToCamelCase()));
-        return $"{prefix}-{type.Name.Pluralize().ToCamelCase()}";
+        return $"{_prefix}{prefix}-{type.Name.Pluralize().ToCamelCase()}";
     }
 }

--- a/Source/Kernel/MongoDB/Clients/ConnectedClientsStorageProvider.cs
+++ b/Source/Kernel/MongoDB/Clients/ConnectedClientsStorageProvider.cs
@@ -36,8 +36,8 @@ public class ConnectedClientsStorageProvider : IGrainStorage
     public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
     {
         var microserviceId = (MicroserviceId)grainReference.GetPrimaryKey();
-        var cursor = await Collection.FindAsync(_ => _.Id == microserviceId);
-        var mongoState = await cursor.FirstOrDefaultAsync();
+        var cursor = await Collection.FindAsync(_ => _.Id == microserviceId).ConfigureAwait(false);
+        var mongoState = await cursor.FirstOrDefaultAsync().ConfigureAwait(false);
 
         grainState.State = new ConnectedClientsState
         {
@@ -46,11 +46,11 @@ public class ConnectedClientsStorageProvider : IGrainStorage
     }
 
     /// <inheritdoc/>
-    public Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+    public async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
     {
         var microserviceId = (MicroserviceId)grainReference.GetPrimaryKey();
         var state = (grainState.State as ConnectedClientsState)!;
         var mongoState = new MongoDBConnectedClientsForMicroserviceState(microserviceId, state.Clients);
-        return Collection.ReplaceOneAsync(_ => _.Id == microserviceId, mongoState, options: new ReplaceOptions { IsUpsert = true });
+        await Collection.ReplaceOneAsync(_ => _.Id == microserviceId, mongoState, options: new ReplaceOptions { IsUpsert = true }).ConfigureAwait(false);
     }
 }

--- a/Source/Kernel/MongoDB/Observation/ObserverStorageProvider.cs
+++ b/Source/Kernel/MongoDB/Observation/ObserverStorageProvider.cs
@@ -61,7 +61,7 @@ public class ObserverStorageProvider : IGrainStorage
 
         ExecutionContextManager.Establish(observerKey.TenantId, CorrelationId.New(), observerKey.MicroserviceId);
 
-        var failedPartitionsCursor = await RecoverFailedPartitionCollection.FindAsync(_ => _.ObserverId == observerId);
+        var failedPartitionsCursor = await RecoverFailedPartitionCollection.FindAsync(_ => _.ObserverId == observerId).ConfigureAwait(false);
         var failedPartitions = failedPartitionsCursor.ToList().Select(_ => new FailedPartition(
             _.Partition,
             _.CurrentError,
@@ -70,8 +70,8 @@ public class ObserverStorageProvider : IGrainStorage
             _.InitialPartitionFailedOn)).ToArray();
 
         var key = GetKeyFrom(observerKey, observerId);
-        var cursor = await Collection.FindAsync(_ => _.Id == key);
-        var state = await cursor.FirstOrDefaultAsync() ?? new ObserverState
+        var cursor = await Collection.FindAsync(_ => _.Id == key).ConfigureAwait(false);
+        var state = await cursor.FirstOrDefaultAsync().ConfigureAwait(false) ?? new ObserverState
         {
             Id = key,
             EventSequenceId = eventSequenceId,
@@ -98,7 +98,7 @@ public class ObserverStorageProvider : IGrainStorage
         await Collection.ReplaceOneAsync(
             _ => _.Id == key,
             observerState!,
-            new ReplaceOptions { IsUpsert = true });
+            new ReplaceOptions { IsUpsert = true }).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Source/Kernel/MongoDB/Observation/RecoverFailedPartitionStorageProvider.cs
+++ b/Source/Kernel/MongoDB/Observation/RecoverFailedPartitionStorageProvider.cs
@@ -51,7 +51,7 @@ public class RecoverFailedPartitionStorageProvider : IGrainStorage
         ExecutionContextManager.Establish(partitionedObserverKey.TenantId, CorrelationId.New(), partitionedObserverKey.MicroserviceId);
 
         var key = GetKeyFrom(partitionedObserverKey, observerId);
-        await Collection.DeleteOneAsync(_ => _.Id == key);
+        await Collection.DeleteOneAsync(_ => _.Id == key).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -63,9 +63,9 @@ public class RecoverFailedPartitionStorageProvider : IGrainStorage
         ExecutionContextManager.Establish(partitionedObserverKey.TenantId, CorrelationId.New(), partitionedObserverKey.MicroserviceId);
 
         var key = GetKeyFrom(partitionedObserverKey, observerId);
-        var cursor = await Collection.FindAsync(_ => _.Id == key);
+        var cursor = await Collection.FindAsync(_ => _.Id == key).ConfigureAwait(false);
 
-        grainState.State = await cursor.FirstOrDefaultAsync() ?? new RecoverFailedPartitionState()
+        grainState.State = await cursor.FirstOrDefaultAsync().ConfigureAwait(false) ?? new RecoverFailedPartitionState()
         {
             Id = key,
             ObserverId = observerId
@@ -85,14 +85,14 @@ public class RecoverFailedPartitionStorageProvider : IGrainStorage
 
         if (!observerState.HasBeenInitialized())
         {
-            await Collection.DeleteOneAsync(_ => _.Id == key);
+            await Collection.DeleteOneAsync(_ => _.Id == key).ConfigureAwait(false);
         }
         else
         {
             await Collection.ReplaceOneAsync(
                 _ => _.Id == key,
                 observerState!,
-                new ReplaceOptions { IsUpsert = true });
+                new ReplaceOptions { IsUpsert = true }).ConfigureAwait(false);
         }
     }
 

--- a/Source/Kernel/MongoDB/Observation/ReplayStorageProvider.cs
+++ b/Source/Kernel/MongoDB/Observation/ReplayStorageProvider.cs
@@ -49,6 +49,6 @@ public class ReplayStorageProvider : ObserverStorageProvider
         await Collection.UpdateOneAsync(
             _ => _.Id == key,
             update,
-            new UpdateOptions { IsUpsert = true });
+            new UpdateOptions { IsUpsert = true }).ConfigureAwait(false);
     }
 }

--- a/Source/Kernel/MongoDB/Tenants/TenantConfigurationStorageProvider.cs
+++ b/Source/Kernel/MongoDB/Tenants/TenantConfigurationStorageProvider.cs
@@ -35,8 +35,8 @@ public class TenantConfigurationStorageProvider : IGrainStorage
     public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
     {
         var tenantId = (TenantId)grainReference.GetPrimaryKey();
-        var cursor = await Collection.FindAsync(_ => _.Id == tenantId);
-        var state = await cursor.FirstOrDefaultAsync();
+        var cursor = await Collection.FindAsync(_ => _.Id == tenantId).ConfigureAwait(false);
+        var state = await cursor.FirstOrDefaultAsync().ConfigureAwait(false);
         if (state is not null)
         {
             grainState.State = new TenantConfigurationState(state.Configuration.ToDictionary(_ => _.Key, _ => _.Value));
@@ -56,6 +56,6 @@ public class TenantConfigurationStorageProvider : IGrainStorage
         await Collection.ReplaceOneAsync(
             _ => _.Id == tenantId,
             mongoDBState,
-            new ReplaceOptions { IsUpsert = true });
+            new ReplaceOptions { IsUpsert = true }).ConfigureAwait(false);
     }
 }

--- a/Source/Kernel/Server/Server.csproj
+++ b/Source/Kernel/Server/Server.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
+        <OutputType>Exe</OutputType>
         <AssemblyName>Aksio.Cratis.Kernel.Server</AssemblyName>
         <RootNamespace>Aksio.Cratis.Kernel.Server</RootNamespace>
         <InvariantGlobalization>true</InvariantGlobalization>
         <PublishReadyToRunShowWarnings>false</PublishReadyToRunShowWarnings>
-        <ServerGarbageCollection>true</ServerGarbageCollection>
+        <ServerGarbageCollection>false</ServerGarbageCollection>
     </PropertyGroup>
 
     <!-- 3rd party package references -->

--- a/Source/Kernel/Server/appsettings.Development.json
+++ b/Source/Kernel/Server/appsettings.Development.json
@@ -8,6 +8,7 @@
             "Override": {
                 "Aksio": "Information",
                 "Microsoft": "Warning",
+                "Microsoft.AspNetCore.HttpLogging": "Warning",
                 "Microsoft.Hosting.Lifetime": "Information",
                 "System": "Warning",
                 "Orleans": "Information"


### PR DESCRIPTION
# Summary

This release focuses on what we've seen as memory leakage. After heavy investigation we're seeing that the use of server garbage collector, which is default for any ASP.NET Core based projects, is suboptimal. The Kernel on its own is serialization heavy, meaning that anything coming in our out of the Kernel is serialized. Serialization happens on multiple levels; database -> kernel, kernel -> clients and with Orleans its all serialization for every call being made. Serialization tends to allocate a lot of small objects, not noticable with little traffic as it would be collected even by the server GC pretty fast. But with load, this amounts up and the heap just grows. 

[Microsoft documentation](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/workstation-server-gc) recommends using a server GC in a multi-processor(core) environment. Our findings is that for a serialization heavy solution like the Cratis Kernel, this does not seem to be valid. Garbage collection happens has a too low priority and we end up eating more memory than needed.

### Changed

- Disabled server garbage collector for Kernel.

### Fixed

- Optimized memory allocation in `ConceptConverter` by not reverting to `JsonSerializer` for values.
- Using `.ConfigureAwait(false)` for MongoDB based Orleans Grain state providers. This seems to be best practice.
- Fixing MongoDB extensions for observing with filters, it now uses the filter directly in the `Watch` and will only be notified of documents that match the filter.

