### PR TITLE
Unmap the current subscription information from storage, as this is only for in-memory state

### DIFF
--- a/Source/Kernel/MongoDB/Observation/ObserverStateClassMap.cs
+++ b/Source/Kernel/MongoDB/Observation/ObserverStateClassMap.cs
@@ -20,5 +20,7 @@ public class ObserverStateClassMap : IBsonClassMapFor<ObserverState>
         classMap.AutoMap();
         classMap.MapIdProperty(_ => _.Id);
         classMap.UnmapProperty(_ => _.FailedPartitions);
+        classMap.UnmapProperty(_ => _.CurrentSubscriptionType);
+        classMap.UnmapProperty(_ => _.CurrentSubscriptionArguments);
     }
 }


### PR DESCRIPTION
### Fixed

- Removing current subscription information from the Observer state being stored, as this has only an in-memory value.
