### PR TITLE
Fix/observers

### DIFF
--- a/Source/Kernel/Grains.Interfaces/Observation/IObserverSupervisor.cs
+++ b/Source/Kernel/Grains.Interfaces/Observation/IObserverSupervisor.cs
@@ -44,6 +44,12 @@ public interface IObserverSupervisor : IGrainWithGuidCompoundKey
     Task<ObserverSubscription> GetCurrentSubscription();
 
     /// <summary>
+    /// Get the current in-memory state of the observer.
+    /// </summary>
+    /// <returns>The current <see cref="ObserverState"/>.</returns>
+    Task<ObserverState> GetCurrentState();
+
+    /// <summary>
     /// Unsubscribe from the observer.
     /// </summary>
     /// <returns>Awaitable task.</returns>

--- a/Source/Kernel/Grains/Observation/ObserverSupervisor.Subscribing.cs
+++ b/Source/Kernel/Grains/Observation/ObserverSupervisor.Subscribing.cs
@@ -55,7 +55,8 @@ public partial class ObserverSupervisor
 
         await UnsubscribeStream();
 
-        if (HasDefinitionChanged(eventTypes))
+        var lastSequenceNumber = await EventSequenceStorageProvider.GetTailSequenceNumber(State.EventSequenceId, eventTypes);
+        if (HasDefinitionChanged(eventTypes) && lastSequenceNumber != EventSequenceNumber.Unavailable)
         {
             State.EventTypes = eventTypes;
             await WriteStateAsync();
@@ -67,7 +68,6 @@ public partial class ObserverSupervisor
         State.EventTypes = eventTypes;
 
         var tailSequenceNumber = await EventSequenceStorageProvider.GetTailSequenceNumber(State.EventSequenceId);
-        var lastSequenceNumber = await EventSequenceStorageProvider.GetTailSequenceNumber(State.EventSequenceId, State.EventTypes);
         var nextSequenceNumber = lastSequenceNumber.Next();
 
         if (lastSequenceNumber != EventSequenceNumber.Unavailable &&

--- a/Source/Kernel/Grains/Observation/ObserverSupervisor.cs
+++ b/Source/Kernel/Grains/Observation/ObserverSupervisor.cs
@@ -126,7 +126,11 @@ public partial class ObserverSupervisor : ObserverWorker, IObserverSupervisor
 #pragma warning disable CA1721 // Property names should not match get methods
     /// <inheritdoc/>
     public Task<ObserverSubscription> GetCurrentSubscription() => Task.FromResult(CurrentSubscription);
+
 #pragma warning restore CA1721 // Property names should not match get methods
+
+    /// <inheritdoc/>
+    public Task<ObserverState> GetCurrentState() => Task.FromResult(State);
 
     /// <inheritdoc/>
     public async Task NotifyCatchUpComplete(IEnumerable<FailedPartition> failedPartitions)
@@ -134,6 +138,7 @@ public partial class ObserverSupervisor : ObserverWorker, IObserverSupervisor
         await ReadStateAsync();
 
         State.RunningState = ObserverRunningState.Active;
+        await UnsubscribeStream();
         await WriteStateAsync();
 
         await SubscribeStream(HandleEventForPartitionedObserverWhenSubscribing);
@@ -160,6 +165,7 @@ public partial class ObserverSupervisor : ObserverWorker, IObserverSupervisor
         State.RunningState = ObserverRunningState.Active;
         await WriteStateAsync();
 
+        await UnsubscribeStream();
         await SubscribeStream(HandleEventForPartitionedObserverWhenSubscribing);
 
         if (_failedPartitionSupervisor is not null)

--- a/Source/Kernel/Grains/Observation/ObserverWorker.cs
+++ b/Source/Kernel/Grains/Observation/ObserverWorker.cs
@@ -239,8 +239,10 @@ public abstract class ObserverWorker : Grain
     /// <returns>Awaitable task.</returns>
     protected async Task ReadStateAsync()
     {
+        var subscriptionType = State.CurrentSubscriptionType;
+        var subscriptionArguments = State.CurrentSubscriptionArguments;
         await _observerState.ReadStateAsync();
-        if (string.IsNullOrEmpty(State.CurrentSubscriptionType))
+        if (string.IsNullOrEmpty(subscriptionType))
         {
             CurrentSubscription = ObserverSubscription.Unsubscribed;
         }
@@ -251,8 +253,8 @@ public abstract class ObserverWorker : Grain
                 ObserverId,
                 new(MicroserviceId, TenantId, EventSequenceId, SourceMicroserviceId, SourceTenantId),
                 State.EventTypes,
-                Type.GetType(State.CurrentSubscriptionType)!,
-                State.CurrentSubscriptionArguments!);
+                Type.GetType(subscriptionType)!,
+                subscriptionArguments!);
         }
     }
 

