### PR TITLE
Fixing GetById() to start with a fresh model - so you can call it multiple times safely

### DIFF
--- a/Source/Kernel/Engines/Sinks/InMemory/InMemorySink.cs
+++ b/Source/Kernel/Engines/Sinks/InMemory/InMemorySink.cs
@@ -52,6 +52,17 @@ public class InMemorySink : ISink, IDisposable
     /// </summary>
     public IDictionary<object, ExpandoObject> Collection => _isReplaying ? _rewindCollection : _collection;
 
+    /// <summary>
+    /// Remove any existing model by the given key.
+    /// </summary>
+    /// <param name="key"><see cref="Key"/> for the model to remove.</param>
+    public void RemoveAnyExisting(Key key)
+    {
+        var collection = Collection;
+        var keyValue = GetActualKeyValue(key);
+        collection.Remove(keyValue);
+    }
+
     /// <inheritdoc/>
     public Task<ExpandoObject?> FindOrDefault(Key key, bool isReplaying)
     {
@@ -67,14 +78,14 @@ public class InMemorySink : ISink, IDisposable
     {
         var state = changeset.InitialState.Clone();
         var collection = Collection;
+        var keyValue = GetActualKeyValue(key);
 
         if (changeset.HasBeenRemoved())
         {
-            collection.Remove(key.Value);
+            collection.Remove(keyValue);
             return Task.CompletedTask;
         }
 
-        var keyValue = GetActualKeyValue(key);
         var result = ApplyActualChanges(key, changeset.Changes, state);
         ((dynamic)result).id = key.Value;
         collection[keyValue] = result;


### PR DESCRIPTION
### Fixed

- `GetById()` on `ProjectionSpecificationContext` now starts with a clean model when calling it. Making it safe to call it multiple times and get the same result.
