### PR TITLE
Putting in the key into the Id property when applying changes

### DIFF
--- a/Source/Kernel/Engines/Sinks/InMemory/InMemorySink.cs
+++ b/Source/Kernel/Engines/Sinks/InMemory/InMemorySink.cs
@@ -75,7 +75,9 @@ public class InMemorySink : ISink, IDisposable
         }
 
         var keyValue = GetActualKeyValue(key);
-        collection[keyValue] = ApplyActualChanges(key, changeset.Changes, state);
+        var result = ApplyActualChanges(key, changeset.Changes, state);
+        ((dynamic)result).id = key.Value;
+        collection[keyValue] = result;
 
         return Task.CompletedTask;
     }


### PR DESCRIPTION
### Fixed

- Fixing `InMemorySink` to set the `Id` property to the key value. This fixes a problem when using immediate projections and the read model coming back does not have a `null` for the `Id` property.
