### PR TITLE
Fixing so that if there are no event types for an immediate projection, we return empty result

### DIFF
--- a/Source/Kernel/Grains.Interfaces/Projections/ImmediateProjectionResult.cs
+++ b/Source/Kernel/Grains.Interfaces/Projections/ImmediateProjectionResult.cs
@@ -12,4 +12,10 @@ namespace Aksio.Cratis.Kernel.Grains.Projections;
 /// <param name="Model">The Json representation of the model.</param>
 /// <param name="AffectedProperties">Collection of properties that was set.</param>
 /// <param name="ProjectedEventsCount">Number of events that caused projection.</param>
-public record ImmediateProjectionResult(JsonObject Model, IEnumerable<PropertyPath> AffectedProperties, int ProjectedEventsCount);
+public record ImmediateProjectionResult(JsonObject Model, IEnumerable<PropertyPath> AffectedProperties, int ProjectedEventsCount)
+{
+    /// <summary>
+    /// Represents an empty <see cref="ImmediateProjectionResult"/>.
+    /// </summary>
+    public static readonly ImmediateProjectionResult Empty = new(new JsonObject(), Array.Empty<PropertyPath>(), 0);
+}

--- a/Source/Kernel/Grains/Projections/ImmediateProjection.cs
+++ b/Source/Kernel/Grains/Projections/ImmediateProjection.cs
@@ -65,13 +65,18 @@ public class ImmediateProjection : Grain, IImmediateProjection
     {
         if (_projectionKey is null)
         {
-            return new ImmediateProjectionResult(new JsonObject(), Array.Empty<PropertyPath>(), 0);
+            return ImmediateProjectionResult.Empty;
         }
 
         // TODO: This is a temporary work-around till we fix #264 & #265
         _executionContextManager.Establish(_projectionKey.TenantId, CorrelationId.New(), _projectionKey.MicroserviceId);
 
         var projection = _projectionManagerProvider().Get(projectionId);
+
+        if (!projection.EventTypes.Any())
+        {
+            return ImmediateProjectionResult.Empty;
+        }
 
         var affectedProperties = new HashSet<PropertyPath>();
 

--- a/Source/Kernel/Grains/Projections/ImmediateProjection.cs
+++ b/Source/Kernel/Grains/Projections/ImmediateProjection.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Dynamic;
-using System.Text.Json.Nodes;
 using Aksio.Cratis.Changes;
 using Aksio.Cratis.Dynamic;
 using Aksio.Cratis.Events;


### PR DESCRIPTION
### Fixed

- Fixing immediate projections to return empty result if projection doesn't have any events its observing.
