### PR TITLE
Filtering out identities without subject set for the look up of identity by subject

### DIFF
--- a/Source/Kernel/MongoDB/Identities/MongoDBIdentityStore.cs
+++ b/Source/Kernel/MongoDB/Identities/MongoDBIdentityStore.cs
@@ -33,7 +33,9 @@ public class MongoDBIdentityStore : IIdentityStore
         var result = await GetCollection().FindAsync(_ => true);
         var allIdentities = await result.ToListAsync();
         _identitiesByIdentityId = allIdentities.ToDictionary(_ => (IdentityId)_.Id, _ => new Identity(_.Subject, _.Name, _.UserName));
-        _identityIdsBySubject = _identitiesByIdentityId.ToDictionary(_ => _.Value.Subject, _ => _.Key);
+        _identityIdsBySubject = _identitiesByIdentityId
+                                    .Where(_ => !string.IsNullOrEmpty(_.Value.Subject))
+                                    .ToDictionary(_ => _.Value.Subject, _ => _.Key);
         _identityIdsByUserName = _identitiesByIdentityId.ToDictionary(_ => _.Value.UserName, _ => _.Key);
     }
 


### PR DESCRIPTION
### Fixed

- The resolution of identity for things like caused by looks for a match on subject first and if no subject is registered with that it will try to resolve using the username claim. If already have multiple registred users with subject set to null or empty string, then this would fail on startup. This version fixes this problem.
