### PR TITLE
Fix/startup-logs

### DIFF
--- a/Source/Infrastructure/Boot/BootProcedures.cs
+++ b/Source/Infrastructure/Boot/BootProcedures.cs
@@ -3,6 +3,7 @@
 
 using Aksio.Collections;
 using Aksio.Types;
+using Microsoft.Extensions.Logging;
 
 namespace Aksio.Cratis.Boot;
 
@@ -12,13 +13,25 @@ namespace Aksio.Cratis.Boot;
 public class BootProcedures : IBootProcedures
 {
     readonly IInstancesOf<IPerformBootProcedure> _procedures;
+    readonly ILogger<BootProcedures> _logger;
 
     /// <summary>
     /// Initializes a new instance of <see cref="BootProcedures"/>.
     /// </summary>
     /// <param name="procedures"><see cref="IInstancesOf{T}"/> <see cref="IPerformBootProcedure"/>.</param>
-    public BootProcedures(IInstancesOf<IPerformBootProcedure> procedures) => _procedures = procedures;
+    /// <param name="logger"><see cref="ILogger"/> for logging.</param>
+    public BootProcedures(
+        IInstancesOf<IPerformBootProcedure> procedures,
+        ILogger<BootProcedures> logger)
+    {
+        _procedures = procedures;
+        _logger = logger;
+    }
 
     /// <inheritdoc/>
-    public void Perform() => _procedures.ForEach(_ => _.Perform());
+    public void Perform()
+    {
+        _logger.PerformingBootProcedures();
+        _procedures.ForEach(_ => _.Perform());
+    }
 }

--- a/Source/Infrastructure/Boot/BootProceduresLogMessages.cs
+++ b/Source/Infrastructure/Boot/BootProceduresLogMessages.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Aksio.Cratis.Boot;
+
+internal static partial class BootProceduresLogMessages
+{
+    [LoggerMessage(0, LogLevel.Information, "Performing boot procedures")]
+    internal static partial void PerformingBootProcedures(this ILogger<BootProcedures> logger);
+}

--- a/Source/Kernel/Grains/Projections/Projections.cs
+++ b/Source/Kernel/Grains/Projections/Projections.cs
@@ -106,7 +106,9 @@ public class Projections : Grain, IProjections, IOnBroadcastChannelSubscribed
             var isNew = !await _projectionDefinitions().HasFor(projectionDefinition.Identifier);
             var hasChanged = await _projectionDefinitions().HasChanged(projectionDefinition);
 
-            if (hasChanged || isNew)
+            _executionContextManager.Establish(microserviceId);
+
+            if (hasChanged || isNew || !_projectionManagerProvider().Exists(projectionDefinition.Identifier))
             {
                 await RegisterProjectionAndPipeline(
                     microserviceId,

--- a/Source/Kernel/Server/Startup.cs
+++ b/Source/Kernel/Server/Startup.cs
@@ -21,11 +21,17 @@ public class Startup
 
     public void Configure(IApplicationBuilder app)
     {
+        var logger = app.ApplicationServices.GetRequiredService<ILogger<Startup>>();
+
         app.UseRouting();
         app.UseWebSockets();
         app.UseCratis();
         var appLifetime = app.ApplicationServices.GetRequiredService<IHostApplicationLifetime>();
-        appLifetime.ApplicationStarted.Register(() => app.PerformBootProcedures());
+        appLifetime.ApplicationStarted.Register(() =>
+        {
+            logger.PerformingBootProcedures();
+            app.PerformBootProcedures();
+        });
         app.UseAksio();
     }
 }

--- a/Source/Kernel/Server/StartupLogMessages.cs
+++ b/Source/Kernel/Server/StartupLogMessages.cs
@@ -28,4 +28,7 @@ internal static partial class StartupLogMessages
 
     [LoggerMessage(6, LogLevel.Information, "Using Azure storage clustering")]
     internal static partial void UsingAzureStorageClustering(this ILogger<Startup> logger);
+
+    [LoggerMessage(7, LogLevel.Information, "Performing boot procedures")]
+    internal static partial void PerformingBootProcedures(this ILogger<Startup> logger);
 }


### PR DESCRIPTION
### Fixed

- Adding more logging to see what is going on @ startup.
- Making sure we register projections that aren't registered with the `ProjectionManager`.
