### PR TITLE
Fixing namespace for ClientOptions

### DIFF
--- a/Source/Clients/DotNET/ClientBuilder.cs
+++ b/Source/Clients/DotNET/ClientBuilder.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Aksio.Collections;
-using Aksio.Configuration;
 using Aksio.Cratis.Client;
 using Aksio.Cratis.Compliance;
+using Aksio.Cratis.Configuration;
 using Aksio.Cratis.Connections;
 using Aksio.Cratis.Events;
 using Aksio.Cratis.EventSequences.Outbox;

--- a/Source/Clients/DotNET/Configuration/ClientOptions.cs
+++ b/Source/Clients/DotNET/Configuration/ClientOptions.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Aksio.Cratis.Configuration;
-
-namespace Aksio.Configuration;
+namespace Aksio.Cratis.Configuration;
 
 /// <summary>
 /// Represents the client configuration.

--- a/Source/Clients/DotNET/Connections/ClusteredKernelClient.cs
+++ b/Source/Clients/DotNET/Connections/ClusteredKernelClient.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json;
-using Aksio.Configuration;
+using Aksio.Cratis.Configuration;
 using Aksio.Cratis.Net;
 using Aksio.Tasks;
 using Aksio.Timers;

--- a/Source/Clients/DotNET/Connections/InsideKernelConnection.cs
+++ b/Source/Clients/DotNET/Connections/InsideKernelConnection.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json;
 using Aksio.Commands;
-using Aksio.Configuration;
 using Aksio.Cratis.Configuration;
 using Aksio.Cratis.Net;
 using Aksio.Tasks;

--- a/Source/Clients/DotNET/Connections/OrleansAzureTableStoreKernelConnection.cs
+++ b/Source/Clients/DotNET/Connections/OrleansAzureTableStoreKernelConnection.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json;
-using Aksio.Configuration;
+using Aksio.Cratis.Configuration;
 using Aksio.Cratis.Net;
 using Aksio.Tasks;
 using Aksio.Timers;

--- a/Source/Clients/DotNET/Connections/RestKernelConnection.cs
+++ b/Source/Clients/DotNET/Connections/RestKernelConnection.cs
@@ -6,7 +6,7 @@ using System.Net.Http.Json;
 using System.Reflection;
 using System.Text.Json;
 using Aksio.Commands;
-using Aksio.Configuration;
+using Aksio.Cratis.Configuration;
 using Aksio.Cratis.Dynamic;
 using Aksio.Cratis.Net;
 using Aksio.Queries;

--- a/Source/Clients/DotNET/Connections/SingleKernelConnection.cs
+++ b/Source/Clients/DotNET/Connections/SingleKernelConnection.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json;
-using Aksio.Configuration;
+using Aksio.Cratis.Configuration;
 using Aksio.Tasks;
 using Aksio.Timers;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/Source/Clients/DotNET/Connections/StaticClusteredKernelConnection.cs
+++ b/Source/Clients/DotNET/Connections/StaticClusteredKernelConnection.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json;
-using Aksio.Configuration;
+using Aksio.Cratis.Configuration;
 using Aksio.Cratis.Net;
 using Aksio.Tasks;
 using Aksio.Timers;

--- a/Source/Clients/DotNET/KernelConnectivityClientBuilderExtensions.cs
+++ b/Source/Clients/DotNET/KernelConnectivityClientBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Aksio.Configuration;
 using Aksio.Cratis.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 


### PR DESCRIPTION
### Fixed

- The `ClientOptions` type was in the wrong namespace, fixed to be in `Aksio.Cratis.Configuration` as expected.
