### PR TITLE
Fix/regressions

### DIFF
--- a/Source/Clients/DotNET/EventSequences/IEventSequence.cs
+++ b/Source/Clients/DotNET/EventSequences/IEventSequence.cs
@@ -42,7 +42,7 @@ public interface IEventSequence
     Task Append(EventSourceId eventSourceId, object @event, DateTimeOffset? validFrom = default);
 
     /// <summary>
-    /// Append a single event to the event store.
+    /// Append a collection of events to the event store.
     /// </summary>
     /// <param name="eventSourceId">The <see cref="EventSourceId"/> to append for.</param>
     /// <param name="events">Collection of events to append.</param>
@@ -50,7 +50,7 @@ public interface IEventSequence
     Task AppendMany(EventSourceId eventSourceId, IEnumerable<object> events);
 
     /// <summary>
-    /// Append a single event to the event store.
+    /// Append a collection of events to the event store with valid from per event.
     /// </summary>
     /// <param name="eventSourceId">The <see cref="EventSourceId"/> to append for.</param>
     /// <param name="events">Collection of events with valid from to append.</param>

--- a/Source/Clients/DotNET/Rules/RulesProjections.cs
+++ b/Source/Clients/DotNET/Rules/RulesProjections.cs
@@ -18,11 +18,6 @@ namespace Aksio.Cratis.Rules;
 [Singleton]
 public class RulesProjections : IRulesProjections
 {
-    sealed class RulesClass : RulesFor<RulesClass, object>
-    {
-        public override RuleId Identifier => Guid.Empty;
-    }
-
     readonly IEventTypes _eventTypes;
     readonly IModelNameConvention _modelNameConvention;
     readonly IJsonSchemaGenerator _jsonSchemaGenerator;
@@ -86,7 +81,7 @@ public class RulesProjections : IRulesProjections
 
         var ruleType = typeof(TTarget);
 
-        var defineStateMethod = ruleType.GetMethod(nameof(RulesClass.DefineState), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        var defineStateMethod = ruleType.GetMethod("DefineState", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         if (defineStateMethod is not null)
         {
             var parameters = defineStateMethod.GetParameters();

--- a/Source/Clients/Specifications/EventSequenceStorageProviderForSpecifications.cs
+++ b/Source/Clients/Specifications/EventSequenceStorageProviderForSpecifications.cs
@@ -104,16 +104,16 @@ public class EventSequenceStorageProviderForSpecifications : IEventSequenceStora
     }
 
     /// <inheritdoc/>
-    public Task Append(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, EventSourceId eventSourceId, EventType eventType, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset validFrom, ExpandoObject content) => throw new NotImplementedException();
+    public Task Append(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, EventSourceId eventSourceId, EventType eventType, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset validFrom, DateTimeOffset occurred, ExpandoObject content) => throw new NotImplementedException();
 
     /// <inheritdoc/>
-    public Task Compensate(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, EventType eventType, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset validFrom, ExpandoObject content) => throw new NotImplementedException();
+    public Task Compensate(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, EventType eventType, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset validFrom, DateTimeOffset occurred, ExpandoObject content) => throw new NotImplementedException();
 
     /// <inheritdoc/>
-    public Task<AppendedEvent> Redact(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, RedactionReason reason, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain) => throw new NotImplementedException();
+    public Task<AppendedEvent> Redact(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, RedactionReason reason, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset occurred) => throw new NotImplementedException();
 
     /// <inheritdoc/>
-    public Task<IEnumerable<EventType>> Redact(EventSequenceId eventSequenceId, EventSourceId eventSourceId, RedactionReason reason, IEnumerable<EventType>? eventTypes, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain) => throw new NotImplementedException();
+    public Task<IEnumerable<EventType>> Redact(EventSequenceId eventSequenceId, EventSourceId eventSourceId, RedactionReason reason, IEnumerable<EventType>? eventTypes, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset occurred) => throw new NotImplementedException();
 
     /// <inheritdoc/>
     public Task<AppendedEvent> GetEventAt(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber) => throw new NotImplementedException();

--- a/Source/Kernel/Domain/EventSequences/RedactEvent.cs
+++ b/Source/Kernel/Domain/EventSequences/RedactEvent.cs
@@ -17,5 +17,5 @@ namespace Aksio.Cratis.Kernel.Domain.EventSequences;
 public record RedactEvent(
     EventSequenceNumber SequenceNumber,
     RedactionReason Reason,
-    IEnumerable<Causation> Causation,
-    Identity CausedBy);
+    IEnumerable<Causation>? Causation,
+    Identity? CausedBy);

--- a/Source/Kernel/Domain/EventSequences/RedactEvents.cs
+++ b/Source/Kernel/Domain/EventSequences/RedactEvents.cs
@@ -19,5 +19,5 @@ public record RedactEvents(
     EventSourceId EventSourceId,
     RedactionReason Reason,
     IEnumerable<EventTypeId> EventTypes,
-    IEnumerable<Causation> Causation,
-    Identity CausedBy);
+    IEnumerable<Causation>? Causation,
+    Identity? CausedBy);

--- a/Source/Kernel/Engines/Projections/Definitions/ProjectionDefinitions.cs
+++ b/Source/Kernel/Engines/Projections/Definitions/ProjectionDefinitions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using Aksio.Cratis.Projections;
 using Aksio.Cratis.Projections.Definitions;
 using Aksio.Cratis.Projections.Json;
@@ -16,7 +15,7 @@ public class ProjectionDefinitions : IProjectionDefinitions
 {
     readonly IProjectionDefinitionsStorage _storage;
     readonly IJsonProjectionSerializer _projectionSerializer;
-    readonly ConcurrentDictionary<ProjectionId, ProjectionDefinition> _definitions = new();
+    readonly Dictionary<ProjectionId, ProjectionDefinition> _definitions = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProjectionDefinition"/> class.
@@ -87,7 +86,7 @@ public class ProjectionDefinitions : IProjectionDefinitions
 
     async Task PopulateIfEmpty()
     {
-        if (_definitions.IsEmpty)
+        if (_definitions.Count == 0)
         {
             await Populate();
         }

--- a/Source/Kernel/Engines/Projections/Definitions/ProjectionPipelineDefinitions.cs
+++ b/Source/Kernel/Engines/Projections/Definitions/ProjectionPipelineDefinitions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using Aksio.Cratis.Projections;
 using Aksio.Cratis.Projections.Definitions;
 
@@ -14,7 +13,7 @@ namespace Aksio.Cratis.Kernel.Engines.Projections.Definitions;
 public class ProjectionPipelineDefinitions : IProjectionPipelineDefinitions
 {
     readonly IProjectionPipelineDefinitionsStorage _storage;
-    readonly ConcurrentDictionary<ProjectionId, ProjectionPipelineDefinition> _definitions = new();
+    readonly Dictionary<ProjectionId, ProjectionPipelineDefinition> _definitions = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProjectionDefinition"/> class.
@@ -65,7 +64,7 @@ public class ProjectionPipelineDefinitions : IProjectionPipelineDefinitions
 
     async Task PopulateIfEmpty()
     {
-        if (_definitions.IsEmpty)
+        if (_definitions.Count == 0)
         {
             await Populate();
         }

--- a/Source/Kernel/Engines/Projections/ProjectionManager.cs
+++ b/Source/Kernel/Engines/Projections/ProjectionManager.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using Aksio.Cratis.Kernel.Engines.Projections.Pipelines;
 using Aksio.Cratis.Projections;
 using Aksio.Cratis.Projections.Definitions;
@@ -16,8 +15,8 @@ public class ProjectionManager : IProjectionManager
 {
     readonly IProjectionFactory _projectionFactory;
     readonly IProjectionPipelineFactory _projectionPipelineFactory;
-    readonly ConcurrentDictionary<ProjectionId, IProjection> _projections = new();
-    readonly ConcurrentDictionary<ProjectionId, IProjectionPipeline> _pipelines = new();
+    readonly Dictionary<ProjectionId, IProjection> _projections = new();
+    readonly Dictionary<ProjectionId, IProjectionPipeline> _pipelines = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProjectionManager"/> class.

--- a/Source/Kernel/Engines/Projections/ProjectionSinks.cs
+++ b/Source/Kernel/Engines/Projections/ProjectionSinks.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using Aksio.Cratis.Projections;
 using Aksio.Types;
 
@@ -16,7 +15,7 @@ public class ProjectionSinks : IProjectionSinks
     sealed record Key(ProjectionSinkTypeId TypeId, ProjectionId ProjectionId);
 
     readonly IDictionary<ProjectionSinkTypeId, IProjectionSinkFactory> _factories;
-    readonly ConcurrentDictionary<Key, IProjectionSink> _stores = new();
+    readonly Dictionary<Key, IProjectionSink> _stores = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProjectionSinks"/> class.

--- a/Source/Kernel/Grains/EventSequences/EventSequence.cs
+++ b/Source/Kernel/Grains/EventSequences/EventSequence.cs
@@ -247,7 +247,8 @@ public class EventSequence : Grain<EventSequenceState>, IEventSequence
             sequenceNumber,
             reason,
             causation,
-            await _identityStoreProvider().GetFor(causedBy));
+            await _identityStoreProvider().GetFor(causedBy),
+            DateTimeOffset.UtcNow);
         return await RewindPartitionForAffectedObservers(affectedEvent.Context.EventSourceId, sequenceNumber, new[] { affectedEvent.Metadata.Type });
     }
 
@@ -272,7 +273,8 @@ public class EventSequence : Grain<EventSequenceState>, IEventSequence
             reason,
             eventTypes,
             causation,
-            await _identityStoreProvider().GetFor(causedBy));
+            await _identityStoreProvider().GetFor(causedBy),
+            DateTimeOffset.UtcNow);
         return await RewindPartitionForAffectedObservers(eventSourceId, EventSequenceNumber.First, affectedEventTypes);
     }
 

