### PR TITLE
Feature/projection-add-child

### DIFF
--- a/Source/Clients/DotNET/Projections/AddChildBuilder.cs
+++ b/Source/Clients/DotNET/Projections/AddChildBuilder.cs
@@ -54,7 +54,7 @@ public class AddChildBuilder<TParentModel, TChildModel, TEvent> : IAddChildBuild
     /// <inheritdoc/>
     public IAddChildBuilder<TChildModel, TEvent> UsingParentCompositeKey<TKeyType>(Action<ICompositeKeyBuilder<TKeyType, TEvent>> builderCallback)
     {
-        _fromBuilder!.UsingParentCompositeKey<TKeyType>(builderCallback);
+        _fromBuilder!.UsingParentCompositeKey(builderCallback);
         return this;
     }
 

--- a/Source/Clients/DotNET/Projections/IChildrenBuilder.cs
+++ b/Source/Clients/DotNET/Projections/IChildrenBuilder.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using Aksio.Cratis.Projections.Definitions;
+using Aksio.Cratis.Properties;
 
 namespace Aksio.Cratis.Projections;
 
@@ -16,10 +17,25 @@ public interface IChildrenBuilder<TParentModel, TChildModel> : IProjectionBuilde
     /// <summary>
     /// Sets the property that identifies the child model in the collection within the parent.
     /// </summary>
+    /// <param name="propertyPath">The <see cref="PropertyPath"/>  that represents the property used to identify.</param>
+    /// <returns>Builder continuation.</returns>
+    IChildrenBuilder<TParentModel, TChildModel> IdentifiedBy(PropertyPath propertyPath);
+
+    /// <summary>
+    /// Sets the property that identifies the child model in the collection within the parent.
+    /// </summary>
     /// <param name="propertyExpression">The expression that represents the property used to identify.</param>
     /// <typeparam name="TProperty">Type of property.</typeparam>
     /// <returns>Builder continuation.</returns>
     IChildrenBuilder<TParentModel, TChildModel> IdentifiedBy<TProperty>(Expression<Func<TChildModel, TProperty>> propertyExpression);
+
+    /// <summary>
+    /// Defines the event and property on it that the child should be created as a value from.
+    /// </summary>
+    /// <param name="propertyExpression">The expression that represents the property on the event to use.</param>
+    /// <typeparam name="TEvent">Type of event.</typeparam>
+    /// <returns>Builder continuation.</returns>
+    IChildrenBuilder<TParentModel, TChildModel> FromEventProperty<TEvent>(Expression<Func<TEvent, TChildModel>> propertyExpression);
 
     /// <summary>
     /// Build the <see cref="ChildrenDefinition"/>.

--- a/Source/Clients/DotNET/Projections/IModelPropertiesBuilder.cs
+++ b/Source/Clients/DotNET/Projections/IModelPropertiesBuilder.cs
@@ -91,6 +91,15 @@ public interface IModelPropertiesBuilder<TModel, TEvent, TBuilder>
     TBuilder Count<TProperty>(Expression<Func<TModel, TProperty>> modelPropertyAccessor);
 
     /// <summary>
+    /// Start building a child operation that add a child based on a property on the event.
+    /// </summary>
+    /// <param name="targetProperty">The collection property that will receive the child.</param>
+    /// <param name="eventProperty">Event property accessor for defining the source property.</param>
+    /// <typeparam name="TChildModel">Type of child model.</typeparam>
+    /// <returns>Builder continuation.</returns>
+    TBuilder AddChild<TChildModel>(Expression<Func<TModel, IEnumerable<TChildModel>>> targetProperty, Expression<Func<TEvent, TChildModel>> eventProperty);
+
+    /// <summary>
     /// Start building the add child operation to a target property holding an collection of a specific child model type.
     /// </summary>
     /// <param name="targetProperty">The collection property that will receive the child.</param>
@@ -103,7 +112,7 @@ public interface IModelPropertiesBuilder<TModel, TEvent, TBuilder>
     /// Start building the set operation to a target property on the model.
     /// </summary>
     /// <param name="propertyPath">Model property path for defining the target property.</param>
