### PR TITLE
Adding support for retrying a partition manually

### DIFF
--- a/Source/Kernel/Domain/Observation/Observers.cs
+++ b/Source/Kernel/Domain/Observation/Observers.cs
@@ -78,6 +78,25 @@ public class Observers : Controller
     }
 
     /// <summary>
+    /// Retry a specific partition for a microservice and tenant.
+    /// </summary>
+    /// <param name="microserviceId"></param>
+    /// <param name="tenantId"></param>
+    /// <param name="observerId"></param>
+    /// <param name="partitionId"></param>
+    /// <returns>Awaitable task.</returns>
+    [HttpPost("{observerId}/failed-partitions/{tenantId}/retry/{partitionId}")]
+    public async Task RetryPartition(
+        [FromRoute] MicroserviceId microserviceId,
+        [FromRoute] TenantId tenantId,
+        [FromRoute] ObserverId observerId,
+        [FromRoute] EventSourceId partitionId)
+    {
+        var observer = _grainFactory.GetGrain<IObserverSupervisor>(observerId, new ObserverKey(microserviceId, tenantId, EventSequenceId.Log));
+        await observer.TryResumePartition(partitionId);
+    }
+
+    /// <summary>
     /// Rewind a specific observer for a microservice and tenant.
     /// </summary>
     /// <param name="microserviceId"><see cref="MicroserviceId"/> the observer is for.</param>

--- a/Source/Kernel/Domain/Observation/Observers.cs
+++ b/Source/Kernel/Domain/Observation/Observers.cs
@@ -80,10 +80,10 @@ public class Observers : Controller
     /// <summary>
     /// Retry a specific partition for a microservice and tenant.
     /// </summary>
-    /// <param name="microserviceId"></param>
-    /// <param name="tenantId"></param>
-    /// <param name="observerId"></param>
-    /// <param name="partitionId"></param>
+    /// <param name="microserviceId"><see cref="MicroserviceId"/> the observer is for.</param>
+    /// <param name="tenantId"><see cref="TenantId"/> the observer is for.</param>
+    /// <param name="observerId"><see cref="ObserverId"/> to rewind.</param>
+    /// <param name="partitionId"><see cref="EventSourceId">Partition</see> to retry.</param>
     /// <returns>Awaitable task.</returns>
     [HttpPost("{observerId}/failed-partitions/{tenantId}/retry/{partitionId}")]
     public async Task RetryPartition(

--- a/Source/Workbench/API/events/store/observers/RetryPartition.ts
+++ b/Source/Workbench/API/events/store/observers/RetryPartition.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  **DO NOT EDIT** - This file is an automatically generated file.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Command, CommandValidator, CommandPropertyValidators, useCommand, SetCommandValues, ClearCommandValues } from '@aksio/cratis-applications-frontend/commands';
+import { Validator } from '@aksio/cratis-applications-frontend/validation';
+import Handlebars from 'handlebars';
+
+const routeTemplate = Handlebars.compile('/api/events/store/{{microserviceId}}/observers/{{observerId}}/failed-partitions/{{tenantId}}/retry/{{partitionId}}');
+
+export interface IRetryPartition {
+    microserviceId?: string;
+    tenantId?: string;
+    observerId?: string;
+    partitionId?: string;
+}
+
+export class RetryPartitionValidator extends CommandValidator {
+    readonly properties: CommandPropertyValidators = {
+        microserviceId: new Validator(),
+        tenantId: new Validator(),
+        observerId: new Validator(),
+        partitionId: new Validator(),
+    };
+}
+
+export class RetryPartition extends Command<IRetryPartition> implements IRetryPartition {
+    readonly route: string = '/api/events/store/{{microserviceId}}/observers/{{observerId}}/failed-partitions/{{tenantId}}/retry/{{partitionId}}';
+    readonly routeTemplate: Handlebars.TemplateDelegate = routeTemplate;
+    readonly validation: CommandValidator = new RetryPartitionValidator();
+
+    private _microserviceId!: string;
+    private _tenantId!: string;
+    private _observerId!: string;
+    private _partitionId!: string;
+
+    constructor() {
+        super(Object, false);
+    }
+
+    get requestArguments(): string[] {
+        return [
+            'microserviceId',
+            'tenantId',
+            'observerId',
+            'partitionId',
+        ];
+    }
+
+    get properties(): string[] {
+        return [
+            'microserviceId',
+            'tenantId',
+            'observerId',
+            'partitionId',
+        ];
+    }
+
+    get microserviceId(): string {
+        return this._microserviceId;
+    }
+
+    set microserviceId(value: string) {
+        this._microserviceId = value;
+        this.propertyChanged('microserviceId');
+    }
+    get tenantId(): string {
+        return this._tenantId;
+    }
+
+    set tenantId(value: string) {
+        this._tenantId = value;
+        this.propertyChanged('tenantId');
+    }
+    get observerId(): string {
+        return this._observerId;
+    }
+
+    set observerId(value: string) {
+        this._observerId = value;
+        this.propertyChanged('observerId');
+    }
+    get partitionId(): string {
+        return this._partitionId;
+    }
+
+    set partitionId(value: string) {
+        this._partitionId = value;
+        this.propertyChanged('partitionId');
+    }
+
+    static use(initialValues?: IRetryPartition): [RetryPartition, SetCommandValues<IRetryPartition>, ClearCommandValues] {
+        return useCommand<RetryPartition, IRetryPartition>(RetryPartition, initialValues);
+    }
+}