--- a/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceCache.cs
+++ b/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceCache.cs
@@ -80,8 +80,6 @@ public class EventSequenceCache : IEventSequenceCache
         _executionContextManager = executionContextManager;
         _eventSequenceStorageProvider = eventSequenceStorageProvider;
         _logger = logger;
-
-        PreFillWithTailWindow();
     }
 
     /// <inheritdoc/>
@@ -155,6 +153,16 @@ public class EventSequenceCache : IEventSequenceCache
         }
     }
 
+    /// <inheritdoc/>
+    public async Task PrimeWithTailWindow()
+    {
+        _executionContextManager.Establish(_tenantId, CorrelationId.New(), _microserviceId);
+        var tail = await _eventSequenceStorageProvider().GetTailSequenceNumber(_eventSequenceId);
+        tail -= NumberOfEventsToFetch;
+        if ((long)tail.Value < 0) tail = 0;
+        Prime(tail);
+    }
+
     void AddImplementation(AppendedEvent @event)
     {
         if (_eventsBySequenceNumber.ContainsKey(@event.Metadata.SequenceNumber))
@@ -191,14 +199,5 @@ public class EventSequenceCache : IEventSequenceCache
                 _head = _head.Next;
             }
         }
-    }
-
-    void PreFillWithTailWindow()
-    {
-        _executionContextManager.Establish(_tenantId, CorrelationId.New(), _microserviceId);
-        var tail = _eventSequenceStorageProvider().GetTailSequenceNumber(_eventSequenceId).GetAwaiter().GetResult();
-        tail -= NumberOfEventsToFetch;
-        if ((long)tail.Value < 0) tail = 0;
-        Prime(tail);
     }
 }