--- a/Source/Kernel/Grains/Observation/Replay.cs
+++ b/Source/Kernel/Grains/Observation/Replay.cs
@@ -18,6 +18,7 @@ public class Replay : ObserverWorker, IReplay
 {
     readonly ILogger<Replay> _logger;
     readonly List<FailedPartition> _failedPartitions = new();
+
     ObserverKey? _observerKey;
     IDisposable? _timer;
     bool _isRunning;
@@ -96,6 +97,7 @@ public class Replay : ObserverWorker, IReplay
     async Task PerformReplay(object arg)
     {
         _timer?.Dispose();
+
         try
         {
             var provider = EventSequenceStorageProvider;
@@ -138,7 +140,7 @@ public class Replay : ObserverWorker, IReplay
 
             _isRunning = false;
             _logger.Replayed(ObserverId, MicroserviceId, TenantId, EventSequenceId, SourceMicroserviceId, SourceTenantId);
-            await Supervisor.NotifyCatchUpComplete(_failedPartitions.ToArray());
+            await Supervisor.NotifyReplayComplete(_failedPartitions.ToArray());
             _failedPartitions.Clear();
         }
         catch (Exception ex)

--- a/Specifications/Kernel/Grains/Observation/for_Replay/when_replaying_with_failure.cs
+++ b/Specifications/Kernel/Grains/Observation/for_Replay/when_replaying_with_failure.cs
@@ -15,12 +15,12 @@ public class when_replaying_with_failure : given.a_replay_with_two_pending_event
             .Returns(Task.FromResult(ObserverSubscriberResult.Ok))
             .Returns(Task.FromResult(ObserverSubscriberResult.Failed));
 
-        supervisor.Setup(_ => _.NotifyCatchUpComplete(IsAny<IEnumerable<FailedPartition>>())).Callback((IEnumerable<FailedPartition> partitions) => failed_partitions = partitions);
+        supervisor.Setup(_ => _.NotifyReplayComplete(IsAny<IEnumerable<FailedPartition>>())).Callback((IEnumerable<FailedPartition> partitions) => failed_partitions = partitions);
     }
 
     Task Because() => replay.Start(new(GrainId, ObserverKey.Parse(GrainKeyExtension), event_types, typeof(ObserverSubscriber), subscriber_args));
 
-    [Fact] void should_notify_supervisor_that_catch_up_is_complete_with_failed_partition() => failed_partitions.Count().ShouldEqual(1);
+    [Fact] void should_notify_supervisor_that_replay_is_complete_with_failed_partition() => failed_partitions.Count().ShouldEqual(1);
     [Fact] void should_have_correct_partition() => failed_partitions.First().Partition.ShouldEqual(second_event_source_id);
     [Fact] void should_have_correct_tail() => failed_partitions.First().Tail.ShouldEqual(second_appended_event.Metadata.SequenceNumber);
 }

--- a/Specifications/Kernel/Grains/Observation/for_Replay/when_replaying_with_no_events_to_replay.cs
+++ b/Specifications/Kernel/Grains/Observation/for_Replay/when_replaying_with_no_events_to_replay.cs
@@ -9,5 +9,5 @@ public class when_replaying_with_no_events_to_replay : given.a_replay_worker
 {
     Task Because() => replay.Start(new(GrainId, ObserverKey.Parse(GrainKeyExtension), Enumerable.Empty<EventType>(), typeof(ObserverSubscriber), subscriber_args));
 
-    [Fact] void should_notify_supervisor_that_catch_up_is_complete() => supervisor.Verify(_ => _.NotifyCatchUpComplete(IsAny<IEnumerable<FailedPartition>>()), Once);
+    [Fact] void should_notify_supervisor_that_replay_is_complete() => supervisor.Verify(_ => _.NotifyReplayComplete(IsAny<IEnumerable<FailedPartition>>()), Once);
 }

--- a/Specifications/Kernel/Grains/Observation/for_Replay/when_replaying_with_two_events_to_replay.cs
+++ b/Specifications/Kernel/Grains/Observation/for_Replay/when_replaying_with_two_events_to_replay.cs
@@ -25,5 +25,5 @@ public class when_replaying_with_two_events_to_replay : given.a_replay_with_two_
     [Fact] void should_replay_second_event() => events_replayed[1].Content.ShouldEqual(first_appended_event.Content);
     [Fact] void should_have_head_of_replay_state_for_first_event() => events_replayed[0].Context.ObservationState.HasFlag(EventObservationState.HeadOfReplay).ShouldBeTrue();
     [Fact] void should_have_tail_of_replay_state_for_first_event() => events_replayed[1].Context.ObservationState.HasFlag(EventObservationState.TailOfReplay).ShouldBeTrue();
-    [Fact] void should_notify_supervisor_that_catch_up_is_complete() => supervisor.Verify(_ => _.NotifyCatchUpComplete(IsAny<IEnumerable<FailedPartition>>()), Once);
+    [Fact] void should_notify_supervisor_that_replay_is_complete() => supervisor.Verify(_ => _.NotifyReplayComplete(IsAny<IEnumerable<FailedPartition>>()), Once);
 }


### PR DESCRIPTION
### Fixed

- Replay now calls the replay completed method rather than the catchup completed method when it is done.
- Making sure the subscription information is kept in memory when reading state, so that it is not lost.
- Ignoring replay if there are no events to replay.