-    /// <returns>The <see cref="ISetBuilder{TModel, TEvent, TProperty, TBuilder}"/> to continue building on.</returns>
+    /// <returns>The <see cref="ISetBuilder{TModel, TEvent, TBuilder}"/> to continue building on.</returns>
     ISetBuilder<TModel, TEvent, TBuilder> Set(PropertyPath propertyPath);
 
     /// <summary>
@@ -113,4 +122,10 @@ public interface IModelPropertiesBuilder<TModel, TEvent, TBuilder>
     /// <param name="modelPropertyAccessor">Model property accessor for defining the target property.</param>
     /// <returns>The <see cref="ISetBuilder{TModel, TEvent, TProperty, TBuilder}"/> to continue building on.</returns>
     ISetBuilder<TModel, TEvent, TProperty, TBuilder> Set<TProperty>(Expression<Func<TModel, TProperty>> modelPropertyAccessor);
+
+    /// <summary>
+    /// Start building the set operation to target the value instance itself.
+    /// </summary>
+    /// <returns>The <see cref="ISetBuilder{TModel, TEvent, TBuilder}"/> to continue building on.</returns>
+    ISetBuilder<TModel, TEvent, TBuilder> SetThisValue();
 }

--- a/Source/Clients/DotNET/Projections/ProjectionBuilderFor.cs
+++ b/Source/Clients/DotNET/Projections/ProjectionBuilderFor.cs
@@ -82,6 +82,7 @@ public class ProjectionBuilderFor<TModel> : ProjectionBuilder<TModel, IProjectio
             _joinDefinitions,
             _childrenDefinitions,
             _allDefinition,
+            null,
             _removedWithEvent == default ? default : new RemovedWithDefinition(_removedWithEvent));
     }
 }

--- a/Source/Clients/Specifications/Projections/ProjectionSpecificationContext.cs
+++ b/Source/Clients/Specifications/Projections/ProjectionSpecificationContext.cs
@@ -117,7 +117,7 @@ public class ProjectionSpecificationContext<TModel> : IHaveEventLog, IDisposable
     public async Task<ProjectionResult<TModel>> GetById(EventSourceId eventSourceId, object? modelId = null)
     {
         var projectedEventsCount = 0;
-        modelId ??= eventSourceId;
+        modelId ??= eventSourceId.Value;
         var cursor = await _eventSequenceStorage.GetFromSequenceNumber(EventSequenceId.Log, EventSequenceNumber.First, eventSourceId, _projection.EventTypes);
         while (await cursor.MoveNext())
         {

--- a/Source/Clients/Specifications/Projections/ProjectionSpecificationContext.cs
+++ b/Source/Clients/Specifications/Projections/ProjectionSpecificationContext.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using Aksio.Cratis.Changes;
 using Aksio.Cratis.Compliance;
+using Aksio.Cratis.Dynamic;
 using Aksio.Cratis.Events;
 using Aksio.Cratis.EventSequences;
 using Aksio.Cratis.Json;
@@ -20,6 +21,7 @@ using Aksio.Cratis.Projections.Definitions;
 using Aksio.Cratis.Properties;
 using Aksio.Cratis.Schemas;
 using Aksio.Json;
+using Aksio.Reflection;
 using Aksio.Types;
 
 namespace Aksio.Cratis.Specifications.Integration;
@@ -69,6 +71,7 @@ public class ProjectionSpecificationContext<TModel> : IHaveEventLog, IDisposable
 
         var factory = new ProjectionFactory(
             new ModelPropertyExpressionResolvers(eventValueProviderExpressionResolvers, typeFormats),
+            new EventValueProviderExpressionResolvers(typeFormats),
             new KeyExpressionResolvers(eventValueProviderExpressionResolvers),
             new ExpandoObjectConverter(typeFormats),
             new EventSequenceStorageProviderForSpecifications(_eventLog));
@@ -77,7 +80,7 @@ public class ProjectionSpecificationContext<TModel> : IHaveEventLog, IDisposable
         var objectComparer = new ObjectComparer();
 
         _eventSequenceStorage = new EventSequenceStorageProviderForSpecifications(_eventLog);
-        _sink = new InMemorySink(_projection.Model, typeFormats, objectComparer);
+        _sink = new InMemorySink(_projection.Model, typeFormats);
         _pipeline = new ProjectionPipeline(
             _projection,
             _eventSequenceStorage,
@@ -125,7 +128,12 @@ public class ProjectionSpecificationContext<TModel> : IHaveEventLog, IDisposable
             }
         }
 
-        var result = await _sink.FindOrDefault(new(modelId, ArrayIndexers.NoIndexers), false);
+        if (modelId?.GetType().IsAPrimitiveType() == false)
+        {
+            modelId = modelId.AsExpandoObject();
+        }
+
+        var result = await _sink.FindOrDefault(new(modelId!, ArrayIndexers.NoIndexers), false);
         var json = JsonSerializer.Serialize(result, Globals.JsonSerializerOptions);
         return new(JsonSerializer.Deserialize<TModel>(json, Globals.JsonSerializerOptions)!, Array.Empty<PropertyPath>(), projectedEventsCount);
     }