--- a/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceCaches.cs
+++ b/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceCaches.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using Aksio.Cratis.EventSequences;
+using Aksio.Cratis.Kernel.Configuration;
 
 namespace Aksio.Cratis.Kernel.Grains.EventSequences.Streaming;
 
@@ -12,16 +12,21 @@ namespace Aksio.Cratis.Kernel.Grains.EventSequences.Streaming;
 [Singleton]
 public class EventSequenceCaches : IEventSequenceCaches
 {
-    readonly ConcurrentDictionary<(MicroserviceId, TenantId, EventSequenceId), IEventSequenceCache> _caches = new();
+    readonly Dictionary<(MicroserviceId, TenantId, EventSequenceId), IEventSequenceCache> _caches = new();
     readonly IEventSequenceCacheFactory _eventSequenceCacheFactory;
+    readonly KernelConfiguration _configuration;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EventSequenceCaches"/> class.
     /// </summary>
     /// <param name="eventSequenceCacheFactory"><see cref="IEventSequenceCacheFactory"/> for creating <see cref="IEventSequenceCache"/> instances.</param>
-    public EventSequenceCaches(IEventSequenceCacheFactory eventSequenceCacheFactory)
+    /// <param name="configuration">The <see cref="KernelConfiguration"/>.</param>///
+    public EventSequenceCaches(
+        IEventSequenceCacheFactory eventSequenceCacheFactory,
+        KernelConfiguration configuration)
     {
         _eventSequenceCacheFactory = eventSequenceCacheFactory;
+        _configuration = configuration;
     }
 
     /// <inheritdoc/>
@@ -39,6 +44,22 @@ public class EventSequenceCaches : IEventSequenceCaches
 
     /// <inheritdoc/>
     public bool IsUnderPressure() => _caches.Values.Any(_ => _.IsUnderPressure());
+
+    /// <inheritdoc/>
+    public Task PrimeAll()
+    {
+        var tasks = new List<Task>();
+
+        foreach (var (microserviceId, microservice) in _configuration.Microservices)
+        {
+            foreach (var (tenantId, _) in _configuration.Tenants)
+            {
+                tasks.Add(GetFor(microserviceId, tenantId, EventSequenceId.Log).PrimeWithTailWindow());
+            }
+        }
+
+        return Task.WhenAll(tasks.ToArray());
+    }
 
     /// <inheritdoc/>
     public void Purge()

--- a/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceQueueAdapter.cs
+++ b/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceQueueAdapter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using Aksio.Cratis.Events;
 using Aksio.Cratis.EventSequences;
 using Aksio.Cratis.Identities;
@@ -17,7 +16,7 @@ namespace Aksio.Cratis.Kernel.Grains.EventSequences.Streaming;
 /// </summary>
 public class EventSequenceQueueAdapter : IQueueAdapter
 {
-    readonly ConcurrentDictionary<QueueId, EventSequenceQueueAdapterReceiver> _receivers = new();
+    readonly Dictionary<QueueId, EventSequenceQueueAdapterReceiver> _receivers = new();
 
     readonly IStreamQueueMapper _mapper;
     readonly ProviderFor<IEventSequenceStorage> _eventSequenceStorageProvider;

--- a/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceQueueAdapter.cs
+++ b/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceQueueAdapter.cs
@@ -74,6 +74,7 @@ public class EventSequenceQueueAdapter : IQueueAdapter
                         appendedEvent.Metadata.Type,
                         appendedEvent.Context.Causation,
                         await _identityStoreProvider().GetFor(appendedEvent.Context.CausedBy),
+                        DateTimeOffset.UtcNow,
                         appendedEvent.Context.ValidFrom,
                         appendedEvent.Content);
 

--- a/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceQueueAdapterReceiver.cs
+++ b/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceQueueAdapterReceiver.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using Aksio.Cratis.Events;
 using Orleans.Runtime;
 using Orleans.Streams;
@@ -13,13 +12,13 @@ namespace Aksio.Cratis.Kernel.Grains.EventSequences.Streaming;
 /// </summary>
 public class EventSequenceQueueAdapterReceiver : IQueueAdapterReceiver
 {
-    readonly ConcurrentBag<IBatchContainer> _eventBatches = new();
+    readonly List<IBatchContainer> _eventBatches = new();
     readonly List<IBatchContainer> _empty = new();
 
     /// <inheritdoc/>
     public Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
     {
-        if (!_eventBatches.IsEmpty)
+        if (_eventBatches.Count != 0)
         {
             var result = _eventBatches.OrderBy(_ => _.SequenceToken).ToArray().ToList();
             _eventBatches.Clear();

--- a/Source/Kernel/Grains/EventSequences/Streaming/IEventSequenceCache.cs
+++ b/Source/Kernel/Grains/EventSequences/Streaming/IEventSequenceCache.cs
@@ -52,6 +52,12 @@ public interface IEventSequenceCache : IDisposable
     void Prime(EventSequenceNumber from);
 
     /// <summary>
+    /// Prime the cache with the tail window.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
+    Task PrimeWithTailWindow();
+
+    /// <summary>
     /// Check if the cache is under pressure.
     /// </summary>
     /// <returns>True if it is, false if not.</returns>

--- a/Source/Kernel/Grains/EventSequences/Streaming/IEventSequenceCaches.cs
+++ b/Source/Kernel/Grains/EventSequences/Streaming/IEventSequenceCaches.cs
@@ -20,6 +20,12 @@ public interface IEventSequenceCaches
     IEventSequenceCache GetFor(MicroserviceId microserviceId, TenantId tenantId, EventSequenceId eventSequenceId);
 
     /// <summary>
+    /// Prime all caches.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
+    Task PrimeAll();
+
+    /// <summary>
     /// Check if any of the caches are under pressure.
     /// </summary>
     /// <returns>True if any is, false if not.</returns>

--- a/Source/Kernel/Grains/Observation/CatchUp.cs
+++ b/Source/Kernel/Grains/Observation/CatchUp.cs
@@ -70,10 +70,9 @@ public class CatchUp : ObserverWorker, ICatchUp
             return;
         }
 
-        await ReadStateAsync();
-
         _logger.Starting(ObserverId, MicroserviceId, TenantId, EventSequenceId, SourceMicroserviceId, SourceTenantId);
         CurrentSubscription = subscription;
+        await ReadStateAsync();
         _isRunning = true;
         _timer = RegisterTimer(PerformCatchUp, null, TimeSpan.Zero, TimeSpan.FromHours(1));
     }

--- a/Source/Kernel/Grains/Observation/ObserverWorker.cs
+++ b/Source/Kernel/Grains/Observation/ObserverWorker.cs
@@ -19,12 +19,22 @@ public abstract class ObserverWorker : Grain
     readonly ProviderFor<IEventSequenceStorage> _eventSequenceStorageProviderProvider;
     readonly IExecutionContextManager _executionContextManager;
     readonly IPersistentState<ObserverState> _observerState;
+    ObserverSubscription _currentSubscription = ObserverSubscription.Unsubscribed;
     IObserverSupervisor? _supervisor;
 
     /// <summary>
     /// Gets or sets the subscriber type.
     /// </summary>
-    protected ObserverSubscription CurrentSubscription { get; set; } = ObserverSubscription.Unsubscribed;
+    protected ObserverSubscription CurrentSubscription
+    {
+        get => _currentSubscription;
+        set
+        {
+            _currentSubscription = value;
+            State.CurrentSubscriptionType = _currentSubscription.SubscriberType.AssemblyQualifiedName;
+            State.CurrentSubscriptionArguments = _currentSubscription.Arguments;
+        }
+    }
 
     /// <summary>
     /// Gets the <see cref="ObserverState"/>.
@@ -250,10 +260,5 @@ public abstract class ObserverWorker : Grain
     /// Write the observer state.
     /// </summary>
     /// <returns>Awaitable task.</returns>
-    protected Task WriteStateAsync()
-    {
-        State.CurrentSubscriptionType = CurrentSubscription.SubscriberType.AssemblyQualifiedName;
-        State.CurrentSubscriptionArguments = CurrentSubscription.Arguments;
-        return _observerState.WriteStateAsync();
-    }
+    protected Task WriteStateAsync() => _observerState.WriteStateAsync();
 }

--- a/Source/Kernel/Grains/Observation/Replay.cs
+++ b/Source/Kernel/Grains/Observation/Replay.cs
@@ -70,10 +70,9 @@ public class Replay : ObserverWorker, IReplay
             return;
         }
 