--- a/Source/Workbench/eventStore/FailedPartitions.tsx
+++ b/Source/Workbench/eventStore/FailedPartitions.tsx
@@ -1,22 +1,20 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import {
-    Panel
-} from '@fluentui/react';
 import { useEffect, useState, useMemo } from 'react';
 import { AllFailedPartitions } from 'API/events/store/failed-partitions/AllFailedPartitions';
 import { AllTenants } from 'API/configuration/tenants/AllTenants';
 import { TenantInfo } from 'API/configuration/tenants/TenantInfo';
 import { RecoverFailedPartitionState } from 'API/events/store/failed-partitions/RecoverFailedPartitionState';
-import { useBoolean } from '@fluentui/react-hooks';
 import { AllEventSequences } from 'API/events/store/sequences/AllEventSequences';
 import { EventSequenceInformation } from 'API/events/store/sequences/EventSequenceInformation';
 import { QueryResultWithState } from '@aksio/cratis-applications-frontend/queries';
 import { useRouteParams } from './RouteParams';
-import { Box, Divider, FormControl, Grid, InputLabel, MenuItem, Select, Stack, TextField, Toolbar, Typography } from '@mui/material';
-import { DataGrid, GridColDef, GridValueGetterParams } from '@mui/x-data-grid';
+import { Box, Button, Divider, FormControl, Grid, InputLabel, MenuItem, Select, Stack, TextField, Toolbar, Typography } from '@mui/material';
+import { DataGrid, GridCallbackDetails, GridColDef, GridRowSelectionModel, GridValueGetterParams } from '@mui/x-data-grid';
 import { Label } from '@mui/icons-material';
+import * as icons from '@mui/icons-material';
+import { RetryPartition } from 'API/events/store/observers/RetryPartition';
 
 let eventSequences: QueryResultWithState<EventSequenceInformation[]>;
 