--- a/Source/Infrastructure/Changes/Changeset.cs
+++ b/Source/Infrastructure/Changes/Changeset.cs
@@ -86,6 +86,12 @@ public class Changeset<TSource, TTarget> : IChangeset<TSource, TTarget>
     }
 
     /// <inheritdoc/>
+    public void AddChild(PropertyPath childrenProperty, object child)
+    {
+        Add(new ChildAdded(child, childrenProperty, PropertyPath.Root, null!));
+    }
+
+    /// <inheritdoc/>
     public void AddChild<TChild>(
         PropertyPath childrenProperty,
         PropertyPath identifiedByProperty,

--- a/Source/Infrastructure/Changes/IChangeset.cs
+++ b/Source/Infrastructure/Changes/IChangeset.cs
@@ -73,6 +73,13 @@ public interface IChangeset<TSource, TTarget>
     IChangeset<TSource, TTarget> ResolvedJoin(PropertyPath onProperty, object key, TSource incoming, IArrayIndexers arrayIndexers);
 
     /// <summary>
+    /// Adds a child as is to a given children property.
+    /// </summary>
+    /// <param name="childrenProperty"><see cref="PropertyPath"/> for accessing the children collection.</param>
+    /// <param name="child">Child to add.</param>
+    void AddChild(PropertyPath childrenProperty, object child);
+
+    /// <summary>
     /// Applies properties to the child in the model to the <see cref="IChangeset{TSource, TTarget}"/>.
     /// </summary>
     /// <typeparam name="TChild">Type of child.</typeparam>

--- a/Source/Infrastructure/Properties/PropertyPath.cs
+++ b/Source/Infrastructure/Properties/PropertyPath.cs
@@ -56,22 +56,6 @@ public class PropertyPath
     }
 
     /// <summary>
-    /// Create a new <see cref="PropertyPath"/> from segments.
-    /// </summary>
-    /// <param name="segments">Segments to initialize it with.</param>
-    /// <returns>A new <see cref="PropertyPath"/> instance.</returns>
-    public static PropertyPath CreateFrom(IPropertyPathSegment[] segments)
-    {
-        var current = Root;
-        foreach (var segment in segments)
-        {
-            current += segment;
-        }
-
-        return current;
-    }
-
-    /// <summary>
     /// Gets the full path of the property.
     /// </summary>
     public string Path { get; }
@@ -170,6 +154,22 @@ public class PropertyPath
             ThisAccessor => left.AddThisAccessor(),
             _ => left
         };
+    }
+
+    /// <summary>
+    /// Create a new <see cref="PropertyPath"/> from segments.
+    /// </summary>
+    /// <param name="segments">Segments to initialize it with.</param>
+    /// <returns>A new <see cref="PropertyPath"/> instance.</returns>
+    public static PropertyPath CreateFrom(IPropertyPathSegment[] segments)
+    {
+        var current = Root;
+        foreach (var segment in segments)
+        {
+            current += segment;
+        }
+
+        return current;
     }
 
     /// <summary>

--- a/Source/Infrastructure/Properties/ThisAccessor.cs
+++ b/Source/Infrastructure/Properties/ThisAccessor.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Properties;
+
+/// <summary>
+/// Represents a <see cref="IPropertyPathSegment"/> for a *THIS* property.
+/// </summary>
+/// <remarks>
+/// THIS or $this properties represents the actual instance of a value.
+/// </remarks>
+public record ThisAccessor() : IPropertyPathSegment
+{
+    /// <inheritdoc/>
+    public string Value => "$this";
+
+    /// <inheritdoc/>
+    public override string ToString() => "$this";
+}