-        await ReadStateAsync();
-
         _logger.Starting(ObserverId, MicroserviceId, TenantId, EventSequenceId, SourceMicroserviceId, SourceTenantId);
         CurrentSubscription = subscription;
+        await ReadStateAsync();
         _isRunning = true;
         _timer = RegisterTimer(PerformReplay, null, TimeSpan.Zero, TimeSpan.FromHours(1));
     }

--- a/Source/Kernel/MongoDB/EventSequences/MongoDBEventSequenceStorage.cs
+++ b/Source/Kernel/MongoDB/EventSequences/MongoDBEventSequenceStorage.cs
@@ -61,10 +61,10 @@ public class MongoDBEventSequenceStorage : IEventSequenceStorage
     }
 
     /// <inheritdoc/>
-    public Task<long> GetCount(EventSequenceId eventSequenceId)
+    public async Task<long> GetCount(EventSequenceId eventSequenceId)
     {
         var collection = GetCollectionFor(eventSequenceId);
-        return collection.CountDocumentsAsync(FilterDefinition<Event>.Empty);
+        return await collection.CountDocumentsAsync(FilterDefinition<Event>.Empty).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -103,7 +103,7 @@ public class MongoDBEventSequenceStorage : IEventSequenceStorage
                 },
                 Array.Empty<EventCompensation>());
             var collection = GetCollectionFor(eventSequenceId);