@@ -66,12 +64,13 @@ const columns: GridColDef[] = [
 
 export const FailedPartitions = () => {
     const { microserviceId } = useRouteParams();
+    const [retryCommand, setRetryCommandValues] = RetryPartition.use();
 
     const [es] = AllEventSequences.use();
     eventSequences = es;
     const [tenants] = AllTenants.use();
     const [selectedTenant, setSelectedTenant] = useState<TenantInfo>();
-    const [selectedItem, setSelectedItem] = useState<RecoverFailedPartitionState>();
+    const [selectedFailedPartition, setSelectedFailedPartition] = useState<RecoverFailedPartitionState>();
 
     const [failedPartitions] = AllFailedPartitions.use({
         microserviceId: microserviceId,
@@ -85,7 +84,14 @@ export const FailedPartitions = () => {
     }, [tenants.data]);
 
     const closePanel = () => {
-        setSelectedItem(undefined);
+        setSelectedFailedPartition(undefined);
+    };
+
+    const failedPartitionSelected = (selectionModel: GridRowSelectionModel, details: GridCallbackDetails) => {
+        const selectedItems = selectionModel.map(_ => failedPartitions.data.find(__ => __.id == _)) as RecoverFailedPartitionState[];
+        if (selectedItems.length > 0) {
+            setSelectedFailedPartition(selectedItems[0]);
+        }
     };
 
     return (
@@ -109,6 +115,20 @@ export const FailedPartitions = () => {
                             })}
                         </Select>
                     </FormControl>
+
+                    {selectedFailedPartition &&
+                        <Button
+                        startIcon={<icons.RestartAlt />}
+                        onClick={() => {
+                            setRetryCommandValues({
+                                observerId: selectedFailedPartition.observerId,
+                                microserviceId: microserviceId,
+                                tenantId: selectedTenant?.id,
+                                partitionId: selectedFailedPartition.partition,
+                            });
+                            retryCommand.execute();
+                        }}>Retry</Button>
+                    }
                 </Toolbar>
 
                 <Box sx={{ height: '100%', flex: 1 }}>
@@ -120,25 +140,26 @@ export const FailedPartitions = () => {
                                 sortingMode="client"
                                 getRowId={row => row.id}
                                 rows={failedPartitions.data}
+                                onRowSelectionModelChange={failedPartitionSelected}
                             />
                         </Grid>
                         <Grid item xs={4}>
                             <Box>
                                 <Typography variant='h5'>Details</Typography>
-                                {selectedItem &&
+                                {selectedFailedPartition &&
                                     <>
 
-                                        <Typography variant='h6'>{selectedItem?.observerName}</Typography>
+                                        <Typography variant='h6'>{selectedFailedPartition?.observerName}</Typography>
                                         <FormControl size='small' sx={{ m: 1, minWidth: '90%' }}>
                                             <TextField label='Occurred' disabled
-                                                defaultValue={(selectedItem?.initialPartitionFailedOn || new Date()).toISOString().toLocaleString()} />
+                                                defaultValue={(selectedFailedPartition?.initialPartitionFailedOn || new Date()).toISOString().toLocaleString()} />
                                         </FormControl>
                                         <Label>Messages</Label>
                                         {
-                                            (selectedItem?.messages) && selectedItem.messages.map((value, index) => <TextField key={index} disabled defaultValue={value.toString()} title={value.toString()} />)
+                                            (selectedFailedPartition?.messages) && selectedFailedPartition.messages.map((value, index) => <TextField key={index} disabled defaultValue={value.toString()} title={value.toString()} />)
                                         }
                                         <FormControl size='small' sx={{ m: 1, minWidth: '90%' }}>
-                                            <TextField label="Stack Trace" disabled defaultValue={selectedItem?.stackTrace} multiline title={selectedItem?.stackTrace.toString()} />
+                                            <TextField label="Stack Trace" disabled defaultValue={selectedFailedPartition?.stackTrace} multiline title={selectedFailedPartition?.stackTrace.toString()} />
                                         </FormControl>
                                     </>}
                             </Box>


### PR DESCRIPTION
### Added

- Added the capability of retrying a failed partition. This is done by selecting a failed partition in the "failed partitions" view and then clicking the "Retry" button.

<img width="547" alt="image" src="https://github.com/aksio-insurtech/Cratis/assets/134365/5fcd8720-0866-44f1-8cba-75389b53b21a">
