### PR TITLE
Make benchmark project not packable

### DIFF
--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);CA1720;IDE0060;SA0001;SA1600</NoWarn>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Fixed

- Setting `IsPackable` to `false` for the Benchmark project - we're not trying to publish this to NuGet.