-            await collection.InsertOneAsync(@event);
+            await collection.InsertOneAsync(@event).ConfigureAwait(false);
         }
         catch (MongoWriteException writeException) when (writeException.WriteError.Category == ServerErrorCategory.DuplicateKey)
         {
@@ -156,7 +156,7 @@ public class MongoDBEventSequenceStorage : IEventSequenceStorage
         }
 
         var updateModel = CreateRedactionUpdateModelFor(@event, reason, causation, causedByChain);
-        collection.UpdateOne(updateModel.Filter, updateModel.Update);
+        await collection.UpdateOneAsync(updateModel.Filter, updateModel.Update).ConfigureAwait(false);
 
         return @event;
     }

--- a/Source/Kernel/MongoDB/Observation/ObserverStorageProvider.cs
+++ b/Source/Kernel/MongoDB/Observation/ObserverStorageProvider.cs
@@ -80,6 +80,8 @@ public class ObserverStorageProvider : IGrainStorage
             RunningState = ObserverRunningState.New
         };
         state.FailedPartitions = failedPartitions;
+        state.CurrentSubscriptionType = actualGrainState.State?.CurrentSubscriptionType;
+        state.CurrentSubscriptionArguments = actualGrainState.State?.CurrentSubscriptionArguments;
         actualGrainState.State = state;
     }
 

