### PR TITLE
Initial partition failed

### DIFF
--- a/Source/Kernel/Grains.Interfaces/Observation/IRecoverFailedPartition.cs
+++ b/Source/Kernel/Grains.Interfaces/Observation/IRecoverFailedPartition.cs
@@ -20,8 +20,9 @@ public interface IRecoverFailedPartition : IGrainWithGuidCompoundKey
     /// <param name="eventTypes">Event types to filter.</param>
     /// <param name="messages">Any messages associated with the failure.</param>
     /// <param name="stackTrace">A stack trace associated with the failure.</param>
-    /// /// <returns>Awaitable task.</returns>
-    Task Recover(ObserverKey observerKey, ObserverName observerName, EventSequenceNumber fromEvent, IEnumerable<EventType> eventTypes, IEnumerable<string> messages, string stackTrace);
+    /// <param name="occurred">The date and time of when the failure occurred.</param>
+    /// <returns>Awaitable task.</returns>
+    Task Recover(ObserverKey observerKey, ObserverName observerName, EventSequenceNumber fromEvent, IEnumerable<EventType> eventTypes, IEnumerable<string> messages, string stackTrace, DateTimeOffset occurred);
 
     /// <summary>
     /// Catches up any additional events on a failed partition after recovery was completed.
@@ -29,6 +30,12 @@ public interface IRecoverFailedPartition : IGrainWithGuidCompoundKey
     /// <param name="fromEvent">The event to start catching up from.</param>
     /// <returns>Awaitable task.</returns>
     Task Catchup(EventSequenceNumber fromEvent);
+
+    /// <summary>
+    /// Resumes recovery of a failed partition.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
+    Task ResumeRecovery();
 
     /// <summary>
     /// Resets the recovery state for a failed partition.

--- a/Source/Kernel/Grains/Observation/FailedPartitionSupervisor.cs
+++ b/Source/Kernel/Grains/Observation/FailedPartitionSupervisor.cs
@@ -139,13 +139,7 @@ public class FailedPartitionSupervisor : IChildStateProvider<FailedPartitionsSta
         if (failedPartition is null) return;
 
         await GetRecoveryGrain(failedPartition.Partition)
-            .Recover(
-                _observerKey,
-                _observerName,
-                failedPartition.RecoveredTo ?? failedPartition.Tail,
-                _eventTypes,
-                failedPartition.Messages,
-                failedPartition.StackTrace);
+            .ResumeRecovery();
     }
 
     /// <summary>
@@ -176,7 +170,8 @@ public class FailedPartitionSupervisor : IChildStateProvider<FailedPartitionsSta
                 sequenceNumber,
                 _eventTypes,
                 messages,
-                stackTrace);
+                stackTrace,
+                occurred);
     }
 
     IRecoverFailedPartition GetRecoveryGrain(EventSourceId partitionId) => _grainFactory.GetGrain<IRecoverFailedPartition>(_observerId, PartitionedObserverKey.FromObserverKey(_observerKey, partitionId));

--- a/Source/Kernel/Shared/Observation/RecoverFailedPartitionState.cs
+++ b/Source/Kernel/Shared/Observation/RecoverFailedPartitionState.cs
@@ -195,6 +195,7 @@ public class RecoverFailedPartitionState
     /// <param name="eventTypes">Types of event that are in the event sequence.</param>
     /// <param name="messages">Any messages associated with the error.</param>
     /// <param name="stacktrace">A stack trace associated with the error.</param>
+    /// <param name="occurred">The date and time for when the error initially occurred.</param>
     public void InitializeError(
         ObserverKey observerKey,
         ObserverName observerName,
@@ -202,14 +203,15 @@ public class RecoverFailedPartitionState
         EventSequenceNumber fromEvent,
         IEnumerable<EventType> eventTypes,
         IEnumerable<string> messages,
-        string stacktrace)
+        string stacktrace,
+        DateTimeOffset occurred)
     {
         ObserverKey = observerKey.ToString();
         ObserverName = observerName;
         SubscriberKey = subscriberKey.ToString();
         CurrentError = fromEvent;
         InitialError = fromEvent;
-        InitialPartitionFailedOn = DateTimeOffset.UtcNow;
+        InitialPartitionFailedOn = occurred;
         EventTypes = eventTypes;
         Messages = messages;
         StackTrace = stacktrace;

--- a/Specifications/Kernel/Grains/Observation/for_FailedPartitionSupervisor/when_failing_a_partition/and_the_partition_is_already_failed.cs
+++ b/Specifications/Kernel/Grains/Observation/for_FailedPartitionSupervisor/when_failing_a_partition/and_the_partition_is_already_failed.cs
@@ -36,5 +36,5 @@ public class and_the_partition_is_already_failed : given.a_supervisor
     [Fact] void should_have_failed_partitions() => supervisor.HasFailedPartitions.ShouldBeTrue();
     [Fact] void should_have_the_failed_partition() => supervisor.GetState().FailedPartitions.SingleOrDefault(_ => _.Partition == partition_id).ShouldNotBeNull();
     [Fact] void should_have_the_details_of_the_original_failed_partition() => supervisor.GetState().FailedPartitions.SingleOrDefault(_ => _.Partition == partition_id).Tail.ShouldEqual(sequence_number);
-    [Fact] void should_not_initiate_the_failed_partition() => failed_partition_mock.Verify(_ => _.Recover(IsAny<ObserverKey>(), IsAny<ObserverName>(), next_sequence_number, event_types, IsAny<IEnumerable<string>>(), IsAny<string>()), Never);
+    [Fact] void should_not_initiate_the_failed_partition() => failed_partition_mock.Verify(_ => _.Recover(IsAny<ObserverKey>(), IsAny<ObserverName>(), next_sequence_number, event_types, IsAny<IEnumerable<string>>(), IsAny<string>(), occurred), Never);
 }

