### PR TITLE
Fixing comments

### DIFF
--- a/Source/Kernel/Domain/EventSequences/AppendEvent.cs
+++ b/Source/Kernel/Domain/EventSequences/AppendEvent.cs
@@ -16,8 +16,8 @@ namespace Aksio.Cratis.Kernel.Domain.EventSequences;
 /// <param name="EventSourceId">The <see cref="EventSourceId"/>.</param>
 /// <param name="EventType">The <see cref="EventType"/> to append.</param>
 /// <param name="Content">The content of the event represented as <see cref="JsonObject"/>.</param>
-/// <param name="Causation">Collection of <see cref="Causation"/>.</param>
-/// <param name="CausedBy"><see cref="CausedBy"/> to identify the person, system or service that caused the event.</param>
+/// <param name="Causation">Optional Collection of <see cref="Causation"/>.</param>
+/// <param name="CausedBy">Optional <see cref="CausedBy"/> to identify the person, system or service that caused the event.</param>
 /// <param name="ValidFrom">Optional valid from.</param>
 public record AppendEvent(
     EventSourceId EventSourceId,

--- a/Source/Kernel/Domain/EventSequences/AppendManyEvents.cs
+++ b/Source/Kernel/Domain/EventSequences/AppendManyEvents.cs
@@ -14,8 +14,8 @@ namespace Aksio.Cratis.Kernel.Domain.EventSequences;
 /// </summary>
 /// <param name="EventSourceId">The <see cref="EventSourceId"/> to append to.</param>
 /// <param name="Events">The events to append.</param>
-/// <param name="Causation">Collection of <see cref="Causation"/>.</param>
-/// <param name="CausedBy"><see cref="CausedBy"/> to identify the person, system or service that caused the events.</param>
+/// <param name="Causation">Optional Collection of <see cref="Causation"/>.</param>
+/// <param name="CausedBy">Optional <see cref="CausedBy"/> to identify the person, system or service that caused the events.</param>
 public record AppendManyEvents(
     EventSourceId EventSourceId,
     IEnumerable<EventToAppend> Events,


### PR DESCRIPTION
### Fixed

- Making `Causation` and `CausedBy` on the server side optional and automatically injected if not there based on context in the server. This is for backwards compability with any 9.x clients