--- a/Source/Kernel/Server/BootProcedure.cs
+++ b/Source/Kernel/Server/BootProcedure.cs
@@ -6,6 +6,7 @@ using Aksio.Cratis.EventSequences.Inboxes;
 using Aksio.Cratis.Identities;
 using Aksio.Cratis.Kernel.Configuration;
 using Aksio.Cratis.Kernel.Grains.EventSequences.Inbox;
+using Aksio.Cratis.Kernel.Grains.EventSequences.Streaming;
 using Aksio.Cratis.Kernel.Grains.Projections;
 
 namespace Aksio.Cratis.Kernel.Server;
@@ -19,6 +20,7 @@ public class BootProcedure : IPerformBootProcedure
     readonly IExecutionContextManager _executionContextManager;
     readonly IGrainFactory _grainFactory;
     readonly KernelConfiguration _configuration;
+    readonly ILogger<BootProcedure> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BootProcedure"/> class.
@@ -27,16 +29,19 @@ public class BootProcedure : IPerformBootProcedure
     /// <param name="executionContextManager"><see cref="IExecutionContextManager"/> for working with the execution context.</param>
     /// <param name="grainFactory"><see cref="IGrainFactory"/> for getting grains.</param>
     /// <param name="configuration">The <see cref="KernelConfiguration"/>.</param>
+    /// <param name="logger">Logger for logging.</param>
     public BootProcedure(
         IServiceProvider serviceProvider,
         IExecutionContextManager executionContextManager,
         IGrainFactory grainFactory,
-        KernelConfiguration configuration)
+        KernelConfiguration configuration,
+        ILogger<BootProcedure> logger)
     {
         _serviceProvider = serviceProvider;
         _executionContextManager = executionContextManager;
         _grainFactory = grainFactory;
         _configuration = configuration;
+        _logger = logger;
     }
 
     /// <inheritdoc/>