--- a/Source/Kernel/Engines/Projections/ProjectionExtensions.cs
+++ b/Source/Kernel/Engines/Projections/ProjectionExtensions.cs
@@ -130,6 +130,26 @@ public static class ProjectionExtensions
     }
 
     /// <summary>
+    /// Add a child from the value of an event property.
+    /// </summary>
+    /// <param name="observable"><see cref="IObservable{T}"/> to work with.</param>
+    /// <param name="valueProvider">The <see cref="ValueProvider{T}"/> for getting the value from the event.</param>
+    /// <returns>The observable for continuation.</returns>
+    public static IObservable<ProjectionEventContext> AddChildFromEventProperty(
+        this IObservable<ProjectionEventContext> observable,
+        ValueProvider<AppendedEvent> valueProvider)
+    {
+        observable.Subscribe(_ =>
+        {
+            var value = valueProvider(_.Event);
+
+            Console.WriteLine("Hello");
+        });
+
+        return observable;
+    }
+
+    /// <summary>
     /// Remove item based on event.
     /// </summary>
     /// <param name="observable"><see cref="IObservable{T}"/> to work with.</param>

--- a/Source/Kernel/Engines/Projections/ProjectionExtensions.cs
+++ b/Source/Kernel/Engines/Projections/ProjectionExtensions.cs
@@ -9,6 +9,7 @@ using Aksio.Cratis.Dynamic;
 using Aksio.Cratis.Events;
 using Aksio.Cratis.EventSequences;
 using Aksio.Cratis.Properties;
+using Aksio.Reflection;
 
 namespace Aksio.Cratis.Kernel.Engines.Projections;
 
@@ -133,17 +134,23 @@ public static class ProjectionExtensions
     /// Add a child from the value of an event property.
     /// </summary>
     /// <param name="observable"><see cref="IObservable{T}"/> to work with.</param>
