### PR TITLE
Fix/sink-writing-errors

### DIFF
--- a/Source/Infrastructure/Changes/ObjectComparer.cs
+++ b/Source/Infrastructure/Changes/ObjectComparer.cs
@@ -71,7 +71,7 @@ public class ObjectComparer : IObjectComparer
                 continue;
             }
 
-            var propertyPath = currentPropertyPath + (type.IsEnumerable() ? $"[{key}]" : key);
+            var propertyPath = currentPropertyPath.AddProperty(key, type);
             CompareValues(type, leftValue, rightValue, propertyPath, differences);
         }
     }

--- a/Source/Infrastructure/Json/ExpandoObjectConverter.cs
+++ b/Source/Infrastructure/Json/ExpandoObjectConverter.cs
@@ -117,6 +117,11 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
     {
         if (jsonNode is JsonObject childObject)
         {
+            if (schemaProperty.IsDictionary)
+            {
+                return ConvertJsonObjectToDictionary(childObject);
+            }
+
             return ToExpandoObject(
                 childObject,
                 schemaProperty.IsArray ? schemaProperty.Item.Reference ?? schemaProperty.Item : schemaProperty.ActualTypeSchema);
@@ -132,6 +137,17 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
             return ConvertJsonValueToSchemaType(jsonNode, schemaProperty);
         }
         return ConvertJsonValueFromUnknownFormat(jsonNode, schemaProperty);
+    }
+
+    IDictionary<object, object> ConvertJsonObjectToDictionary(JsonObject childObject)
+    {
+        var dictionary = new Dictionary<object, object>();
+        foreach (var (key, value) in childObject)
+        {
+            dictionary[key] = ConvertUnknownSchemaTypeToClrType(value!)!;
+        }
+
+        return dictionary;
     }
 
     object? ConvertJsonValueFromUnknownFormat(JsonNode jsonNode, JsonSchema schemaProperty)

--- a/Source/Infrastructure/Properties/PropertyPath.cs
+++ b/Source/Infrastructure/Properties/PropertyPath.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
 using System.Dynamic;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using Aksio.Cratis.Dynamic;
 using Aksio.Cratis.Objects;
+using Aksio.Reflection;
 using Aksio.Strings;
 
 namespace Aksio.Cratis.Properties;
@@ -157,10 +159,16 @@ public class PropertyPath
     /// Add an <see cref="PropertyName"/> as segment by creating a new <see cref="PropertyPath"/>.
     /// </summary>
     /// <param name="name">Name of the property.</param>
+    /// <param name="type">Optional type. It will use this to determine things like if it is an array or not.</param>
     /// <returns>A new <see cref="PropertyPath"/> with the segment appended.</returns>
     /// <remarks>This operation does not mutate the original.</remarks>