@@ -44,15 +49,23 @@ public class BootProcedure : IPerformBootProcedure
     {
         _ = Task.Run(() =>
         {
+            _logger.PrimingEventSequenceCaches();
+            var eventSequenceCaches = _serviceProvider.GetRequiredService<IEventSequenceCaches>()!;
+            eventSequenceCaches.PrimeAll().Wait();
+
             foreach (var (microserviceId, microservice) in _configuration.Microservices)
             {
                 _executionContextManager.Establish(microserviceId);
+
+                this._logger.PopulateSchemaStore();
                 var schemaStore = _serviceProvider.GetRequiredService<Schemas.ISchemaStore>()!;
                 schemaStore.Populate().Wait();
 
+                this._logger.PopulateIdentityStore();
                 var identityStore = _serviceProvider.GetRequiredService<IIdentityStore>()!;
                 identityStore.Populate().Wait();
 
+                _logger.RehydrateProjections();
                 var projections = _grainFactory.GetGrain<IProjections>(0);
                 projections.Rehydrate().Wait();
 

--- a/Source/Kernel/Server/BootProcedureLogMessages.cs
+++ b/Source/Kernel/Server/BootProcedureLogMessages.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Kernel.Server;
+
+internal static partial class BootProcedureLogMessages
+{
+    [LoggerMessage(0, LogLevel.Information, "Priming caches for all event sequences for all microservices and tenants")]
+    internal static partial void PrimingEventSequenceCaches(this ILogger logger);
+
+    [LoggerMessage(1, LogLevel.Information, "Populating schema store")]
+    internal static partial void PopulateSchemaStore(this ILogger logger);
+
+    [LoggerMessage(2, LogLevel.Information, "Populating identity store")]
+    internal static partial void PopulateIdentityStore(this ILogger logger);
+
+    [LoggerMessage(3, LogLevel.Information, "Rehydrating projections")]
+    internal static partial void RehydrateProjections(this ILogger logger);
+}

--- a/Source/Kernel/Shared/EventSequences/IEventSequenceStorage.cs
+++ b/Source/Kernel/Shared/EventSequences/IEventSequenceStorage.cs
@@ -29,10 +29,11 @@ public interface IEventSequenceStorage
     /// <param name="eventType">The <see cref="EventType">type of event</see> to append.</param>
     /// <param name="causation">Collection of <see cref="Causation"/>.</param>
     /// <param name="causedByChain">The chain of <see cref="IdentityId"/> representing the person, system or service that caused the event.</param>
-    /// <param name="validFrom">Optional date and time for when the compensation is valid from. </param>
+    /// <param name="occurred">The date and time the event occurred.</param>
+    /// <param name="validFrom">Date and time for when the compensation is valid from. </param>
     /// <param name="content">The content of the event.</param>
     /// <returns>Awaitable <see cref="Task"/>.</returns>
-    Task Append(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, EventSourceId eventSourceId, EventType eventType, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset validFrom, ExpandoObject content);
+    Task Append(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, EventSourceId eventSourceId, EventType eventType, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset occurred, DateTimeOffset validFrom, ExpandoObject content);
 
     /// <summary>
     /// Compensate a single event to the event store.
@@ -42,10 +43,11 @@ public interface IEventSequenceStorage
     /// <param name="eventType">The <see cref="EventType">type of event</see> to append.</param>
     /// <param name="causation">Collection of <see cref="Causation"/>.</param>
     /// <param name="causedByChain">The chain of <see cref="IdentityId"/> representing the person, system or service that caused the event.</param>
+    /// <param name="occurred">The date and time the compensation occurred.</param>
     /// <param name="validFrom">Optional date and time for when the compensation is valid from. </param>
     /// <param name="content">The content of the event.</param>
     /// <returns>Awaitable <see cref="Task"/>.</returns>
-    Task Compensate(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, EventType eventType, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset validFrom, ExpandoObject content);
+    Task Compensate(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, EventType eventType, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset occurred, DateTimeOffset validFrom, ExpandoObject content);
 
     /// <summary>
     /// Redact an event at a specific sequence number.
@@ -55,8 +57,9 @@ public interface IEventSequenceStorage
     /// <param name="reason">Reason for redacting.</param>
     /// <param name="causation">Collection of <see cref="Causation"/>.</param>
     /// <param name="causedByChain">The chain of <see cref="IdentityId"/> representing the person, system or service that caused the event.</param>
+    /// <param name="occurred">The date and time the redaction occurred.</param>
     /// <returns>Affected event.</returns>
-    Task<AppendedEvent> Redact(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, RedactionReason reason, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain);
+    Task<AppendedEvent> Redact(EventSequenceId eventSequenceId, EventSequenceNumber sequenceNumber, RedactionReason reason, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset occurred);
 
     /// <summary>
     /// Redact all events for a specific <see cref="EventSourceId"/>.
@@ -67,8 +70,9 @@ public interface IEventSequenceStorage
     /// <param name="eventTypes">Optionally any specific event types.</param>
     /// <param name="causation">Collection of <see cref="Causation"/>.</param>
     /// <param name="causedByChain">The chain of <see cref="IdentityId"/> representing the person, system or service that caused the event.</param>
+    /// <param name="occurred">The date and time the redaction occurred.</param>
     /// <returns>Affected event types.</returns>
-    Task<IEnumerable<EventType>> Redact(EventSequenceId eventSequenceId, EventSourceId eventSourceId, RedactionReason reason, IEnumerable<EventType>? eventTypes, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain);
+    Task<IEnumerable<EventType>> Redact(EventSequenceId eventSequenceId, EventSourceId eventSourceId, RedactionReason reason, IEnumerable<EventType>? eventTypes, IEnumerable<Causation> causation, IEnumerable<IdentityId> causedByChain, DateTimeOffset occurred);
 
     /// <summary>
     /// Get the sequence number of the first event as part of the filtered event types.

--- a/Source/Workbench/API/events/store/sequence/RedactEvent.ts
+++ b/Source/Workbench/API/events/store/sequence/RedactEvent.ts
@@ -16,7 +16,7 @@ export interface IRedactEvent {
     tenantId?: string;
     sequenceNumber?: number;
     reason?: string;
-    causation?: Causation[];
+    causation?: Causation;
     causedBy?: Identity;
 }
 
@@ -42,7 +42,7 @@ export class RedactEvent extends Command<IRedactEvent> implements IRedactEvent {
     private _tenantId!: string;
     private _sequenceNumber!: number;
     private _reason!: string;
-    private _causation!: Causation[];
+    private _causation!: Causation;
     private _causedBy!: Identity;
 
     constructor() {
@@ -109,11 +109,11 @@ export class RedactEvent extends Command<IRedactEvent> implements IRedactEvent {
         this._reason = value;
         this.propertyChanged('reason');
     }
-    get causation(): Causation[] {
+    get causation(): Causation {
         return this._causation;
     }
 
-    set causation(value: Causation[]) {
+    set causation(value: Causation) {
         this._causation = value;
         this.propertyChanged('causation');
     }

--- a/Source/Workbench/API/events/store/sequence/RedactEvents.ts
+++ b/Source/Workbench/API/events/store/sequence/RedactEvents.ts
@@ -17,7 +17,7 @@ export interface IRedactEvents {
     eventSourceId?: string;
     reason?: string;
     eventTypes?: string[];
-    causation?: Causation[];
+    causation?: Causation;
     causedBy?: Identity;
 }
 
@@ -45,7 +45,7 @@ export class RedactEvents extends Command<IRedactEvents> implements IRedactEvent
     private _eventSourceId!: string;
     private _reason!: string;
     private _eventTypes!: string[];
-    private _causation!: Causation[];
+    private _causation!: Causation;
     private _causedBy!: Identity;
 
     constructor() {
@@ -121,11 +121,11 @@ export class RedactEvents extends Command<IRedactEvents> implements IRedactEvent
         this._eventTypes = value;
         this.propertyChanged('eventTypes');
     }
-    get causation(): Causation[] {
+    get causation(): Causation {
         return this._causation;
     }
 
-    set causation(value: Causation[]) {
+    set causation(value: Causation) {
         this._causation = value;
         this.propertyChanged('causation');
     }

--- a/Specifications/Kernel/Grains/EventSequences/Streaming/for_EventSequenceCaches/given/an_event_sequence_caches.cs
+++ b/Specifications/Kernel/Grains/EventSequences/Streaming/for_EventSequenceCaches/given/an_event_sequence_caches.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Aksio.Cratis.EventSequences;
+using Aksio.Cratis.Kernel.Configuration;
 
 namespace Aksio.Cratis.Kernel.Grains.EventSequences.Streaming.for_EventSequenceCaches.given;
 
@@ -10,6 +11,7 @@ public class an_event_sequence_caches : Specification
     protected Mock<IExecutionContextManager> execution_context_manager;
     protected Mock<IEventSequenceStorage> event_sequence_storage_provider;
     protected Mock<IEventSequenceCacheFactory> event_sequence_cache_factory;
+    protected KernelConfiguration configuration;
     protected EventSequenceCaches caches;
 
     void Establish()
@@ -17,6 +19,7 @@ public class an_event_sequence_caches : Specification
         execution_context_manager = new();
         event_sequence_storage_provider = new();
         event_sequence_cache_factory = new();
-        caches = new(event_sequence_cache_factory.Object);
+        configuration = new();
+        caches = new(event_sequence_cache_factory.Object, configuration);
     }
 }


### PR DESCRIPTION
### Fixed

- Dead lock situation when starting kernel with observers needing to replay. Solved this by explicitly priming the event sequence caches at startup, rather than lazily through the streaming infrastructure.
- Moving the decision of what time an event operation occurred to the owning systems (e.g. EventSequence grain), rather than letting the persistence layer do this.
- Fixing underlying problem with observer state with regards to current subscriptions, causing replays to only work once and sometimes never. 
- Making redaction work in the workbench again by making causation and caused optional and setting these on server side if not set. The endpoints got a 409 with validation error messages before this change.