### PR TITLE
Removing Task.Run() for registering observers - seems that this is in conflict with Orleans task model

### DIFF
--- a/Source/Kernel/Domain/Observation/Observers.cs
+++ b/Source/Kernel/Domain/Observation/Observers.cs
@@ -47,24 +47,19 @@ public class Observers : Controller
     /// <param name="registrations">Collection of <see cref="ClientObserverRegistration"/>.</param>
     /// <returns>Awaitable task.</returns>
     [HttpPost("register/{connectionId}")]
-    public Task Register(
+    public async Task Register(
         [FromRoute] MicroserviceId microserviceId,
         [FromRoute] ConnectionId connectionId,
         [FromBody] IEnumerable<ClientObserverRegistration> registrations)
     {
         _logger.RegisterObservers();
 
-        _ = Task.Run(async () =>
-        {
-            var connectedClients = _grainFactory.GetGrain<IConnectedClients>(microserviceId);
-            var client = await connectedClients.GetConnectedClient(connectionId);
-            var tenants = client.IsMultiTenanted ? _configuration.Tenants.GetTenantIds() : new TenantId[] { TenantId.NotSet };
+        var connectedClients = _grainFactory.GetGrain<IConnectedClients>(microserviceId);
+        var client = await connectedClients.GetConnectedClient(connectionId);
+        var tenants = client.IsMultiTenanted ? _configuration.Tenants.GetTenantIds() : new TenantId[] { TenantId.NotSet };
 
-            var observers = _grainFactory.GetGrain<IClientObservers>(microserviceId);
-            return observers.Register(connectionId, registrations, tenants);
-        });
-
-        return Task.CompletedTask;
+        var observers = _grainFactory.GetGrain<IClientObservers>(microserviceId);
+        await observers.Register(connectionId, registrations, tenants);
     }
 
     /// <summary>


### PR DESCRIPTION
### Fixed

- Client Observer registrations seems to fail under some circumstances and not necessarily for all. This could be linked to an attempt of an optimization of doing a `Task.Run()` for calling the `ClientObservers` grain for registering and returning to the client as soon as possible. This seems to fail sometimes. Taking it out and it seems to be consistent.