--- a/Specifications/Kernel/Grains/Observation/for_FailedPartitionSupervisor/when_failing_a_partition/and_the_partition_is_not_already_failed.cs
+++ b/Specifications/Kernel/Grains/Observation/for_FailedPartitionSupervisor/when_failing_a_partition/and_the_partition_is_not_already_failed.cs
@@ -34,5 +34,5 @@ public class and_the_partition_is_not_already_failed : given.a_supervisor
     [Fact] void should_have_failed_partitions() => supervisor.HasFailedPartitions.ShouldBeTrue();
     [Fact] void should_have_the_failed_partition() => supervisor.GetState().FailedPartitions.Any(_ => _.Partition == partition_id).ShouldBeTrue();
     [Fact] void should_have_the_failed_partition_with_the_correct_sequence_number() => supervisor.GetState().FailedPartitions.First(_ => _.Partition == partition_id).Tail.ShouldEqual(sequence_number);
-    [Fact] void should_initiate_the_failed_partition() => failed_partition_mock.Verify(_ => _.Recover(IsAny<ObserverKey>(), IsAny<ObserverName>(), sequence_number, event_types, IsAny<IEnumerable<string>>(), IsAny<string>()), Once());
+    [Fact] void should_initiate_the_failed_partition() => failed_partition_mock.Verify(_ => _.Recover(IsAny<ObserverKey>(), IsAny<ObserverName>(), sequence_number, event_types, IsAny<IEnumerable<string>>(), IsAny<string>(), occurred), Once());
 }

--- a/Specifications/Kernel/Grains/Observation/for_RecoverFailedPartition/when_recovering/with_each_event_failing_first_time_then_succeeding.cs
+++ b/Specifications/Kernel/Grains/Observation/for_RecoverFailedPartition/when_recovering/with_each_event_failing_first_time_then_succeeding.cs
@@ -61,7 +61,7 @@ public class with_each_event_failing_first_time_then_succeeding : given.a_recove
         }
     }
 
-    Task Because() => (grain as RecoverFailedPartition).Recover(ObserverKey, string.Empty, initial_error, Enumerable.Empty<EventType>(), Enumerable.Empty<string>(), string.Empty);
+    Task Because() => (grain as RecoverFailedPartition).Recover(ObserverKey, string.Empty, initial_error, Enumerable.Empty<EventType>(), Enumerable.Empty<string>(), string.Empty, DateTimeOffset.UtcNow);
 
     [Fact]
     void should_call_the_subscriber_for_each_successful_event_twice()

--- a/Specifications/Kernel/Grains/Observation/for_RecoverFailedPartition/when_recovering/with_initial_event_failing_first_time_then_succeeding.cs
+++ b/Specifications/Kernel/Grains/Observation/for_RecoverFailedPartition/when_recovering/with_initial_event_failing_first_time_then_succeeding.cs
@@ -54,7 +54,7 @@ public class with_initial_event_failing_first_time_then_succeeding : given.a_rec
         };
     }
 
-    Task Because() => (grain as RecoverFailedPartition).Recover(observer_key, string.Empty, initial_error, Enumerable.Empty<EventType>(), Enumerable.Empty<string>(), string.Empty);
+    Task Because() => (grain as RecoverFailedPartition).Recover(observer_key, string.Empty, initial_error, Enumerable.Empty<EventType>(), Enumerable.Empty<string>(), string.Empty, DateTimeOffset.UtcNow);
 
     [Fact]
     void should_call_the_subscriber_for_the_failed_event_twice()

--- a/Specifications/Kernel/Grains/Observation/for_RecoverFailedPartition/when_recovering/with_no_errors_on_processing_from_failed_event.cs
+++ b/Specifications/Kernel/Grains/Observation/for_RecoverFailedPartition/when_recovering/with_no_errors_on_processing_from_failed_event.cs
@@ -45,7 +45,7 @@ public class with_no_errors_on_processing_from_failed_event : given.a_recover_fa
         };
     }
 
-    Task Because() => (grain as RecoverFailedPartition).Recover(observer_key, string.Empty, initial_error, Enumerable.Empty<EventType>(), Enumerable.Empty<string>(), string.Empty);
+    Task Because() => (grain as RecoverFailedPartition).Recover(observer_key, string.Empty, initial_error, Enumerable.Empty<EventType>(), Enumerable.Empty<string>(), string.Empty, DateTimeOffset.UtcNow);
 
     [Fact]
     void should_call_the_subscriber_for_each_event()

--- a/Specifications/Kernel/Grains/Observation/for_RecoverFailedPartitionState/when_initialising_error.cs
+++ b/Specifications/Kernel/Grains/Observation/for_RecoverFailedPartitionState/when_initialising_error.cs
@@ -26,7 +26,7 @@ public class when_initialising_error : Specification
         state = new RecoverFailedPartitionState();
     }
 
-    void Because() => state.InitializeError(observer_key, string.Empty, subscriber_key, initial_error, event_types, Enumerable.Empty<string>(), string.Empty);
+    void Because() => state.InitializeError(observer_key, string.Empty, subscriber_key, initial_error, event_types, Enumerable.Empty<string>(), string.Empty, DateTimeOffset.UtcNow);
 
     [Fact] void should_set_the_initial_error() => state.InitialError.ShouldEqual(initial_error);
 


### PR DESCRIPTION
## Summary

Addresses #854 by fixing an issue in the RecoverFailedPartition grain

### Fixed

- When recovery of a failed partition is started the original occurred timestamp is carried over all the way to the state
- Added an additional ResumeRecovery method resumes recovery without overriding the InitialPartitionFailedOn timestamp