-    public PropertyPath AddProperty(string name)
+    public PropertyPath AddProperty(string name, Type? type = null)
     {
+        if (type?.IsEnumerable() == true && type?.IsAssignableTo(typeof(IDictionary)) == false)
+        {
+            name = $"[{name}]]";
+        }
+
         if (Path.Length == 0)
         {
             return new(name);

--- a/Source/Infrastructure/Reflection/DictionaryExtensions.cs
+++ b/Source/Infrastructure/Reflection/DictionaryExtensions.cs
@@ -15,7 +15,9 @@ public static class DictionaryExtensions
     /// </summary>
     /// <param name="type">Type to check.</param>
     /// <returns>True if it is, false if not.</returns>
-    public static bool IsDictionary(this Type type) => type.GetInterfaces().Any(_ => _.IsGenericType && _.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+    public static bool IsDictionary(this Type type) =>
+        (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IDictionary<,>)) ||
+        type.GetInterfaces().Any(_ => _.IsGenericType && _.GetGenericTypeDefinition() == typeof(IDictionary<,>));
 
     /// <summary>
     /// Get the key type of a dictionary.
@@ -48,12 +50,12 @@ public static class DictionaryExtensions
     /// </summary>
     /// <param name="enumerable"><see cref="IEnumerable"/> which is a dictionary to get from.</param>
     /// <returns>A collection of key value pairs of string type.</returns>
-    public static IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs(this IEnumerable enumerable)
+    public static IEnumerable<KeyValuePair<string, object>> GetKeyValuePairs(this IEnumerable enumerable)
     {
         var dictionaryType = enumerable.GetType();
         if (!dictionaryType.IsDictionary())
         {
-            return Enumerable.Empty<KeyValuePair<string, string>>();
+            return Enumerable.Empty<KeyValuePair<string, object>>();
         }
 
         var keyType = dictionaryType.GetKeyType();
@@ -61,13 +63,13 @@ public static class DictionaryExtensions
         var keyValuePairType = typeof(KeyValuePair<,>).MakeGenericType(keyType, valueType);
         var keyProperty = keyValuePairType.GetProperty(nameof(KeyValuePair<object, object>.Key))!;
         var valueProperty = keyValuePairType.GetProperty(nameof(KeyValuePair<object, object>.Value))!;
-        var keyValuePairs = new List<KeyValuePair<string, string>>();
+        var keyValuePairs = new List<KeyValuePair<string, object>>();
 
         foreach (var keyValuePair in enumerable)
         {
-            keyValuePairs.Add(new KeyValuePair<string, string>(
+            keyValuePairs.Add(new KeyValuePair<string, object>(
                 keyProperty.GetValue(keyValuePair)?.ToString() ?? string.Empty,
-                valueProperty.GetValue(keyValuePair)?.ToString() ?? string.Empty));
+                valueProperty.GetValue(keyValuePair)!));
         }
 
         return keyValuePairs;

--- a/Source/Infrastructure/Reflection/DictionaryExtensions.cs
+++ b/Source/Infrastructure/Reflection/DictionaryExtensions.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+
+namespace Aksio.Cratis.Reflection;
+
+/// <summary>
+/// Provides extension methods for <see cref="Type"/>.
+/// </summary>
+public static class DictionaryExtensions
+{
+    /// <summary>
+    /// Check if a type is a dictionary.
+    /// </summary>
+    /// <param name="type">Type to check.</param>
+    /// <returns>True if it is, false if not.</returns>
+    public static bool IsDictionary(this Type type) => type.GetInterfaces().Any(_ => _.IsGenericType && _.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+
+    /// <summary>
+    /// Get the key type of a dictionary.
+    /// </summary>
+    /// <param name="type">Dictionary type to get from.</param>
+    /// <returns>Type of key.</returns>
+    public static Type GetKeyType(this Type type)
+    {
+        var dictionaryInterface = Array.Find(type.GetInterfaces(), _ => _.IsGenericType && _.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+        if (dictionaryInterface is null) return typeof(object);
+
+        return dictionaryInterface.GetGenericArguments()[0];
+    }
+
+    /// <summary>
+    /// Get the key type of a dictionary.
+    /// </summary>
+    /// <param name="type">Dictionary type to get from.</param>
+    /// <returns>Type of key.</returns>
+    public static Type GetValueType(this Type type)
+    {
+        var dictionaryInterface = Array.Find(type.GetInterfaces(), _ => _.IsGenericType && _.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+        if (dictionaryInterface is null) return typeof(object);
+
+        return dictionaryInterface.GetGenericArguments()[1];
+    }
+
+    /// <summary>
+    /// Get the key value pairs from a dictionary.
+    /// </summary>
+    /// <param name="enumerable"><see cref="IEnumerable"/> which is a dictionary to get from.</param>
+    /// <returns>A collection of key value pairs of string type.</returns>
+    public static IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs(this IEnumerable enumerable)
+    {
+        var dictionaryType = enumerable.GetType();
+        if (!dictionaryType.IsDictionary())
+        {
+            return Enumerable.Empty<KeyValuePair<string, string>>();
+        }
+
+        var keyType = dictionaryType.GetKeyType();
+        var valueType = dictionaryType.GetValueType();
+        var keyValuePairType = typeof(KeyValuePair<,>).MakeGenericType(keyType, valueType);
+        var keyProperty = keyValuePairType.GetProperty(nameof(KeyValuePair<object, object>.Key))!;
+        var valueProperty = keyValuePairType.GetProperty(nameof(KeyValuePair<object, object>.Value))!;
+        var keyValuePairs = new List<KeyValuePair<string, string>>();
+
+        foreach (var keyValuePair in enumerable)
+        {
+            keyValuePairs.Add(new KeyValuePair<string, string>(
+                keyProperty.GetValue(keyValuePair)?.ToString() ?? string.Empty,
+                valueProperty.GetValue(keyValuePair)?.ToString() ?? string.Empty));
+        }
+
+        return keyValuePairs;
+    }
+}

--- a/Source/Kernel/MongoDB/ExpandoObjectConverter.cs
+++ b/Source/Kernel/MongoDB/ExpandoObjectConverter.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Dynamic;
+using Aksio.Cratis.Reflection;
 using Aksio.Cratis.Schemas;
 using MongoDB.Bson;
 using NJsonSchema;
@@ -83,6 +84,11 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
 
     BsonValue ConvertToBsonValue(object? value, JsonSchema schemaProperty)
     {
+        if (schemaProperty.IsDictionary)
+        {
+            return ConvertUnknownSchemaTypeToBsonValue(value);
+        }
+
         if (value is ExpandoObject expando)
         {
             return ToBsonDocument(
@@ -112,6 +118,11 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
     {
         if (bsonValue is BsonDocument childDocument)
         {
+            if (schemaProperty.IsDictionary)
+            {
+                return ToDictionary(childDocument);
+            }
+
             return ToExpandoObject(
                 childDocument,
                 schemaProperty.IsArray ? schemaProperty.Item.Reference ?? schemaProperty.Item : schemaProperty.ActualTypeSchema);
@@ -127,6 +138,16 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
             return bsonValue.ToTargetType(_typeFormats.GetTypeForFormat(schemaProperty.Format));
         }
         return ConvertBsonValueFromUnknownFormat(bsonValue, schemaProperty);
+    }
+
+    IDictionary<object, object> ToDictionary(BsonDocument childDocument)
+    {
+        var dictionary = new Dictionary<object, object>();
+        foreach (var element in childDocument.Elements)
+        {
+            dictionary[element.Name] = ConvertUnknownSchemaTypeToClrType(element.Value)!;
+        }
+        return dictionary;
     }
 
     BsonValue ConvertUnknownSchemaTypeToBsonValue(object? value)
@@ -148,6 +169,11 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
         if (bsonValue != BsonNull.Value)
         {
             return bsonValue;
+        }
+
+        if (value?.GetType().IsDictionary() == true)
+        {
+            return value.ToBsonValue();
         }
 
         if (value is IEnumerable enumerable)
@@ -188,6 +214,10 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
             case BsonType.Double:
                 return value.AsDouble;
             case BsonType.String:
+                if (Guid.TryParse(value.AsString, out var guid))
+                {
+                    return guid;
+                }
                 return value.AsString;
             case BsonType.ObjectId:
                 return value.AsObjectId;

--- a/Source/Kernel/MongoDB/Sinks/MongoDBChangesetConverter.cs
+++ b/Source/Kernel/MongoDB/Sinks/MongoDBChangesetConverter.cs
@@ -102,7 +102,7 @@ public class MongoDBChangesetConverter : IMongoDBChangesetConverter
     {
         var allArrayFilters = new List<BsonDocumentArrayFilterDefinition<BsonDocument>>();
 
-        foreach (var propertyDifference in propertiesChanged.Differences)
+        foreach (var propertyDifference in propertiesChanged.Differences.Where(_ => !_.PropertyPath.IsMongoDBKey()).ToArray())
         {
             var (property, arrayFilters) = _converter.ToMongoDBProperty(propertyDifference.PropertyPath, key.ArrayIndexers);
             allArrayFilters.AddRange(arrayFilters);

--- a/Source/Kernel/MongoDB/Sinks/MongoDBConverter.cs
+++ b/Source/Kernel/MongoDB/Sinks/MongoDBConverter.cs
@@ -155,6 +155,8 @@ public class MongoDBConverter : IMongoDBConverter
     /// <inheritdoc/>
     public BsonValue ToBsonValue(object? input, JsonSchemaProperty schemaProperty)
     {
+        if (input is null) return BsonNull.Value;
+
         if (_typeFormats.IsKnown(schemaProperty.Format))
         {
             var targetType = _typeFormats.GetTypeForFormat(schemaProperty.Format);
@@ -165,6 +167,11 @@ public class MongoDBConverter : IMongoDBConverter
         if (bsonValue != BsonNull.Value)
         {
             return bsonValue;
+        }
+
+        if (input is ExpandoObject expandoObject)
+        {
+            return _expandoObjectConverter.ToBsonDocument(expandoObject, schemaProperty.ActualTypeSchema);
         }
 
         if (input is IEnumerable enumerable)
@@ -185,9 +192,9 @@ public class MongoDBConverter : IMongoDBConverter
         }
 
         var value = input.ToBsonValueBasedOnSchemaPropertyType(schemaProperty);
-        if (value == BsonNull.Value && input is ExpandoObject expandoObject)
+        if (value == BsonNull.Value)
         {
-            return _expandoObjectConverter.ToBsonDocument(expandoObject, schemaProperty.ActualTypeSchema);
+            return BsonNull.Value;
         }
 
         return value;

--- a/Source/Kernel/MongoDB/Sinks/MongoDBConverter.cs
+++ b/Source/Kernel/MongoDB/Sinks/MongoDBConverter.cs
@@ -163,15 +163,15 @@ public class MongoDBConverter : IMongoDBConverter
             return input.ToBsonValue(targetType);
         }
 
+        if (input is ExpandoObject expandoObject)
+        {
+            return _expandoObjectConverter.ToBsonDocument(expandoObject, schemaProperty.ActualTypeSchema);
+        }
+
         var bsonValue = input.ToBsonValue();
         if (bsonValue != BsonNull.Value)
         {
             return bsonValue;
-        }
-
-        if (input is ExpandoObject expandoObject)
-        {
-            return _expandoObjectConverter.ToBsonDocument(expandoObject, schemaProperty.ActualTypeSchema);
         }
 
         if (input is IEnumerable enumerable)

--- a/Source/Kernel/MongoDB/Sinks/PropertyPathExtensions.cs
+++ b/Source/Kernel/MongoDB/Sinks/PropertyPathExtensions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Properties;
+
+namespace Aksio.Cratis.Kernel.MongoDB.Sinks;
+
+/// <summary>
+/// Extensions for <see cref="PropertyPath"/>.
+/// </summary>
+public static class PropertyPathExtensions
+{
+    /// <summary>
+    /// Checks whether or not a <see cref="PropertyPath"/> is the MongoDB key property (_id / id).
+    /// </summary>
+    /// <param name="propertyPath"><see cref="PropertyPath"/> to check.</param>
+    /// <returns>True if it is the key property, false if not.</returns>
+    public static bool IsMongoDBKey(this PropertyPath propertyPath) => propertyPath == "_id" || propertyPath == "id";
+}

--- a/Specifications/Infrastructure/Changes/for_ObjectsComparer/when_comparing_object_with_dictionary_with_complex_type/and_key_is_the_same_but_class_object_is_different.cs
+++ b/Specifications/Infrastructure/Changes/for_ObjectsComparer/when_comparing_object_with_dictionary_with_complex_type/and_key_is_the_same_but_class_object_is_different.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Strings;
+
+namespace Aksio.Cratis.Changes.for_ObjectComparer.when_comparing_object_with_dictionary_with_complex_type;
+
+public class and_key_is_the_same_but_class_object_is_different : given.an_object_comparer
+{
+    class OtherType
+    {
+        public string Value { get; set; }
+    }
+
+    record TheType(IDictionary<string, OtherType> Dictionary);
+
+    TheType left;
+    TheType right;
+
+    bool result;
+    IEnumerable<PropertyDifference> differences;
+
+    void Establish()
+    {
+        left = new(new Dictionary<string, OtherType>
+        {
+            { "Key", new()
+                {
+                    Value = "Value"
+                }
+            }
+        });
+        right = new(new Dictionary<string, OtherType>
+        {
+            { "Key", new()
+                {
+                    Value = "Something else"
+                }
+            }
+        });
+    }
+
+    void Because() => result = comparer.Equals(left, right, out differences);
+
+    [Fact] void should_not_be_equal() => result.ShouldBeFalse();
+    [Fact] void should_only_have_one_property_difference() => differences.Count().ShouldEqual(1);
+    [Fact] void should_have_dictionary_property_as_difference() => differences.First().PropertyPath.Path.ShouldEqual(nameof(TheType.Dictionary).ToCamelCase());
+}

--- a/Specifications/Infrastructure/Changes/for_ObjectsComparer/when_comparing_object_with_dictionary_with_string_type/and_key_is_the_same_but_class_object_is_different.cs
+++ b/Specifications/Infrastructure/Changes/for_ObjectsComparer/when_comparing_object_with_dictionary_with_string_type/and_key_is_the_same_but_class_object_is_different.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Strings;
+
+namespace Aksio.Cratis.Changes.for_ObjectComparer.when_comparing_object_with_dictionary_with_string_type;
+
+public class and_key_is_the_same_but_class_object_is_different : given.an_object_comparer
+{
+    record TheType(IDictionary<string, string> Dictionary);
+
+    TheType left;
+    TheType right;
+
+    bool result;
+    IEnumerable<PropertyDifference> differences;
+
+    void Establish()
+    {
+        left = new(new Dictionary<string, string>
+        {
+            { "Key",  "Value" }
+        });
+        right = new(new Dictionary<string, string>
+        {
+            { "Key",  "Something else" }
+        });
+    }
+
+    void Because() => result = comparer.Equals(left, right, out differences);
+
+    [Fact] void should_not_be_equal() => result.ShouldBeFalse();
+    [Fact] void should_only_have_one_property_difference() => differences.Count().ShouldEqual(1);
+    [Fact] void should_have_dictionary_property_as_difference() => differences.First().PropertyPath.Path.ShouldEqual(nameof(TheType.Dictionary).ToCamelCase());
+}

--- a/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/TargetType.cs
+++ b/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/TargetType.cs
@@ -56,4 +56,7 @@ public record TargetType(
     OtherType Reference,
     IEnumerable<OtherType> Children,
     IEnumerable<string> StringArray,
-    IEnumerable<int> IntArray);
+    IEnumerable<int> IntArray,
+    IDictionary<string, string> StringDictionary,
+    IDictionary<string, int> IntDictionary,
+    IDictionary<string, OtherType> ComplexTypeDictionary);

--- a/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
+++ b/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
@@ -9,6 +9,7 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
 {
     JsonObject source;
     JsonObject reference;
+    JsonObject complex_type_for_dictionary;
     JsonObject child;
     dynamic result;
 
@@ -30,6 +31,14 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
             ["guidValue"] = "251b9fbe-83d4-4306-9a5d-9d0e7d4dd456",
         };
 
+        complex_type_for_dictionary = new JsonObject
+        {
+            ["intValue"] = 45,
+            ["floatValue"] = 45.45,
+            ["doubleValue"] = 45.45,
+            ["guidValue"] = Guid.Parse("251b9fbe-83d4-4306-9a5d-9d0e7d4dd456")
+        };
+
         source = new JsonObject
         {
             ["intValue"] = 42,
@@ -49,7 +58,21 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
             ["reference"] = reference,
             ["children"] = new JsonArray(child),
             ["stringArray"] = new JsonArray { "first", "second" },
-            ["intArray"] = new JsonArray { 42, 43 }
+            ["intArray"] = new JsonArray { 42, 43 },
+            ["stringDictionary"] = new JsonObject
+            {
+                ["first"] = "firstValue",
+                ["second"] = "secondValue"
+            },
+            ["intDictionary"] = new JsonObject
+            {
+                ["1"] = 42,
+                ["2"] = 43
+            },
+            ["complexTypeDictionary"] = new JsonObject
+            {
+                ["first"] = complex_type_for_dictionary
+            }
         };
     }
 
@@ -85,6 +108,14 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
     [Fact] void should_set_top_level_string_array_second_item() => ((string)result.stringArray[1]).ShouldEqual("second");
     [Fact] void should_set_top_level_int_array_first_item() => ((int)result.intArray[0]).ShouldEqual(42);
     [Fact] void should_set_top_level_int_array_second_item() => ((int)result.intArray[1]).ShouldEqual(43);
+    [Fact] void should_set_top_level_string_dictionary_first_item() => ((string)result.stringDictionary["first"]).ShouldEqual("firstValue");
+    [Fact] void should_set_top_level_string_dictionary_second_item() => ((string)result.stringDictionary["second"]).ShouldEqual("secondValue");
+    [Fact] void should_set_top_level_int_dictionary_first_item() => ((int)result.intDictionary["1"]).ShouldEqual(42);
+    [Fact] void should_set_top_level_int_dictionary_second_item() => ((int)result.intDictionary["2"]).ShouldEqual(43);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_int_value() => ((int)result.complexTypeDictionary["first"].intValue).ShouldEqual(45);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_float_value() => ((float)result.complexTypeDictionary["first"].floatValue).ShouldEqual((float)45.45f);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_double_value() => ((double)result.complexTypeDictionary["first"].doubleValue).ShouldEqual(45.45);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_guid_value() => ((Guid)result.complexTypeDictionary["first"].guidValue).ShouldEqual(Guid.Parse("251b9fbe-83d4-4306-9a5d-9d0e7d4dd456"));
 
     [Fact] void should_reference_level_int_value_to_be_of_int_type() => ((object)result.reference.intValue).ShouldBeOfExactType<int>();
     [Fact] void should_reference_level_int_value_to_hold_correct_value() => ((int)result.reference.intValue).ShouldEqual(reference["intValue"].GetValue<int>());

--- a/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_json_object.cs
+++ b/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_json_object.cs
@@ -44,6 +44,29 @@ public class when_converting_complex_structure_to_json_object : given.an_expando
         child_expando.guidValue = "633f3280-cb69-4a8b-9e03-7fec8c9e7845";
 
         expando.children = new ExpandoObject[] { child_expando };
+
+        expando.stringDictionary = new Dictionary<string, string>
+        {
+            { "first", "first value" },
+            { "second", "second value" }
+        };
+
+        expando.intDictionary = new Dictionary<string, int>
+        {
+            { "first", 42 },
+            { "second", 43 }
+        };
+
+        dynamic complexType = new ExpandoObject();
+        complexType.intValue = 45;
+        complexType.floatValue = 45.45f;
+        complexType.doubleValue = 45.45;
+        complexType.guidValue = Guid.Parse("a4134076-5823-4189-b017-d82756816305");
+        expando.complexTypeDictionary = new Dictionary<string, ExpandoObject>
+        {
+            { "first", complexType }
+        };
+
         source = expando;
         source_dynamic = expando;
 
@@ -63,6 +86,15 @@ public class when_converting_complex_structure_to_json_object : given.an_expando
     [Fact] void should_set_top_level_date_time_offset_value_to_hold_correct_value() => result["dateTimeOffsetValue"].GetValue<DateTimeOffset>().ShouldEqual(DateTimeOffset.Parse((string)source_dynamic.dateTimeOffsetValue));
     [Fact] void should_set_top_level_date_only_value_to_hold_correct_value() => result["dateOnlyValue"].GetValue<DateTime>().ShouldEqual(DateOnly.Parse((string)source_dynamic.dateOnlyValue).ToDateTime(JsonValueExtensions.Noon));
     [Fact] void should_set_top_level_time_only_value_to_hold_correct_value() => result["timeOnlyValue"].GetValue<DateTime>().ShouldEqual(DateTime.MinValue.Add(TimeOnly.FromDateTime(DateTime.Parse((string)source_dynamic.timeOnlyValue)).ToTimeSpan()));
+    [Fact] void should_set_top_level_string_dictionary_first_item() => result["stringDictionary"]["first"].GetValue<string>().ShouldEqual((string)source_dynamic.stringDictionary["first"]);
+    [Fact] void should_set_top_level_string_dictionary_second_item() => result["stringDictionary"]["second"].GetValue<string>().ShouldEqual((string)source_dynamic.stringDictionary["second"]);
+    [Fact] void should_set_top_level_int_dictionary_first_item() => result["intDictionary"]["first"].GetValue<int>().ShouldEqual((int)source_dynamic.intDictionary["first"]);
+    [Fact] void should_set_top_level_int_dictionary_second_item() => result["intDictionary"]["second"].GetValue<int>().ShouldEqual((int)source_dynamic.intDictionary["second"]);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_int_value() => result["complexTypeDictionary"]["first"]["intValue"].GetValue<int>().ShouldEqual((int)source_dynamic.complexTypeDictionary["first"].intValue);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_float_value() => result["complexTypeDictionary"]["first"]["floatValue"].GetValue<float>().ShouldEqual((float)source_dynamic.complexTypeDictionary["first"].floatValue);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_double_value() => result["complexTypeDictionary"]["first"]["doubleValue"].GetValue<double>().ShouldEqual((double)source_dynamic.complexTypeDictionary["first"].doubleValue);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_guid_value() => result["complexTypeDictionary"]["first"]["guidValue"].GetValue<Guid>().ShouldEqual((Guid)source_dynamic.complexTypeDictionary["first"].guidValue);
+
 
     [Fact] void should_set_reference_object_int_value_to_hold_correct_value() => result["reference"]["intValue"].GetValue<int>().ShouldEqual((int)source_dynamic.reference.intValue);
     [Fact] void should_set_reference_object_float_value_to_hold_correct_value() => result["reference"]["floatValue"].GetValue<float>().ShouldEqual((float)source_dynamic.reference.floatValue);

--- a/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_a_property_to_an_empty_property_with_a_dictionary_type.cs
+++ b/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_a_property_to_an_empty_property_with_a_dictionary_type.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Properties.for_PropertyPath;
+
+public class when_adding_a_property_to_an_empty_property_with_a_dictionary_type : Specification
+{
+    const string left = "";
+    const string right = "something";
+
+    PropertyPath result;
+
+    void Because() => result = new PropertyPath(left).AddProperty(right, typeof(Dictionary<string, string>));
+
+    [Fact] void should_hold_only_property_added_on() => result.Path.ShouldEqual(right);
+}

--- a/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_a_property_to_an_empty_property_with_an_enumerable_type.cs
+++ b/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_a_property_to_an_empty_property_with_an_enumerable_type.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Properties.for_PropertyPath;
+
+public class when_adding_a_property_to_an_empty_property_with_an_enumerable_type : Specification
+{
+    const string left = "";
+    const string right = "something";
+
+    PropertyPath result;
+
+    void Because() => result = new PropertyPath(left).AddProperty(right, typeof(List<string>));
+
+    [Fact] void should_hold_only_property_added_on_as_array() => result.Path.ShouldEqual($"[{right}]");
+}

--- a/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_a_property_to_an_existing_property_with_a_dictionary_type.cs
+++ b/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_a_property_to_an_existing_property_with_a_dictionary_type.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Properties.for_PropertyPath;
+
+public class when_adding_a_property_to_an_existing_property_with_a_dictionary_type : Specification
+{
+    const string left = "left";
+    const string right = "right";
+
+    PropertyPath result;
+
+    void Because() => result = new PropertyPath(left).AddProperty(right, typeof(Dictionary<string, string>));
+
+    [Fact] void should_combine_with_dot_separator() => result.Path.ShouldEqual($"{left}.{right}");
+}

--- a/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_a_property_to_an_existing_property_with_an_enumerable_type.cs
+++ b/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_a_property_to_an_existing_property_with_an_enumerable_type.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Properties.for_PropertyPath;
+
+public class when_adding_a_property_to_an_existing_property_with_an_enumerable_type : Specification
+{
+    const string left = "left";
+    const string right = "right";
+
+    PropertyPath result;
+
+    void Because() => result = new PropertyPath(left).AddProperty(right, typeof(List<string>));
+
+    [Fact] void should_combine_with_dot_separator() => result.Path.ShouldEqual($"{left}.[{right}]");
+}

--- a/Specifications/Infrastructure/Reflection/for_DictionaryExtensions/when_checking_if_type_is_dictionary/and_it_implements_dictionary_interface.cs
+++ b/Specifications/Infrastructure/Reflection/for_DictionaryExtensions/when_checking_if_type_is_dictionary/and_it_implements_dictionary_interface.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Reflection.for_DictionaryExtensions.when_checking_if_type_is_dictionary;
+
+public class and_it_implements_dictionary_interface : Specification
+{
+    bool result;
+
+    void Because() => result = typeof(Dictionary<string, object>).IsDictionary();
+
+    [Fact] void should_be_considered_a_dictionary() => result.ShouldBeTrue();
+}

--- a/Specifications/Infrastructure/Reflection/for_DictionaryExtensions/when_checking_if_type_is_dictionary/and_it_is_not.cs
+++ b/Specifications/Infrastructure/Reflection/for_DictionaryExtensions/when_checking_if_type_is_dictionary/and_it_is_not.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Reflection.for_DictionaryExtensions.when_checking_if_type_is_dictionary;
+
+public class and_it_is_not : Specification
+{
+    bool result;
+
+    void Because() => result = typeof(string).IsDictionary();
+
+    [Fact] void should_not_be_considered_a_dictionary() => result.ShouldBeFalse();
+}

--- a/Specifications/Infrastructure/Reflection/for_DictionaryExtensions/when_checking_if_type_is_dictionary/and_it_is_the_dictionary_interface.cs
+++ b/Specifications/Infrastructure/Reflection/for_DictionaryExtensions/when_checking_if_type_is_dictionary/and_it_is_the_dictionary_interface.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Reflection.for_DictionaryExtensions.when_checking_if_type_is_dictionary;
+
+public class and_it_is_the_dictionary_interface : Specification
+{
+    bool result;
+
+    void Because() => result = typeof(IDictionary<string, object>).IsDictionary();
+
+    [Fact] void should_be_considered_a_dictionary() => result.ShouldBeTrue();
+}

--- a/Specifications/Kernel/MongoDB/Sinks/for_MongoDBConverter/given/a_mongodb_converter.cs
+++ b/Specifications/Kernel/MongoDB/Sinks/for_MongoDBConverter/given/a_mongodb_converter.cs
@@ -6,10 +6,9 @@ using Aksio.Cratis.Schemas;
 using NJsonSchema.Generation;
 using NJsonSchemaGenerator = NJsonSchema.Generation.JsonSchemaGenerator;
 
-
 namespace Aksio.Cratis.Kernel.MongoDB.Sinks.for_MongoDBConverter.given;
 
-public record ReadModel();
+public record ReadModel(string SomeProperty);
 
 public class a_mongodb_converter : Specification
 {

--- a/Specifications/Kernel/MongoDB/Sinks/for_MongoDBConverter/when_converting_to_bson_value/and_value_is_expando_object.cs
+++ b/Specifications/Kernel/MongoDB/Sinks/for_MongoDBConverter/when_converting_to_bson_value/and_value_is_expando_object.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using MongoDB.Bson;
+
+namespace Aksio.Cratis.Kernel.MongoDB.Sinks.for_MongoDBConverter.when_converting_to_bson_value;
+
+public class and_value_is_expando_object : given.a_mongodb_converter
+{
+    ExpandoObject value;
+    BsonValue result;
+
+    void Establish()
+    {
+        value = new ExpandoObject();
+        ((dynamic)value).SomeProperty = "Some value";
+    }
+
+    void Because() => result = converter.ToBsonValue(value);
+
+    [Fact] void should_return_a_bson_document() => result.ShouldNotBeNull();
+    [Fact] void should_have_the_correct_value() => result.AsBsonDocument["SomeProperty"].AsString.ShouldEqual("Some value");
+}

--- a/Specifications/Kernel/MongoDB/Sinks/for_MongoDBConverter/when_converting_to_bson_value_with_schema_info/and_value_is_expando_object.cs
+++ b/Specifications/Kernel/MongoDB/Sinks/for_MongoDBConverter/when_converting_to_bson_value_with_schema_info/and_value_is_expando_object.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Aksio.Cratis.Schemas;
+using MongoDB.Bson;
+using NJsonSchema;
+
+namespace Aksio.Cratis.Kernel.MongoDB.Sinks.for_MongoDBConverter.when_converting_to_bson_value_with_schema_info;
+
+public class and_value_is_expando_object : given.a_mongodb_converter
+{
+    ExpandoObject value;
+    BsonValue result;
+    JsonSchemaProperty schema_property;
+    BsonDocument bson_document;
+
+    void Establish()
+    {
+        value = new ExpandoObject();
+        ((dynamic)value).SomeProperty = "Some value";
+        schema_property = model.Schema.GetSchemaPropertyForPropertyPath(nameof(given.ReadModel.SomeProperty));
+
+        bson_document = new()
+        {
+            { "someProperty", "Some value" }
+        };
+        expando_object_converter.Setup(_ => _.ToBsonDocument(value, schema_property)).Returns(bson_document);
+    }
+
+    void Because() => result = converter.ToBsonValue(value, schema_property);
+
+    [Fact] void should_convert_using_expando_object_converter() => expando_object_converter.Verify(_ => _.ToBsonDocument(value, schema_property), Once);
+    [Fact] void should_return_the_converted_object() => result.ShouldEqual(bson_document);
+}

--- a/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/TargetType.cs
+++ b/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/TargetType.cs
@@ -14,4 +14,7 @@ public record TargetType(
     DateOnly DateOnlyValue,
     TimeOnly TimeOnlyValue,
     OtherType Reference,
-    IEnumerable<OtherType> Children);
+    IEnumerable<OtherType> Children,
+    IDictionary<string, string> StringDictionary,
+    IDictionary<string, int> IntDictionary,
+    IDictionary<string, OtherType> ComplexTypeDictionary);

--- a/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/when_converting_complex_structure_to_bson_document.cs
+++ b/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/when_converting_complex_structure_to_bson_document.cs
@@ -1,90 +1,119 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Dynamic;
 using MongoDB.Bson;
 
 namespace Aksio.Cratis.Kernel.MongoDB.for_ExpandoObjectConverter;
 
 public class when_converting_complex_structure_to_bson_document : given.an_expando_object_converter
 {
-    BsonDocument source;
-    BsonDocument reference;
-    BsonDocument child;
-    dynamic result;
+    ExpandoObject source;
+    ExpandoObject child;
+
+    dynamic source_dynamic;
+    dynamic child_dynamic;
+
+    BsonDocument result;
 
     void Establish()
     {
-        reference = new BsonDocument(new BsonElement[]
+        dynamic expando = new ExpandoObject();
+        expando.intValue = 42;
+        expando.floatValue = 42.42f;
+        expando.doubleValue = 42.42;
+        expando.enumValue = 2;
+        expando.guidValue = "3023e769-4594-45fd-938e-9b231cf3e3f5";
+        expando.dateTimeValue = "2022-10-31T14:51:32.8450000Z";
+        expando.dateTimeOffsetValue = "2022-10-31T14:51:32.8450000Z";
+        expando.dateOnlyValue = "2022-10-31";
+        expando.timeOnlyValue = "2022-10-31T14:51:32";
+        expando.reference = new ExpandoObject();
+        expando.reference.intValue = 43;
+        expando.reference.floatValue = 43.43f;
+        expando.reference.doubleValue = 43.43;
+        expando.reference.guidValue = Guid.Parse("b17a2668-37ba-4a20-ab6a-0aba09926b64");
+        expando.stringDictionary = new Dictionary<string, string>
         {
-            new BsonElement("intValue", 43),
-            new BsonElement("floatValue", 43.43),
-            new BsonElement("doubleValue", 43.43),
-            new BsonElement("guidValue", new BsonBinaryData(Guid.Parse("4f8cef8b-0443-4e4b-9c94-42fac316b241"), GuidRepresentation.Standard))
-        }.AsEnumerable());
+            { "first", "firstValue" },
+            { "second", "secondValue" }
+        };
+        expando.intDictionary = new Dictionary<string, int>
+        {
+            { "first", 42 },
+            { "second", 43 }
+        };
 
-        child = new BsonDocument(new BsonElement[]
-        {
-            new BsonElement("intValue", 44),
-            new BsonElement("floatValue", 44.44),
-            new BsonElement("doubleValue", 44.44),
-            new BsonElement("guidValue", "e0771dc1-0f2a-482a-9c1f-14afaf155716")
-        }.AsEnumerable());
+        dynamic child_expando = new ExpandoObject();
+        child_expando.intValue = 44;
+        child_expando.floatValue = 44.44f;
+        child_expando.doubleValue = 44.44;
+        child_expando.guidValue = "633f3280-cb69-4a8b-9e03-7fec8c9e7845";
 
-        source = new BsonDocument(new BsonElement[]
+        expando.children = new ExpandoObject[] { child_expando };
+
+        dynamic complexType = new ExpandoObject();
+        complexType.intValue = 45;
+        complexType.floatValue = 45.45f;
+        complexType.doubleValue = 45.45;
+        complexType.guidValue = Guid.Parse("a4134076-5823-4189-b017-d82756816305");
+        expando.complexTypeDictionary = new Dictionary<string, ExpandoObject>
         {
-            new BsonElement("intValue", 42),
-            new BsonElement("floatValue", 42.42),
-            new BsonElement("doubleValue", 42.42),
-            new BsonElement("enumValue", 1),
-            new BsonElement("guidValue", "251b9fbe-83d4-4306-9a5d-9d0e7d4dd456"),
-            new BsonElement("dateTimeValue", new BsonDateTime(DateTime.Parse("2022-10-31T14:51:32.8450000Z"))),
-            new BsonElement("dateTimeOffsetValue", new BsonDateTime(DateTime.Parse("2022-10-31T14:51:32.8450000Z"))),
-            new BsonElement("dateOnlyValue", new BsonDateTime(DateTime.Parse("2022-10-31T14:51:32.8450000Z"))),
-            new BsonElement("timeOnlyValue", new BsonDateTime(DateTime.Parse("2022-10-31T14:51:32.8450000Z"))),
-            new BsonElement("reference", reference),
-            new BsonElement("children", new BsonArray(new BsonDocument[]
-            {
-                child
-            }))
-        }.AsEnumerable());
+            { "first", complexType }
+        };
+
+        source = expando;
+        source_dynamic = expando;
+
+        child = child_expando;
+        child_dynamic = child_expando;
     }
 
-    void Because() => result = converter.ToExpandoObject(source, schema);
+    void Because() => result = converter.ToBsonDocument(source, schema);
 
-    [Fact] void should_set_top_level_int_value_to_be_of_int_type() => ((object)result.intValue).ShouldBeOfExactType<int>();
-    [Fact] void should_set_top_level_int_value_to_hold_correct_value() => ((int)result.intValue).ShouldEqual(source.GetElement("intValue").Value.AsInt32);
-    [Fact] void should_set_top_level_float_value_to_be_of_float_type() => ((object)result.floatValue).ShouldBeOfExactType<float>();
-    [Fact] void should_set_top_level_float_value_to_hold_correct_value() => ((float)result.floatValue).ShouldEqual((float)source.GetElement("floatValue").Value.AsDouble);
-    [Fact] void should_set_top_level_double_value_to_be_of_float_type() => ((object)result.doubleValue).ShouldBeOfExactType<double>();
-    [Fact] void should_set_top_level_double_value_to_hold_correct_value() => ((double)result.doubleValue).ShouldEqual(source.GetElement("doubleValue").Value.AsDouble);
-    [Fact] void should_set_top_level_enum_value_to_be_of_float_type() => ((object)result.enumValue).ShouldBeOfExactType<int>();
-    [Fact] void should_set_top_level_enum_value_to_hold_correct_value() => ((double)result.enumValue).ShouldEqual(source.GetElement("enumValue").Value.AsInt32);
-    [Fact] void should_set_top_level_guid_value_to_be_of_guid_type() => ((object)result.guidValue).ShouldBeOfExactType<Guid>();
-    [Fact] void should_set_top_level_guid_value_to_hold_correct_value() => ((Guid)result.guidValue).ShouldEqual(Guid.Parse(source.GetElement("guidValue").Value.AsString));
-    [Fact] void should_set_top_level_date_time_value_to_be_of_date_time_type() => ((object)result.dateTimeValue).ShouldBeOfExactType<DateTime>();
-    [Fact] void should_set_top_level_date_time_value_to_hold_correct_value() => ((DateTime)result.dateTimeValue).ShouldEqual(source.GetElement("dateTimeValue").Value.ToUniversalTime());
-    [Fact] void should_set_top_level_date_time_offset_value_to_be_of_date_time_offset_type() => ((object)result.dateTimeOffsetValue).ShouldBeOfExactType<DateTimeOffset>();
-    [Fact] void should_set_top_level_date_time_offset_value_to_hold_correct_value() => ((DateTimeOffset)result.dateTimeOffsetValue).ShouldEqual(DateTimeOffset.FromUnixTimeMilliseconds(((BsonDateTime)source.GetElement("dateTimeOffsetValue").Value).MillisecondsSinceEpoch));
-    [Fact] void should_set_top_level_date_only_value_to_be_of_date_time_offset_type() => ((object)result.dateOnlyValue).ShouldBeOfExactType<DateOnly>();
-    [Fact] void should_set_top_level_date_only_value_to_hold_correct_value() => ((DateOnly)result.dateOnlyValue).ShouldEqual(DateOnly.FromDateTime(source.GetElement("dateOnlyValue").Value.ToUniversalTime()));
-    [Fact] void should_set_top_level_time_only_value_to_be_of_date_time_offset_type() => ((object)result.timeOnlyValue).ShouldBeOfExactType<TimeOnly>();
-    [Fact] void should_set_top_level_time_only_value_to_hold_correct_value() => ((TimeOnly)result.timeOnlyValue).ShouldEqual(TimeOnly.FromDateTime(source.GetElement("timeOnlyValue").Value.ToUniversalTime()));
+    [Fact] void should_set_top_level_int_value_to_be_of_int_type() => result.GetElement("intValue").Value.ShouldBeOfExactType<BsonInt32>();
+    [Fact] void should_set_top_level_int_value_to_hold_correct_value() => result.GetElement("intValue").Value.AsInt32.ShouldEqual((int)source_dynamic.intValue);
+    [Fact] void should_set_top_level_float_value_to_be_of_double_type() => result.GetElement("floatValue").Value.ShouldBeOfExactType<BsonDouble>();
+    [Fact] void should_set_top_level_float_value_to_hold_correct_value() => result.GetElement("floatValue").Value.AsDouble.ShouldEqual((float)source_dynamic.floatValue);
+    [Fact] void should_set_top_level_double_value_to_be_of_double_type() => result.GetElement("doubleValue").Value.ShouldBeOfExactType<BsonDouble>();
+    [Fact] void should_set_top_level_double_value_to_hold_correct_value() => result.GetElement("doubleValue").Value.AsDouble.ShouldEqual((double)source_dynamic.doubleValue);
+    [Fact] void should_set_top_level_enum_value_to_be_of_double_type() => result.GetElement("enumValue").Value.ShouldBeOfExactType<BsonInt32>();
+    [Fact] void should_set_top_level_enum_value_to_hold_correct_value() => result.GetElement("enumValue").Value.AsInt32.ShouldEqual((int)source_dynamic.enumValue);
+    [Fact] void should_set_top_level_guid_value_to_be_of_binary_type() => result.GetElement("guidValue").Value.ShouldBeOfExactType<BsonBinaryData>();
+    [Fact] void should_set_top_level_guid_value_to_hold_correct_value() => result.GetElement("guidValue").Value.AsGuid.ShouldEqual(Guid.Parse((string)source_dynamic.guidValue));
+    [Fact] void should_set_top_level_date_time_value_to_be_of_date_time_type() => result.GetElement("dateTimeValue").Value.ShouldBeOfExactType<BsonDateTime>();
+    [Fact] void should_set_top_level_date_time_value_to_hold_correct_value() => result.GetElement("dateTimeValue").Value.ToUniversalTime().ShouldEqual(DateTime.Parse((string)source_dynamic.dateTimeValue).ToUniversalTime());
+    [Fact] void should_set_top_level_date_time_offset_value_to_be_of_date_time_type() => result.GetElement("dateTimeOffsetValue").Value.ShouldBeOfExactType<BsonDateTime>();
+    [Fact] void should_set_top_level_date_time_offset_value_to_hold_correct_value() => DateTimeOffset.FromUnixTimeMilliseconds(((BsonDateTime)result.GetElement("dateTimeOffsetValue").Value).MillisecondsSinceEpoch).ShouldEqual(DateTimeOffset.Parse((string)source_dynamic.dateTimeOffsetValue));
+    [Fact] void should_set_top_level_date_only_value_to_be_of_date_time_type() => result.GetElement("dateOnlyValue").Value.ShouldBeOfExactType<BsonDateTime>();
+    [Fact] void should_set_top_level_date_only_value_to_hold_correct_value() => DateOnly.FromDateTime(result.GetElement("dateOnlyValue").Value.ToUniversalTime()).ShouldEqual(DateOnly.Parse((string)source_dynamic.dateOnlyValue));
+    [Fact] void should_set_top_level_time_only_value_to_be_of_date_time_type() => result.GetElement("timeOnlyValue").Value.ShouldBeOfExactType<BsonDateTime>();
+    [Fact] void should_set_top_level_time_only_value_to_hold_correct_value() => TimeOnly.FromDateTime(result.GetElement("timeOnlyValue").Value.ToUniversalTime()).ShouldEqual(TimeOnly.FromDateTime(DateTime.Parse((string)source_dynamic.timeOnlyValue)));
+    [Fact] void should_set_top_level_string_dictionary_first_item() => result.GetElement("stringDictionary").Value.AsBsonDocument.GetElement("first").Value.AsString.ShouldEqual((string)source_dynamic.stringDictionary["first"]);
+    [Fact] void should_set_top_level_string_dictionary_second_item() => result.GetElement("stringDictionary").Value.AsBsonDocument.GetElement("second").Value.AsString.ShouldEqual((string)source_dynamic.stringDictionary["second"]);
+    [Fact] void should_set_top_level_int_dictionary_first_item() => result.GetElement("intDictionary").Value.AsBsonDocument.GetElement("first").Value.AsInt32.ShouldEqual((int)source_dynamic.intDictionary["first"]);
+    [Fact] void should_set_top_level_int_dictionary_second_item() => result.GetElement("intDictionary").Value.AsBsonDocument.GetElement("second").Value.AsInt32.ShouldEqual((int)source_dynamic.intDictionary["second"]);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_int_value() => result.GetElement("complexTypeDictionary").Value.AsBsonDocument.GetElement("first").Value.AsBsonDocument.GetElement("intValue").Value.AsInt32.ShouldEqual((int)source_dynamic.complexTypeDictionary["first"].intValue);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_float_value() => result.GetElement("complexTypeDictionary").Value.AsBsonDocument.GetElement("first").Value.AsBsonDocument.GetElement("floatValue").Value.AsDouble.ShouldEqual((float)source_dynamic.complexTypeDictionary["first"].floatValue);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_double_value() => result.GetElement("complexTypeDictionary").Value.AsBsonDocument.GetElement("first").Value.AsBsonDocument.GetElement("doubleValue").Value.AsDouble.ShouldEqual((double)source_dynamic.complexTypeDictionary["first"].doubleValue);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_guid_value() => result.GetElement("complexTypeDictionary").Value.AsBsonDocument.GetElement("first").Value.AsBsonDocument.GetElement("guidValue").Value.AsGuid.ShouldEqual((Guid)source_dynamic.complexTypeDictionary["first"].guidValue);
 
-    [Fact] void should_reference_level_int_value_to_be_of_int_type() => ((object)result.reference.intValue).ShouldBeOfExactType<int>();
-    [Fact] void should_reference_level_int_value_to_hold_correct_value() => ((int)result.reference.intValue).ShouldEqual(reference.GetElement("intValue").Value.AsInt32);
-    [Fact] void should_reference_level_float_value_to_be_of_float_type() => ((object)result.reference.floatValue).ShouldBeOfExactType<float>();
-    [Fact] void should_reference_level_float_value_to_hold_correct_value() => ((float)result.reference.floatValue).ShouldEqual((float)reference.GetElement("floatValue").Value.AsDouble);
-    [Fact] void should_reference_level_double_value_to_be_of_float_type() => ((object)result.reference.doubleValue).ShouldBeOfExactType<double>();
-    [Fact] void should_reference_level_double_value_to_hold_correct_value() => ((double)result.reference.doubleValue).ShouldEqual(reference.GetElement("doubleValue").Value.AsDouble);
-    [Fact] void should_reference_level_guid_value_to_be_of_guid_type() => ((object)result.reference.guidValue).ShouldBeOfExactType<Guid>();
-    [Fact] void should_reference_level_guid_value_to_hold_correct_value() => ((Guid)result.reference.guidValue).ShouldEqual(reference.GetElement("guidValue").Value.AsGuid);
 
-    [Fact] void should_child_int_value_to_be_of_int_type() => ((object)result.children[0].intValue).ShouldBeOfExactType<int>();
-    [Fact] void should_child_int_value_to_hold_correct_value() => ((int)result.children[0].intValue).ShouldEqual(child.GetElement("intValue").Value.AsInt32);
-    [Fact] void should_child_float_value_to_be_of_float_type() => ((object)result.children[0].floatValue).ShouldBeOfExactType<float>();
-    [Fact] void should_child_float_value_to_hold_correct_value() => ((float)result.children[0].floatValue).ShouldEqual((float)child.GetElement("floatValue").Value.AsDouble);
-    [Fact] void should_child_double_value_to_be_of_float_type() => ((object)result.children[0].doubleValue).ShouldBeOfExactType<double>();
-    [Fact] void should_child_double_value_to_hold_correct_value() => ((double)result.children[0].doubleValue).ShouldEqual(child.GetElement("doubleValue").Value.AsDouble);
-    [Fact] void should_child_guid_value_to_be_of_guid_type() => ((object)result.children[0].guidValue).ShouldBeOfExactType<Guid>();
-    [Fact] void should_child_guid_value_to_hold_correct_value() => ((Guid)result.children[0].guidValue).ShouldEqual(Guid.Parse(child.GetElement("guidValue").Value.AsString));
+    [Fact] void should_reference_object_int_value_to_be_of_int_type() => result.GetElement("reference").Value.AsBsonDocument.GetElement("intValue").Value.ShouldBeOfExactType<BsonInt32>();
+    [Fact] void should_reference_object_int_value_to_hold_correct_value() => result.GetElement("reference").Value.AsBsonDocument.GetElement("intValue").Value.AsInt32.ShouldEqual((int)source_dynamic.reference.intValue);
+    [Fact] void should_reference_object_float_value_to_be_of_double_type() => result.GetElement("reference").Value.AsBsonDocument.GetElement("floatValue").Value.ShouldBeOfExactType<BsonDouble>();
+    [Fact] void should_reference_object_float_value_to_hold_correct_value() => result.GetElement("reference").Value.AsBsonDocument.GetElement("floatValue").Value.AsDouble.ShouldEqual((float)source_dynamic.reference.floatValue);
+    [Fact] void should_reference_object_double_value_to_be_of_double_type() => result.GetElement("reference").Value.AsBsonDocument.GetElement("doubleValue").Value.ShouldBeOfExactType<BsonDouble>();
+    [Fact] void should_reference_object_double_value_to_hold_correct_value() => result.GetElement("reference").Value.AsBsonDocument.GetElement("doubleValue").Value.AsDouble.ShouldEqual((double)source_dynamic.reference.doubleValue);
+    [Fact] void should_reference_object_guid_value_to_be_of_binary_type() => result.GetElement("reference").Value.AsBsonDocument.GetElement("guidValue").Value.ShouldBeOfExactType<BsonBinaryData>();
+    [Fact] void should_reference_object_guid_value_to_hold_correct_value() => result.GetElement("reference").Value.AsBsonDocument.GetElement("guidValue").Value.AsGuid.ShouldEqual((Guid)source_dynamic.reference.guidValue);
+
+    [Fact] void should_child_object_int_value_to_be_of_int_type() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("intValue").Value.ShouldBeOfExactType<BsonInt32>();
+    [Fact] void should_child_object_int_value_to_hold_correct_value() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("intValue").Value.AsInt32.ShouldEqual((int)child_dynamic.intValue);
+    [Fact] void should_child_object_float_value_to_be_of_double_type() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("floatValue").Value.ShouldBeOfExactType<BsonDouble>();
+    [Fact] void should_child_object_float_value_to_hold_correct_value() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("floatValue").Value.AsDouble.ShouldEqual((float)child_dynamic.floatValue);
+    [Fact] void should_child_object_double_value_to_be_of_double_type() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("doubleValue").Value.ShouldBeOfExactType<BsonDouble>();
+    [Fact] void should_child_object_double_value_to_hold_correct_value() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("doubleValue").Value.AsDouble.ShouldEqual((double)child_dynamic.doubleValue);
+    [Fact] void should_child_object_guid_value_to_be_of_binary_type() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("guidValue").Value.ShouldBeOfExactType<BsonBinaryData>();
+    [Fact] void should_child_object_guid_value_to_hold_correct_value() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("guidValue").Value.AsGuid.ShouldEqual(Guid.Parse((string)child_dynamic.guidValue));
 }

--- a/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
+++ b/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
@@ -1,90 +1,119 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Dynamic;
 using MongoDB.Bson;
 
 namespace Aksio.Cratis.Kernel.MongoDB.for_ExpandoObjectConverter;
 
 public class when_converting_complex_structure_to_expando_object : given.an_expando_object_converter
 {
-    ExpandoObject source;
-    ExpandoObject child;
-
-    dynamic source_dynamic;
-    dynamic child_dynamic;
-
-    BsonDocument result;
+    BsonDocument source;
+    BsonDocument reference;
+    BsonDocument child;
+    dynamic result;
 
     void Establish()
     {
-        dynamic expando = new ExpandoObject();
-        expando.intValue = 42;
-        expando.floatValue = 42.42;
-        expando.doubleValue = 42.42;
-        expando.enumValue = 2;
-        expando.guidValue = "3023e769-4594-45fd-938e-9b231cf3e3f5";
-        expando.dateTimeValue = "2022-10-31T14:51:32.8450000Z";
-        expando.dateTimeOffsetValue = "2022-10-31T14:51:32.8450000Z";
-        expando.dateOnlyValue = "2022-10-31";
-        expando.timeOnlyValue = "2022-10-31T14:51:32";
-        expando.reference = new ExpandoObject();
-        expando.reference.intValue = 43;
-        expando.reference.floatValue = 43.43;
-        expando.reference.doubleValue = 43.43;
-        expando.reference.guidValue = Guid.Parse("b17a2668-37ba-4a20-ab6a-0aba09926b64");
+        reference = new BsonDocument(new BsonElement[]
+        {
+            new BsonElement("intValue", 43),
+            new BsonElement("floatValue", 43.43),
+            new BsonElement("doubleValue", 43.43),
+            new BsonElement("guidValue", new BsonBinaryData(Guid.Parse("4f8cef8b-0443-4e4b-9c94-42fac316b241"), GuidRepresentation.Standard))
+        }.AsEnumerable());
 
-        dynamic child_expando = new ExpandoObject();
-        child_expando.intValue = 44;
-        child_expando.floatValue = 44.44;
-        child_expando.doubleValue = 44.44;
-        child_expando.guidValue = "633f3280-cb69-4a8b-9e03-7fec8c9e7845";
+        child = new BsonDocument(new BsonElement[]
+        {
+            new BsonElement("intValue", 44),
+            new BsonElement("floatValue", 44.44),
+            new BsonElement("doubleValue", 44.44),
+            new BsonElement("guidValue", "e0771dc1-0f2a-482a-9c1f-14afaf155716")
+        }.AsEnumerable());
 
-        expando.children = new ExpandoObject[] { child_expando };
-
-        source = expando;
-        source_dynamic = expando;
-
-        child = child_expando;
-        child_dynamic = child_expando;
+        source = new BsonDocument(new BsonElement[]
+        {
+            new BsonElement("intValue", 42),
+            new BsonElement("floatValue", 42.42),
+            new BsonElement("doubleValue", 42.42),
+            new BsonElement("enumValue", 1),
+            new BsonElement("guidValue", "251b9fbe-83d4-4306-9a5d-9d0e7d4dd456"),
+            new BsonElement("dateTimeValue", new BsonDateTime(DateTime.Parse("2022-10-31T14:51:32.8450000Z"))),
+            new BsonElement("dateTimeOffsetValue", new BsonDateTime(DateTime.Parse("2022-10-31T14:51:32.8450000Z"))),
+            new BsonElement("dateOnlyValue", new BsonDateTime(DateTime.Parse("2022-10-31T14:51:32.8450000Z"))),
+            new BsonElement("timeOnlyValue", new BsonDateTime(DateTime.Parse("2022-10-31T14:51:32.8450000Z"))),
+            new BsonElement("reference", reference),
+            new BsonElement("children", new BsonArray(new BsonDocument[]
+            {
+                child
+            })),
+            new BsonElement("stringDictionary", new BsonDocument(new BsonElement[]
+            {
+                new BsonElement("first", "firstValue"),
+                new BsonElement("second", "secondValue")
+            }.AsEnumerable())),
+            new BsonElement("intDictionary", new BsonDocument(new BsonElement[]
+            {
+                new BsonElement("first", 42),
+                new BsonElement("second", 43)
+            }.AsEnumerable())),
+            new BsonElement("complexTypeDictionary", new BsonDocument(new BsonElement[]
+            {
+                new BsonElement("first", new BsonDocument(new BsonElement[]
+                {
+                    new BsonElement("intValue", 42),
+                    new BsonElement("floatValue", 42.42),
+                    new BsonElement("doubleValue", 42.42),
+                    new BsonElement("guidValue", "251b9fbe-83d4-4306-9a5d-9d0e7d4dd456")
+                }.AsEnumerable()))
+            }.AsEnumerable())),
+        }.AsEnumerable());
     }
 
-    void Because() => result = converter.ToBsonDocument(source, schema);
+    void Because() => result = converter.ToExpandoObject(source, schema);
 
-    [Fact] void should_set_top_level_int_value_to_be_of_int_type() => result.GetElement("intValue").Value.ShouldBeOfExactType<BsonInt32>();
-    [Fact] void should_set_top_level_int_value_to_hold_correct_value() => result.GetElement("intValue").Value.AsInt32.ShouldEqual((int)source_dynamic.intValue);
-    [Fact] void should_set_top_level_float_value_to_be_of_double_type() => result.GetElement("floatValue").Value.ShouldBeOfExactType<BsonDouble>();
-    [Fact] void should_set_top_level_float_value_to_hold_correct_value() => result.GetElement("floatValue").Value.AsDouble.ShouldEqual((float)source_dynamic.floatValue);
-    [Fact] void should_set_top_level_double_value_to_be_of_double_type() => result.GetElement("doubleValue").Value.ShouldBeOfExactType<BsonDouble>();
-    [Fact] void should_set_top_level_double_value_to_hold_correct_value() => result.GetElement("doubleValue").Value.AsDouble.ShouldEqual((double)source_dynamic.doubleValue);
-    [Fact] void should_set_top_level_enum_value_to_be_of_double_type() => result.GetElement("enumValue").Value.ShouldBeOfExactType<BsonInt32>();
-    [Fact] void should_set_top_level_enum_value_to_hold_correct_value() => result.GetElement("enumValue").Value.AsInt32.ShouldEqual((int)source_dynamic.enumValue);
-    [Fact] void should_set_top_level_guid_value_to_be_of_binary_type() => result.GetElement("guidValue").Value.ShouldBeOfExactType<BsonBinaryData>();
-    [Fact] void should_set_top_level_guid_value_to_hold_correct_value() => result.GetElement("guidValue").Value.AsGuid.ShouldEqual(Guid.Parse((string)source_dynamic.guidValue));
-    [Fact] void should_set_top_level_date_time_value_to_be_of_date_time_type() => result.GetElement("dateTimeValue").Value.ShouldBeOfExactType<BsonDateTime>();
-    [Fact] void should_set_top_level_date_time_value_to_hold_correct_value() => result.GetElement("dateTimeValue").Value.ToUniversalTime().ShouldEqual(DateTime.Parse((string)source_dynamic.dateTimeValue).ToUniversalTime());
-    [Fact] void should_set_top_level_date_time_offset_value_to_be_of_date_time_type() => result.GetElement("dateTimeOffsetValue").Value.ShouldBeOfExactType<BsonDateTime>();
-    [Fact] void should_set_top_level_date_time_offset_value_to_hold_correct_value() => DateTimeOffset.FromUnixTimeMilliseconds(((BsonDateTime)result.GetElement("dateTimeOffsetValue").Value).MillisecondsSinceEpoch).ShouldEqual(DateTimeOffset.Parse((string)source_dynamic.dateTimeOffsetValue));
-    [Fact] void should_set_top_level_date_only_value_to_be_of_date_time_type() => result.GetElement("dateOnlyValue").Value.ShouldBeOfExactType<BsonDateTime>();
-    [Fact] void should_set_top_level_date_only_value_to_hold_correct_value() => DateOnly.FromDateTime(result.GetElement("dateOnlyValue").Value.ToUniversalTime()).ShouldEqual(DateOnly.Parse((string)source_dynamic.dateOnlyValue));
-    [Fact] void should_set_top_level_time_only_value_to_be_of_date_time_type() => result.GetElement("timeOnlyValue").Value.ShouldBeOfExactType<BsonDateTime>();
-    [Fact] void should_set_top_level_time_only_value_to_hold_correct_value() => TimeOnly.FromDateTime(result.GetElement("timeOnlyValue").Value.ToUniversalTime()).ShouldEqual(TimeOnly.FromDateTime(DateTime.Parse((string)source_dynamic.timeOnlyValue)));
+    [Fact] void should_set_top_level_int_value_to_be_of_int_type() => ((object)result.intValue).ShouldBeOfExactType<int>();
+    [Fact] void should_set_top_level_int_value_to_hold_correct_value() => ((int)result.intValue).ShouldEqual(source.GetElement("intValue").Value.AsInt32);
+    [Fact] void should_set_top_level_float_value_to_be_of_float_type() => ((object)result.floatValue).ShouldBeOfExactType<float>();
+    [Fact] void should_set_top_level_float_value_to_hold_correct_value() => ((float)result.floatValue).ShouldEqual((float)source.GetElement("floatValue").Value.AsDouble);
+    [Fact] void should_set_top_level_double_value_to_be_of_float_type() => ((object)result.doubleValue).ShouldBeOfExactType<double>();
+    [Fact] void should_set_top_level_double_value_to_hold_correct_value() => ((double)result.doubleValue).ShouldEqual(source.GetElement("doubleValue").Value.AsDouble);
+    [Fact] void should_set_top_level_enum_value_to_be_of_float_type() => ((object)result.enumValue).ShouldBeOfExactType<int>();
+    [Fact] void should_set_top_level_enum_value_to_hold_correct_value() => ((double)result.enumValue).ShouldEqual(source.GetElement("enumValue").Value.AsInt32);
+    [Fact] void should_set_top_level_guid_value_to_be_of_guid_type() => ((object)result.guidValue).ShouldBeOfExactType<Guid>();
+    [Fact] void should_set_top_level_guid_value_to_hold_correct_value() => ((Guid)result.guidValue).ShouldEqual(Guid.Parse(source.GetElement("guidValue").Value.AsString));
+    [Fact] void should_set_top_level_date_time_value_to_be_of_date_time_type() => ((object)result.dateTimeValue).ShouldBeOfExactType<DateTime>();
+    [Fact] void should_set_top_level_date_time_value_to_hold_correct_value() => ((DateTime)result.dateTimeValue).ShouldEqual(source.GetElement("dateTimeValue").Value.ToUniversalTime());
+    [Fact] void should_set_top_level_date_time_offset_value_to_be_of_date_time_offset_type() => ((object)result.dateTimeOffsetValue).ShouldBeOfExactType<DateTimeOffset>();
+    [Fact] void should_set_top_level_date_time_offset_value_to_hold_correct_value() => ((DateTimeOffset)result.dateTimeOffsetValue).ShouldEqual(DateTimeOffset.FromUnixTimeMilliseconds(((BsonDateTime)source.GetElement("dateTimeOffsetValue").Value).MillisecondsSinceEpoch));
+    [Fact] void should_set_top_level_date_only_value_to_be_of_date_time_offset_type() => ((object)result.dateOnlyValue).ShouldBeOfExactType<DateOnly>();
+    [Fact] void should_set_top_level_date_only_value_to_hold_correct_value() => ((DateOnly)result.dateOnlyValue).ShouldEqual(DateOnly.FromDateTime(source.GetElement("dateOnlyValue").Value.ToUniversalTime()));
+    [Fact] void should_set_top_level_time_only_value_to_be_of_date_time_offset_type() => ((object)result.timeOnlyValue).ShouldBeOfExactType<TimeOnly>();
+    [Fact] void should_set_top_level_time_only_value_to_hold_correct_value() => ((TimeOnly)result.timeOnlyValue).ShouldEqual(TimeOnly.FromDateTime(source.GetElement("timeOnlyValue").Value.ToUniversalTime()));
+    [Fact] void should_set_top_level_string_dictionary_first_item() => ((string)result.stringDictionary["first"]).ShouldEqual(source.GetElement("stringDictionary").Value.AsBsonDocument.GetElement("first").Value.AsString);
+    [Fact] void should_set_top_level_string_dictionary_second_item() => ((string)result.stringDictionary["second"]).ShouldEqual(source.GetElement("stringDictionary").Value.AsBsonDocument.GetElement("second").Value.AsString);
+    [Fact] void should_set_top_level_int_dictionary_first_item() => ((int)result.intDictionary["first"]).ShouldEqual(source.GetElement("intDictionary").Value.AsBsonDocument.GetElement("first").Value.AsInt32);
+    [Fact] void should_set_top_level_int_dictionary_second_item() => ((int)result.intDictionary["second"]).ShouldEqual(source.GetElement("intDictionary").Value.AsBsonDocument.GetElement("second").Value.AsInt32);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_int_value() => ((int)result.complexTypeDictionary["first"].intValue).ShouldEqual(source.GetElement("complexTypeDictionary").Value.AsBsonDocument.GetElement("first").Value.AsBsonDocument.GetElement("intValue").Value.AsInt32);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_float_value() => ((float)result.complexTypeDictionary["first"].floatValue).ShouldEqual((float)source.GetElement("complexTypeDictionary").Value.AsBsonDocument.GetElement("first").Value.AsBsonDocument.GetElement("floatValue").Value.AsDouble);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_double_value() => ((double)result.complexTypeDictionary["first"].doubleValue).ShouldEqual(source.GetElement("complexTypeDictionary").Value.AsBsonDocument.GetElement("first").Value.AsBsonDocument.GetElement("doubleValue").Value.AsDouble);
+    [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_guid_value() => ((Guid)result.complexTypeDictionary["first"].guidValue).ShouldEqual(Guid.Parse(source.GetElement("complexTypeDictionary").Value.AsBsonDocument.GetElement("first").Value.AsBsonDocument.GetElement("guidValue").Value.AsString));
 
-    [Fact] void should_reference_object_int_value_to_be_of_int_type() => result.GetElement("reference").Value.AsBsonDocument.GetElement("intValue").Value.ShouldBeOfExactType<BsonInt32>();
-    [Fact] void should_reference_object_int_value_to_hold_correct_value() => result.GetElement("reference").Value.AsBsonDocument.GetElement("intValue").Value.AsInt32.ShouldEqual((int)source_dynamic.reference.intValue);
-    [Fact] void should_reference_object_float_value_to_be_of_double_type() => result.GetElement("reference").Value.AsBsonDocument.GetElement("floatValue").Value.ShouldBeOfExactType<BsonDouble>();
-    [Fact] void should_reference_object_float_value_to_hold_correct_value() => result.GetElement("reference").Value.AsBsonDocument.GetElement("floatValue").Value.AsDouble.ShouldEqual((float)source_dynamic.reference.floatValue);
-    [Fact] void should_reference_object_double_value_to_be_of_double_type() => result.GetElement("reference").Value.AsBsonDocument.GetElement("doubleValue").Value.ShouldBeOfExactType<BsonDouble>();
-    [Fact] void should_reference_object_double_value_to_hold_correct_value() => result.GetElement("reference").Value.AsBsonDocument.GetElement("doubleValue").Value.AsDouble.ShouldEqual((double)source_dynamic.reference.doubleValue);
-    [Fact] void should_reference_object_guid_value_to_be_of_binary_type() => result.GetElement("reference").Value.AsBsonDocument.GetElement("guidValue").Value.ShouldBeOfExactType<BsonBinaryData>();
-    [Fact] void should_reference_object_guid_value_to_hold_correct_value() => result.GetElement("reference").Value.AsBsonDocument.GetElement("guidValue").Value.AsGuid.ShouldEqual((Guid)source_dynamic.reference.guidValue);
 
-    [Fact] void should_child_object_int_value_to_be_of_int_type() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("intValue").Value.ShouldBeOfExactType<BsonInt32>();
-    [Fact] void should_child_object_int_value_to_hold_correct_value() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("intValue").Value.AsInt32.ShouldEqual((int)child_dynamic.intValue);
-    [Fact] void should_child_object_float_value_to_be_of_double_type() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("floatValue").Value.ShouldBeOfExactType<BsonDouble>();
-    [Fact] void should_child_object_float_value_to_hold_correct_value() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("floatValue").Value.AsDouble.ShouldEqual((float)child_dynamic.floatValue);
-    [Fact] void should_child_object_double_value_to_be_of_double_type() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("doubleValue").Value.ShouldBeOfExactType<BsonDouble>();
-    [Fact] void should_child_object_double_value_to_hold_correct_value() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("doubleValue").Value.AsDouble.ShouldEqual((double)child_dynamic.doubleValue);
-    [Fact] void should_child_object_guid_value_to_be_of_binary_type() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("guidValue").Value.ShouldBeOfExactType<BsonBinaryData>();
-    [Fact] void should_child_object_guid_value_to_hold_correct_value() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("guidValue").Value.AsGuid.ShouldEqual(Guid.Parse((string)child_dynamic.guidValue));
+    [Fact] void should_reference_level_int_value_to_be_of_int_type() => ((object)result.reference.intValue).ShouldBeOfExactType<int>();
+    [Fact] void should_reference_level_int_value_to_hold_correct_value() => ((int)result.reference.intValue).ShouldEqual(reference.GetElement("intValue").Value.AsInt32);
+    [Fact] void should_reference_level_float_value_to_be_of_float_type() => ((object)result.reference.floatValue).ShouldBeOfExactType<float>();
+    [Fact] void should_reference_level_float_value_to_hold_correct_value() => ((float)result.reference.floatValue).ShouldEqual((float)reference.GetElement("floatValue").Value.AsDouble);
+    [Fact] void should_reference_level_double_value_to_be_of_float_type() => ((object)result.reference.doubleValue).ShouldBeOfExactType<double>();
+    [Fact] void should_reference_level_double_value_to_hold_correct_value() => ((double)result.reference.doubleValue).ShouldEqual(reference.GetElement("doubleValue").Value.AsDouble);
+    [Fact] void should_reference_level_guid_value_to_be_of_guid_type() => ((object)result.reference.guidValue).ShouldBeOfExactType<Guid>();
+    [Fact] void should_reference_level_guid_value_to_hold_correct_value() => ((Guid)result.reference.guidValue).ShouldEqual(reference.GetElement("guidValue").Value.AsGuid);
+
+    [Fact] void should_child_int_value_to_be_of_int_type() => ((object)result.children[0].intValue).ShouldBeOfExactType<int>();
+    [Fact] void should_child_int_value_to_hold_correct_value() => ((int)result.children[0].intValue).ShouldEqual(child.GetElement("intValue").Value.AsInt32);
+    [Fact] void should_child_float_value_to_be_of_float_type() => ((object)result.children[0].floatValue).ShouldBeOfExactType<float>();
+    [Fact] void should_child_float_value_to_hold_correct_value() => ((float)result.children[0].floatValue).ShouldEqual((float)child.GetElement("floatValue").Value.AsDouble);
+    [Fact] void should_child_double_value_to_be_of_float_type() => ((object)result.children[0].doubleValue).ShouldBeOfExactType<double>();
+    [Fact] void should_child_double_value_to_hold_correct_value() => ((double)result.children[0].doubleValue).ShouldEqual(child.GetElement("doubleValue").Value.AsDouble);
+    [Fact] void should_child_guid_value_to_be_of_guid_type() => ((object)result.children[0].guidValue).ShouldBeOfExactType<Guid>();
+    [Fact] void should_child_guid_value_to_hold_correct_value() => ((Guid)result.children[0].guidValue).ShouldEqual(Guid.Parse(child.GetElement("guidValue").Value.AsString));
 }


### PR DESCRIPTION
### Fixed

- Skipping `_id` properties in changeset when creating update definition for Mongo, as this is implicitly set by the MongoDB C# driver and will cause an exception if its there.
- FIxing conversion check ordering to make sure we get correct types (complex types first, then value types, dictionaries, enumerables).
- Adding support for dictionary types for the entire Reducer & Projection pipelines, including the MongoDB Sink.
