### PR TITLE
Fix/observer-staleness

### DIFF
--- a/Source/Kernel/MongoDB/EventSequences/MongoDBEventSequenceStorage.cs
+++ b/Source/Kernel/MongoDB/EventSequences/MongoDBEventSequenceStorage.cs
@@ -328,7 +328,7 @@ public class MongoDBEventSequenceStorage : IEventSequenceStorage
 
         if (eventTypes?.Any() ?? false)
         {
-            filters.Add(Builders<Event>.Filter.Or(eventTypes.Select(_ => Builders<Event>.Filter.Eq(e => e.Type, _.Id)).ToArray()));
+            filters.Add(Builders<Event>.Filter.In(_ => _.Type, eventTypes.Select(_ => _.Id.Value).ToArray()));
         }
         if (eventSourceId?.IsSpecified == true)
         {

--- a/Source/Kernel/MongoDB/Observation/CatchUpStorageProvider.cs
+++ b/Source/Kernel/MongoDB/Observation/CatchUpStorageProvider.cs
@@ -6,6 +6,7 @@ using Aksio.Cratis.Kernel.Grains.Observation;
 using Aksio.Cratis.Observation;
 using Aksio.DependencyInversion;
 using Aksio.Strings;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using Orleans.Runtime;
 
@@ -22,11 +23,13 @@ public class CatchUpStorageProvider : ObserverStorageProvider
     /// <param name="executionContextManager"><see cref="IExecutionContextManager"/> for working with the execution context.</param>
     /// <param name="eventStoreDatabaseProvider">Provider for <see cref="IEventStoreDatabase"/>.</param>
     /// <param name="eventSequenceStorageProvider">Provider for <see cref="IEventSequenceStorage"/>.</param>
+    /// <param name="logger"><see cref="ILogger"/> for logging.</param>
     public CatchUpStorageProvider(
         IExecutionContextManager executionContextManager,
         ProviderFor<IEventStoreDatabase> eventStoreDatabaseProvider,
-        ProviderFor<IEventSequenceStorage> eventSequenceStorageProvider)
-        : base(executionContextManager, eventStoreDatabaseProvider, eventSequenceStorageProvider)
+        ProviderFor<IEventSequenceStorage> eventSequenceStorageProvider,
+        ILogger<ObserverStorageProvider> logger)
+        : base(executionContextManager, eventStoreDatabaseProvider, eventSequenceStorageProvider, logger)
     {
     }
 

--- a/Source/Kernel/MongoDB/Observation/ObserverStorageProviderLogMessages.cs
+++ b/Source/Kernel/MongoDB/Observation/ObserverStorageProviderLogMessages.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Events;
+using Aksio.Cratis.Observation;
+using Microsoft.Extensions.Logging;
+
+namespace Aksio.Cratis.Kernel.MongoDB.Observation;
+
+internal static partial class ObserverStorageProviderLogMessages
+{
+    [LoggerMessage(0, LogLevel.Trace, "Getting tail sequence number for observer {ObserverId} for tenant {TenantId} and microservice {MicroserviceId}")]
+    internal static partial void GettingTailSequenceNumber(this ILogger<ObserverStorageProvider> logger, ObserverId observerId, TenantId tenantId, MicroserviceId microserviceId);
+
+    [LoggerMessage(1, LogLevel.Trace, "Got tail sequence number {TailSequenceNumber} for observer {ObserverId} for tenant {TenantId} and microservice {MicroserviceId}")]
+    internal static partial void GotTailSequenceNumber(this ILogger<ObserverStorageProvider> logger, ObserverId observerId, TenantId tenantId, MicroserviceId microserviceId, EventSequenceNumber tailSequenceNumber);
+
+    [LoggerMessage(2, LogLevel.Trace, "Getting next sequence number greater or equal than {SequenceNumber} for observer {ObserverId} for tenant {TenantId} and microservice {MicroserviceId}")]
+    internal static partial void GettingNextSequenceNumberGreaterOrEqualThan(this ILogger<ObserverStorageProvider> logger, ObserverId observerId, TenantId tenantId, MicroserviceId microserviceId, EventSequenceNumber sequenceNumber);
+
+    [LoggerMessage(3, LogLevel.Trace, "Got next sequence number {NextSequenceNumber} for observer {ObserverId} for tenant {TenantId} and microservice {MicroserviceId}")]
+    internal static partial void GotNextSequenceNumber(this ILogger<ObserverStorageProvider> logger, ObserverId observerId, TenantId tenantId, MicroserviceId microserviceId, EventSequenceNumber nextSequenceNumber);
+}

--- a/Source/Kernel/MongoDB/Observation/ReplayStorageProvider.cs
+++ b/Source/Kernel/MongoDB/Observation/ReplayStorageProvider.cs
@@ -6,6 +6,7 @@ using Aksio.Cratis.Kernel.Grains.Observation;
 using Aksio.Cratis.Observation;
 using Aksio.DependencyInversion;
 using Aksio.Strings;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using Orleans.Runtime;
 
@@ -22,11 +23,13 @@ public class ReplayStorageProvider : ObserverStorageProvider
     /// <param name="executionContextManager"><see cref="IExecutionContextManager"/> for working with the execution context.</param>
     /// <param name="eventStoreDatabaseProvider">Provider for <see cref="IEventStoreDatabase"/>.</param>
     /// <param name="eventSequenceStorageProvider">Provider for <see cref="IEventSequenceStorage"/>.</param>
+    /// <param name="logger"><see cref="ILogger"/> for logging.</param>
     public ReplayStorageProvider(
         IExecutionContextManager executionContextManager,
         ProviderFor<IEventStoreDatabase> eventStoreDatabaseProvider,
-        ProviderFor<IEventSequenceStorage> eventSequenceStorageProvider)
-        : base(executionContextManager, eventStoreDatabaseProvider, eventSequenceStorageProvider)
+        ProviderFor<IEventSequenceStorage> eventSequenceStorageProvider,
+        ILogger<ObserverStorageProvider> logger)
+        : base(executionContextManager, eventStoreDatabaseProvider, eventSequenceStorageProvider, logger)
     {
     }
 


### PR DESCRIPTION
### Fixed

- Observers ended up being in a stale state due to not getting the actual next sequence number based on the event types. This is now fixed.
- Optimizing query for getting next event sequence number greater or equal to a given sequence number by using `.In()` rather than a collection of `.Or()` statements for the event types.