+    /// <param name="childrenProperty">The property in which children are stored on the object.</param>///
     /// <param name="valueProvider">The <see cref="ValueProvider{T}"/> for getting the value from the event.</param>
     /// <returns>The observable for continuation.</returns>
     public static IObservable<ProjectionEventContext> AddChildFromEventProperty(
         this IObservable<ProjectionEventContext> observable,
+        PropertyPath childrenProperty,
         ValueProvider<AppendedEvent> valueProvider)
     {
         observable.Subscribe(_ =>
         {
             var value = valueProvider(_.Event);
+            if (!value.GetType().IsAPrimitiveType())
+            {
+                value = value.AsExpandoObject();
+            }
 
-            Console.WriteLine("Hello");
+            _.Changeset.AddChild(childrenProperty, value);
         });
 
         return observable;

--- a/Source/Kernel/Engines/Projections/ProjectionFactory.cs
+++ b/Source/Kernel/Engines/Projections/ProjectionFactory.cs
@@ -6,6 +6,7 @@ using Aksio.Cratis.Events;
 using Aksio.Cratis.EventSequences;
 using Aksio.Cratis.Json;
 using Aksio.Cratis.Kernel.Engines.Projections.Expressions;
+using Aksio.Cratis.Kernel.Engines.Projections.Expressions.EventValues;
 using Aksio.Cratis.Kernel.Engines.Projections.Expressions.Keys;
 using Aksio.Cratis.Projections;
 using Aksio.Cratis.Projections.Definitions;
@@ -21,6 +22,7 @@ namespace Aksio.Cratis.Kernel.Engines.Projections;
 public class ProjectionFactory : IProjectionFactory
 {
     readonly IModelPropertyExpressionResolvers _propertyMapperExpressionResolvers;
+    readonly IEventValueProviderExpressionResolvers _eventValueProviderExpressionResolvers;
     readonly IKeyExpressionResolvers _keyExpressionResolvers;
     readonly IExpandoObjectConverter _expandoObjectConverter;
     readonly IEventSequenceStorage _eventProvider;
@@ -29,16 +31,19 @@ public class ProjectionFactory : IProjectionFactory
     /// Initializes a new instance of the <see cref="ProjectionFactory"/> class.
     /// </summary>
     /// <param name="propertyMapperExpressionResolvers"><see cref="IModelPropertyExpressionResolvers"/> for resolving expressions for properties.</param>
+    /// <param name="eventValueProviderExpressionResolvers"><see cref="IEventValueProviderExpressionResolvers"/> for resolving expressions for accessing values on events.</param>
     /// <param name="keyExpressionResolvers"><see cref="IKeyExpressionResolvers"/> for resolving keys.</param>
     /// <param name="expandoObjectConverter"><see cref="IExpandoObjectConverter"/> for converting to and from expando objects.</param>
     /// <param name="eventProvider"><see cref="IEventSequenceStorage"/> for providing events from the event store.</param>
     public ProjectionFactory(
         IModelPropertyExpressionResolvers propertyMapperExpressionResolvers,
+        IEventValueProviderExpressionResolvers eventValueProviderExpressionResolvers,
         IKeyExpressionResolvers keyExpressionResolvers,
         IExpandoObjectConverter expandoObjectConverter,
         IEventSequenceStorage eventProvider)
     {
         _propertyMapperExpressionResolvers = propertyMapperExpressionResolvers;
+        _eventValueProviderExpressionResolvers = eventValueProviderExpressionResolvers;
         _keyExpressionResolvers = keyExpressionResolvers;
         _expandoObjectConverter = expandoObjectConverter;
         _eventProvider = eventProvider;
@@ -100,6 +105,27 @@ public class ProjectionFactory : IProjectionFactory
         SetParentOnAllChildProjections(projection, childProjections);
         ResolveEventsForProjection(projection, childProjections, projectionDefinition, actualIdentifiedByProperty, hasParent);
 
+        if (projectionDefinition.FromEventProperty is not null)
+        {
+            var schemaProperty = model.Schema.GetSchemaPropertyForPropertyPath(childrenAccessorProperty);
+            schemaProperty ??= new JsonSchemaProperty
+            {
+                Type = projection.Model.Schema.Type,
+                Format = projection.Model.Schema.Format
+            };
+
+            var valueProvider = _eventValueProviderExpressionResolvers.Resolve(schemaProperty!, projectionDefinition.FromEventProperty.PropertyExpression);
+
+            projection.Event.Subscribe(_ =>
+            {
+                Console.WriteLine("ASDASD");
+            });
+
+            projection.Event
+                 .WhereEventTypeEquals(projectionDefinition.FromEventProperty.EventType)
+                .AddChildFromEventProperty(valueProvider);
+        }
+
         var propertyMappersForAllEventTypes = projectionDefinition.All.Properties.Select(kvp => ResolvePropertyMapper(projection, childrenAccessorProperty + kvp.Key, kvp.Value));
         foreach (var (eventType, fromDefinition) in projectionDefinition.From)
         {
@@ -120,10 +146,10 @@ public class ProjectionFactory : IProjectionFactory
                     var joinPropertyMappers = joinDefinition.Properties.Select(kvp => ResolvePropertyMapper(projection, childrenAccessorProperty + kvp.Key, kvp.Value)).ToArray();
                     projected = projected
                         .ResolveJoin(_eventProvider, joinEventType, joinDefinition.On)
-                        .Project(
-                            childrenAccessorProperty,
-                            actualIdentifiedByProperty,
-                            joinPropertyMappers);
+                                        .Project(
+                                            childrenAccessorProperty,
+                                            actualIdentifiedByProperty,
+                                            joinPropertyMappers);
                 }
             }
         }
@@ -161,8 +187,20 @@ public class ProjectionFactory : IProjectionFactory
         return projection;
     }
 
