### PR TITLE
Fix/sink

### DIFF
--- a/Source/Kernel/Common/Configuration/KernelConfiguration.cs
+++ b/Source/Kernel/Common/Configuration/KernelConfiguration.cs
@@ -40,6 +40,8 @@ public class KernelConfiguration : IPerformPostBindOperations
     /// <inheritdoc/>
     public void Perform()
     {
+        Tenants[TenantId.NotSet.ToString()] = new();
+        Microservices[MicroserviceId.Unspecified.ToString()] = new();
         Storage.ConfigureKernelMicroservice(Tenants.Select(_ => _.Key));
     }
 }

--- a/Source/Kernel/Common/Configuration/Storage.cs
+++ b/Source/Kernel/Common/Configuration/Storage.cs
@@ -48,17 +48,14 @@ public class Storage
             Tenants = new()
         };
 
-        Microservices[MicroserviceId.Unspecified].Tenants[TenantId.NotSet.ToString()] = new StorageTypes
+        foreach (var microservice in Microservices)
         {
-            ["readModels"] = Cluster,
-            ["eventStore"] = Cluster
-        };
-
-        Microservices[MicroserviceId.Kernel].Tenants[TenantId.NotSet.ToString()] = new StorageTypes
-        {
-            ["readModels"] = Cluster,
-            ["eventStore"] = Cluster
-        };
+            microservice.Value.Tenants[TenantId.NotSet.ToString()] = new StorageTypes
+            {
+                ["readModels"] = Cluster,
+                ["eventStore"] = Cluster
+            };
+        }
 
         foreach (var tenant in tenants)
         {

--- a/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceCaches.cs
+++ b/Source/Kernel/Grains/EventSequences/Streaming/EventSequenceCaches.cs
@@ -55,6 +55,12 @@ public class EventSequenceCaches : IEventSequenceCaches
         {
             foreach (var (tenantId, _) in _configuration.Tenants)
             {
+                if (!_configuration.Storage.Microservices.ContainsKey(microserviceId) ||
+                    !_configuration.Storage.Microservices.Get(microserviceId).Tenants.ContainsKey(tenantId))
+                {
+                    continue;
+                }
+
                 tasks.Add(GetFor(microserviceId, tenantId, EventSequenceId.Log).PrimeWithTailWindow());
             }
         }

--- a/Source/Kernel/MongoDB/ExpandoObjectConverter.cs
+++ b/Source/Kernel/MongoDB/ExpandoObjectConverter.cs
@@ -144,6 +144,12 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
             return document;
         }
 
+        var bsonValue = value.ToBsonValue();
+        if (bsonValue != BsonNull.Value)
+        {
+            return bsonValue;
+        }
+
         if (value is IEnumerable enumerable)
         {
             var array = new BsonArray();
@@ -156,7 +162,7 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
             return array;
         }
 
-        return value.ToBsonValue();
+        return BsonNull.Value;
     }
 
     object? ConvertUnknownSchemaTypeToClrType(BsonValue value)

--- a/Source/Kernel/MongoDB/Sinks/MongoDBConverter.cs
+++ b/Source/Kernel/MongoDB/Sinks/MongoDBConverter.cs
@@ -161,6 +161,12 @@ public class MongoDBConverter : IMongoDBConverter
             return input.ToBsonValue(targetType);
         }
 
+        var bsonValue = input.ToBsonValue();
+        if (bsonValue != BsonNull.Value)
+        {
+            return bsonValue;
+        }
+
         if (input is IEnumerable enumerable)
         {
             var items = new List<BsonValue>();

--- a/Source/Kernel/Server/cratis.json
+++ b/Source/Kernel/Server/cratis.json
@@ -1,24 +1,7 @@
 {
     "tenants": {
-        "3352d47d-c154-4457-b3fb-8a2efb725113": {
-            "name": "development",
-            "configuration": {
-                "something": "42.42"
-            }
-        },
-        "00000000-0000-0000-0000-000000000000": {
-            "name": "None",
-            "configuration": {
-            }
-        }
     },
     "microservices": {
-        "eaf02867-79b9-4967-be67-3e93cee7c601": {
-            "name": "Bank"
-        },
-        "cd51c091-3bba-4608-87a8-93da1f88c4dd": {
-            "name": "Basic Sample"
-        }
     },
     "cluster": {
         "name": "Cratis",
@@ -40,56 +23,6 @@
             "connectionDetails": "mongodb://localhost:27017/cratis-shared"
         },
         "microservices": {
-            "eaf02867-79b9-4967-be67-3e93cee7c601": {
-                "shared": {
-                    "eventStore": {
-                        "type": "MongoDB",
-                        "connectionDetails": "mongodb://localhost:27017/bank-event-store-shared"
-                    }
-                },
-                "tenants": {
-                    "3352d47d-c154-4457-b3fb-8a2efb725113": {
-                        "readModels": {
-                            "type": "MongoDB",
-                            "connectionDetails": "mongodb://localhost:27017/bank-dev-read-models"
-                        },
-                        "eventStore": {
-                            "type": "MongoDB",
-                            "connectionDetails": "mongodb://localhost:27017/bank-dev-event-store"
-                        }
-                    }
-                }
-            },
-            "cd51c091-3bba-4608-87a8-93da1f88c4dd": {
-                "shared": {
-                    "eventStore": {
-                        "type": "MongoDB",
-                        "connectionDetails": "mongodb://localhost:27017/basic-event-store-shared"
-                    }
-                },
-                "tenants": {
-                    "00000000-0000-0000-0000-000000000000": {
-                        "readModels": {
-                            "type": "MongoDB",
-                            "connectionDetails": "mongodb://localhost:27017/basic-dev-read-models"
-                        },
-                        "eventStore": {
-                            "type": "MongoDB",
-                            "connectionDetails": "mongodb://localhost:27017/basic-dev-event-store"
-                        }
-                    },
-                    "3352d47d-c154-4457-b3fb-8a2efb725113": {
-                        "readModels": {
-                            "type": "MongoDB",
-                            "connectionDetails": "mongodb://localhost:27017/basic-dev-read-models"
-                        },
-                        "eventStore": {
-                            "type": "MongoDB",
-                            "connectionDetails": "mongodb://localhost:27017/basic-dev-event-store"
-                        }
-                    }
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
### Fixed

- Fixing so that primitives are directly by the sink before it considers whether or not it is an enumerable. We saw it outputting strings into MongoDB collections as an array of characters.
- Making sure the single tenancy scenario is dealt with properly throughout config and startup. This will be improved even further in a future version of Cratis.
