### PR TITLE
Fix/build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,7 @@
 
         <!-- Analysis -->
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.5.0" />
-        <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4" />
         <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.376" />
         <PackageVersion Include="Roslynator.Analyzers" Version="4.5.0" />
         <PackageVersion Include="Meziantou.Analyzer" Version="2.0.82" />

--- a/Source/Clients/Specifications/Specifications.csproj
+++ b/Source/Clients/Specifications/Specifications.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <AssemblyName>Aksio.Cratis.Specifications</AssemblyName>
         <RootNamespace>Aksio.Cratis.Specifications</RootNamespace>
+        <IsTestProject>false</IsTestProject>
 
         <NoWarn>$(NoWarn);CA1051;RCS1213;IDE0051;CS8618;IDE1006</NoWarn>
     </PropertyGroup>


### PR DESCRIPTION
### Fixed

- Client Observer registrations seems to fail under some circumstances and not necessarily for all. This could be linked to an attempt of an optimization of doing a `Task.Run()` for calling the `ClientObservers` grain for registering and returning to the client as soon as possible. This seems to fail sometimes. Taking it out and it seems to be consistent.