-    PropertyMapper<AppendedEvent, ExpandoObject> ResolvePropertyMapper(IProjection projection, PropertyPath propertyPath, string expression) =>
-        _propertyMapperExpressionResolvers.Resolve(propertyPath, projection.Model.Schema.GetSchemaPropertyForPropertyPath(propertyPath)!, expression);
+    PropertyMapper<AppendedEvent, ExpandoObject> ResolvePropertyMapper(IProjection projection, PropertyPath propertyPath, string expression)
+    {
+        var schemaProperty = projection.Model.Schema.GetSchemaPropertyForPropertyPath(propertyPath);
+        if (propertyPath.LastSegment is ThisAccessor)
+        {
+            schemaProperty = new JsonSchemaProperty
+            {
+                Type = projection.Model.Schema.Type,
+                Format = projection.Model.Schema.Format
+            };
+        }
+
+        return _propertyMapperExpressionResolvers.Resolve(propertyPath, schemaProperty!, expression);
+    }
 
     void ResolveEventsForProjection(IProjection projection, IProjection[] childProjections, ProjectionDefinition projectionDefinition, PropertyPath actualIdentifiedByProperty, bool hasParent)
     {

--- a/Source/Kernel/Engines/Sinks/InMemory/InMemorySinkFactory.cs
+++ b/Source/Kernel/Engines/Sinks/InMemory/InMemorySinkFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Aksio.Cratis.Changes;
 using Aksio.Cratis.Projections;
 using Aksio.Cratis.Schemas;
 using Aksio.Cratis.Sinks;
@@ -14,22 +13,19 @@ namespace Aksio.Cratis.Kernel.Engines.Sinks.InMemory;
 public class InMemorySinkFactory : ISinkFactory
 {
     readonly ITypeFormats _typeFormats;
-    readonly IObjectComparer _comparer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="InMemorySinkFactory"/> class.
     /// </summary>
     /// <param name="typeFormats">The <see cref="ITypeFormats"/> for resolving actual types from JSON schema.</param>
-    /// <param name="comparer"><see cref="IObjectComparer"/> used for complex comparisons of objects.</param>
-    public InMemorySinkFactory(ITypeFormats typeFormats, IObjectComparer comparer)
+    public InMemorySinkFactory(ITypeFormats typeFormats)
     {
         _typeFormats = typeFormats;
-        _comparer = comparer;
     }
 
     /// <inheritdoc/>
     public SinkTypeId TypeId => WellKnownSinkTypes.InMemory;
 
     /// <inheritdoc/>
-    public ISink CreateFor(Model model) => new InMemorySink(model, _typeFormats, _comparer);
+    public ISink CreateFor(Model model) => new InMemorySink(model, _typeFormats);
 }

--- a/Source/Kernel/Shared/Projections/Definitions/ChildrenDefinition.cs
+++ b/Source/Kernel/Shared/Projections/Definitions/ChildrenDefinition.cs
@@ -17,6 +17,7 @@ namespace Aksio.Cratis.Projections.Definitions;
 /// <param name="Join">All the <see cref="JoinDefinition"/> for <see cref="EventType">event types</see>.</param>
 /// <param name="Children">All the <see cref="ChildrenDefinition"/> for properties on model.</param>
 /// <param name="All">The full <see cref="AllDefinition"/>.</param>
+/// <param name="FromEventProperty">Optional <see cref="FromEventPropertyDefinition"/> definition.</param>
 /// <param name="RemovedWith">The definition of what removes a child, if any.</param>
 public record ChildrenDefinition(
     PropertyPath IdentifiedBy,
@@ -26,4 +27,18 @@ public record ChildrenDefinition(
     IDictionary<EventType, JoinDefinition> Join,
     IDictionary<PropertyPath, ChildrenDefinition> Children,
     AllDefinition All,
-    RemovedWithDefinition? RemovedWith) : ProjectionDefinition(Guid.Empty, string.Empty, Model, true, false, InitialModelState, From, Join, Children, All, RemovedWith);
+    FromEventPropertyDefinition? FromEventProperty,
+    RemovedWithDefinition? RemovedWith) :
+    ProjectionDefinition(
+        Guid.Empty,
+        string.Empty,
+        Model,
+        true,
+        false,
+        InitialModelState,
+        From,
+        Join,
+        Children,
+        All,
+        FromEventProperty,
+        RemovedWith);

--- a/Source/Kernel/Shared/Projections/Definitions/ChildrenDefinition.cs
+++ b/Source/Kernel/Shared/Projections/Definitions/ChildrenDefinition.cs
@@ -27,8 +27,8 @@ public record ChildrenDefinition(
     IDictionary<EventType, JoinDefinition> Join,
     IDictionary<PropertyPath, ChildrenDefinition> Children,
     AllDefinition All,
-    FromEventPropertyDefinition? FromEventProperty,
-    RemovedWithDefinition? RemovedWith) :
+    FromEventPropertyDefinition? FromEventProperty = default,
+    RemovedWithDefinition? RemovedWith = default) :
     ProjectionDefinition(
         Guid.Empty,
         string.Empty,

--- a/Source/Kernel/Shared/Projections/Definitions/FromEventPropertyDefinition.cs
+++ b/Source/Kernel/Shared/Projections/Definitions/FromEventPropertyDefinition.cs
@@ -8,6 +8,6 @@ namespace Aksio.Cratis.Projections.Definitions;
 /// <summary>
 /// Represents the definition of a child projection based on one property in an event.
 /// </summary>
-/// <param name="EventType"><see cref="EventType"/> the property is on.</param>
+/// <param name="Event"><see cref="EventType"/> the property is on.</param>
 /// <param name="PropertyExpression"><see cref="PropertyExpression"/> within the event.</param>
-public record FromEventPropertyDefinition(EventType EventType, PropertyExpression PropertyExpression);
+public record FromEventPropertyDefinition(EventType Event, PropertyExpression PropertyExpression);

--- a/Source/Kernel/Shared/Projections/Definitions/FromEventPropertyDefinition.cs
+++ b/Source/Kernel/Shared/Projections/Definitions/FromEventPropertyDefinition.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Events;
+
+namespace Aksio.Cratis.Projections.Definitions;
+
+/// <summary>
+/// Represents the definition of a child projection based on one property in an event.
+/// </summary>
+/// <param name="EventType"><see cref="EventType"/> the property is on.</param>
+/// <param name="PropertyExpression"><see cref="PropertyExpression"/> within the event.</param>
+public record FromEventPropertyDefinition(EventType EventType, PropertyExpression PropertyExpression);

--- a/Source/Kernel/Shared/Projections/Definitions/ProjectionDefinition.cs
+++ b/Source/Kernel/Shared/Projections/Definitions/ProjectionDefinition.cs
@@ -20,6 +20,7 @@ namespace Aksio.Cratis.Projections.Definitions;
 /// <param name="Join">All the <see cref="JoinDefinition"/> for <see cref="EventType">event types</see>.</param>
 /// <param name="Children">All the <see cref="ChildrenDefinition"/> for properties on model.</param>
 /// <param name="All">The full <see cref="AllDefinition"/>.</param>
+/// <param name="FromEventProperty">Optional <see cref="FromEventPropertyDefinition"/> definition.</param>
 /// <param name="RemovedWith">The definition of what removes a child, if any.</param>
 public record ProjectionDefinition(
     ProjectionId Identifier,
@@ -32,6 +33,7 @@ public record ProjectionDefinition(
     IDictionary<EventType, JoinDefinition> Join,
     IDictionary<PropertyPath, ChildrenDefinition> Children,
     AllDefinition All,
+    FromEventPropertyDefinition? FromEventProperty,
     RemovedWithDefinition? RemovedWith = default)
 {
     /// <summary>

--- a/Source/Kernel/Shared/Projections/Definitions/ProjectionDefinition.cs
+++ b/Source/Kernel/Shared/Projections/Definitions/ProjectionDefinition.cs
@@ -33,7 +33,7 @@ public record ProjectionDefinition(
     IDictionary<EventType, JoinDefinition> Join,
     IDictionary<PropertyPath, ChildrenDefinition> Children,
     AllDefinition All,
-    FromEventPropertyDefinition? FromEventProperty,
+    FromEventPropertyDefinition? FromEventProperty = default,
     RemovedWithDefinition? RemovedWith = default)
 {
     /// <summary>

--- a/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_array_indexer.cs
+++ b/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_array_indexer.cs
@@ -21,3 +21,19 @@ public class when_adding_array_indexer : Specification
     [Fact] void should_have_last_segment_be_array_index() => result.LastSegment.ShouldBeOfExactType<ArrayProperty>();
     [Fact] void should_have_last_segment_have_camel_case_identifier() => result.LastSegment.Value.ShouldEqual(third_segment.ToCamelCase());
 }
+
+
+public class when_adding_this_accessor : Specification
+{
+    const string first_segment = "FirstSegment";
+    const string second_segment = "SecondSegment";
+
+    PropertyPath initial;
+    PropertyPath result;
+
+    void Establish() => initial = new PropertyPath($"{first_segment}.{second_segment}");
+
+    void Because() => result = initial.AddThisAccessor();
+
+    [Fact] void should_have_last_segment_be_this_accessor() => result.LastSegment.ShouldBeOfExactType<ThisAccessor>();
+}

--- a/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_this_accessor_as_segment_using_operator.cs
+++ b/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_this_accessor_as_segment_using_operator.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Properties.for_PropertyPath;
+
+public class when_adding_this_accessor_as_segment_using_operator : Specification
+{
+    const string first_segment = "FirstSegment";
+    const string second_segment = "SecondSegment";
+
+    PropertyPath initial;
+    PropertyPath result;
+
+    void Establish() => initial = new PropertyPath($"{first_segment}.{second_segment}");
+
+    void Because() => result = initial + new ThisAccessor();
+
+    [Fact] void should_have_last_segment_be_array_index() => result.LastSegment.ShouldBeOfExactType<ThisAccessor>();
+}

--- a/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_this_accessor_using_operator.cs
+++ b/Specifications/Infrastructure/Properties/for_PropertyPath/when_adding_this_accessor_using_operator.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Cratis.Properties.for_PropertyPath;
+
+public class when_adding_this_accessor_using_operator : Specification
+{
+    const string first_segment = "FirstSegment";
+    const string second_segment = "SecondSegment";
+
+    PropertyPath initial;
+    PropertyPath result;
+
+    void Establish() => initial = new PropertyPath($"{first_segment}.{second_segment}");
+
+    void Because() => result = initial + "$this";
+
+    [Fact] void should_have_last_segment_be_array_index() => result.LastSegment.ShouldBeOfExactType<ThisAccessor>();
+}

--- a/Specifications/Kernel/Engines/Projections/for_ProjectionScenarios/given/a_projection_pipeline.cs
+++ b/Specifications/Kernel/Engines/Projections/for_ProjectionScenarios/given/a_projection_pipeline.cs
@@ -35,10 +35,10 @@ public abstract class a_projection_pipeline_for<TModel> : Specification
         var eventValueProviderExpressionResolvers = new EventValueProviderExpressionResolvers(type_formats);
         expression_resolvers = new ModelPropertyExpressionResolvers(eventValueProviderExpressionResolvers, type_formats);
         var expandoObjectConverter = new ExpandoObjectConverter(type_formats);
-        var objectComparer = new ObjectComparer();
 
         var projectionFactory = new ProjectionFactory(
             expression_resolvers,
+            eventValueProviderExpressionResolvers,
             new KeyExpressionResolvers(eventValueProviderExpressionResolvers),
             expandoObjectConverter,
             event_sequence_storage.Object);
@@ -59,7 +59,7 @@ public abstract class a_projection_pipeline_for<TModel> : Specification
 
         var projectionDefinition = builder.Build();
         var projection = await projectionFactory.CreateFrom(projectionDefinition);
-        sink = new InMemorySink(Model, type_formats, objectComparer);
+        sink = new InMemorySink(Model, type_formats);
 
         pipeline = new ProjectionPipeline(
             projection,


### PR DESCRIPTION
### Added

- Adding a way to simply add a child based on the content of a property on an event for projections. This is super useful when wanting to have a collection of primitive types based on a property on the event. Important to remember, the type of the event property and the element type has to match - this is handled at compile time.

```csharp
public record AccountTransactions(string Account, IEnumerable<DateTimeOffset> TransactionDates);

public class LatestTransactions : IProjectionFor<AccountTransactions>
{
    public ProjectionId Identifier => "d661904f-15e0-4a96-a0cc-c7389635e4cd";

    public void Define(IProjectionBuilderFor<DebitAccountLatestTransactions> builder) => builder
         .From<DepositPerformed>(_ => _
             .Set(m => m.Account).To(e => e.Account)
             .AddChild(m => m.TransactionDates, e => e.TransactionDate);
}
```

