### PR TITLE
Changing stop to do nothing if there is nothing to stop. + do not write its state - it can be stale

### DIFF
--- a/Source/Kernel/Grains/Observation/CatchUp.cs
+++ b/Source/Kernel/Grains/Observation/CatchUp.cs
@@ -98,12 +98,16 @@ public class CatchUp : ObserverWorker, ICatchUp
     }
 
     /// <inheritdoc/>
-    public async Task Stop()
+    public Task Stop()
     {
-        _logger.Stopping(ObserverId, MicroserviceId, TenantId, EventSequenceId, SourceMicroserviceId, SourceTenantId);
-        _isRunning = false;
-        _timer?.Dispose();
-        await WriteStateAsync();
+        if (_isRunning || _timer is not null)
+        {
+            _logger.Stopping(ObserverId, MicroserviceId, TenantId, EventSequenceId, SourceMicroserviceId, SourceTenantId);
+            _isRunning = false;
+            _timer?.Dispose();
+        }
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>

--- a/Source/Kernel/Grains/Observation/Replay.cs
+++ b/Source/Kernel/Grains/Observation/Replay.cs
@@ -99,12 +99,16 @@ public class Replay : ObserverWorker, IReplay
     }
 
     /// <inheritdoc/>
-    public async Task Stop()
+    public Task Stop()
     {
-        _logger.Stopping(ObserverId, MicroserviceId, TenantId, EventSequenceId, SourceMicroserviceId, SourceTenantId);
-        _isRunning = false;
-        _timer?.Dispose();
-        await WriteStateAsync();
+        if (_isRunning || _timer is not null)
+        {
+            _logger.Stopping(ObserverId, MicroserviceId, TenantId, EventSequenceId, SourceMicroserviceId, SourceTenantId);
+            _isRunning = false;
+            _timer?.Dispose();
+        }
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
### Fixed

- Fixing `CatchUp` and `Replay` to not write state on the `Stop()` method, as it is not altering any `ObserverState` at that point. This fixes a problem we've seen were observers seem to be observing events multiple times. The reason for this is that the in-memory state representation of the grain is stale. Observer worker jobs share the state with the parent supervisor, but it is not synchronized and only updated when absolutely needed. This whole thing will be ripped out in an upcoming version with a complete rewrite of how observers work.

