### PR TITLE
Fix/add-primitives-as-children

### DIFF
--- a/Source/Kernel/Engines/Observation/Reducers/ReducerPipelineFactory.cs
+++ b/Source/Kernel/Engines/Observation/Reducers/ReducerPipelineFactory.cs
@@ -14,7 +14,7 @@ namespace Aksio.Cratis.Kernel.Engines.Observation.Reducers;
 /// </summary>
 public class ReducerPipelineFactory : IReducerPipelineFactory
 {
-    readonly ISinks _projectionSinks;
+    readonly ISinks _sinks;
     readonly IObjectComparer _objectComparer;
 
     /// <summary>
@@ -26,7 +26,7 @@ public class ReducerPipelineFactory : IReducerPipelineFactory
         ISinks projectionSinks,
         IObjectComparer objectComparer)
     {
-        _projectionSinks = projectionSinks;
+        _sinks = projectionSinks;
         _objectComparer = objectComparer;
     }
 
@@ -35,7 +35,7 @@ public class ReducerPipelineFactory : IReducerPipelineFactory
     {
         var readModelSchema = await JsonSchema.FromJsonAsync(definition.ReadModel.Schema);
         var readModel = new Model(definition.ReadModel.Name, readModelSchema);
-        var sink = _projectionSinks.GetForTypeAndModel(definition.SinkTypeId, readModel);
+        var sink = _sinks.GetForTypeAndModel(definition.SinkTypeId, readModel);
         return new ReducerPipeline(readModel, sink, _objectComparer);
     }
 }

--- a/Source/Kernel/MongoDB/Sinks/IMongoDBSinkDatabaseProvider.cs
+++ b/Source/Kernel/MongoDB/Sinks/IMongoDBSinkDatabaseProvider.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Driver;
+
+namespace Aksio.Cratis.Kernel.MongoDB.Sinks;
+
+/// <summary>
+/// Defines a system that can provide <see cref="IMongoDatabase"/>.
+/// </summary>
+public interface IMongoDBSinkDatabaseProvider
+{
+    /// <summary>
+    /// Get the database for the ccurrent context.
+    /// </summary>
+    /// <returns><see cref="IMongoDatabase"/>.</returns>
+    IMongoDatabase GetDatabase();
+}

--- a/Source/Kernel/MongoDB/Sinks/MongoDBChangesetConverter.cs
+++ b/Source/Kernel/MongoDB/Sinks/MongoDBChangesetConverter.cs
@@ -8,6 +8,7 @@ using Aksio.Cratis.Kernel.Keys;
 using Aksio.Cratis.Projections;
 using Aksio.Cratis.Properties;
 using Aksio.Cratis.Schemas;
+using Aksio.Reflection;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using NJsonSchema;
@@ -127,14 +128,14 @@ public class MongoDBChangesetConverter : IMongoDBChangesetConverter
     {
         BsonValue bsonValue;
 
-        var schema = _model.Schema.GetSchemaForPropertyPath(childAdded.ChildrenProperty);
-        if (schema is not null)
+        if (childAdded.State.GetType().IsAPrimitiveType())
         {
-            bsonValue = _expandoObjectConverter.ToBsonDocument((childAdded.State as ExpandoObject)!, schema);
+            bsonValue = childAdded.State.ToBsonValue();
         }
         else
         {
-            bsonValue = childAdded.State.ToBsonValue();
+            var schema = _model.Schema.GetSchemaForPropertyPath(childAdded.ChildrenProperty);
+            bsonValue = _expandoObjectConverter.ToBsonDocument((childAdded.State as ExpandoObject)!, schema);
         }
 
         var segments = childAdded.ChildrenProperty.Segments.ToArray();

--- a/Source/Kernel/MongoDB/Sinks/MongoDBChangesetConverter.cs
+++ b/Source/Kernel/MongoDB/Sinks/MongoDBChangesetConverter.cs
@@ -125,8 +125,17 @@ public class MongoDBChangesetConverter : IMongoDBChangesetConverter
 
     void BuildChildAdded(Key key, UpdateDefinitionBuilder<BsonDocument> updateDefinitionBuilder, ref UpdateDefinition<BsonDocument>? updateBuilder, List<BsonDocumentArrayFilterDefinition<BsonDocument>> arrayFiltersForDocument, ChildAdded childAdded)
     {
+        BsonValue bsonValue;
+
         var schema = _model.Schema.GetSchemaForPropertyPath(childAdded.ChildrenProperty);
-        var document = _expandoObjectConverter.ToBsonDocument((childAdded.State as ExpandoObject)!, schema);
+        if (schema is not null)
+        {
+            bsonValue = _expandoObjectConverter.ToBsonDocument((childAdded.State as ExpandoObject)!, schema);
+        }
+        else
+        {
+            bsonValue = childAdded.State.ToBsonValue();
+        }
 
         var segments = childAdded.ChildrenProperty.Segments.ToArray();
         var childrenProperty = new PropertyPath(string.Empty);
@@ -142,11 +151,11 @@ public class MongoDBChangesetConverter : IMongoDBChangesetConverter
 
         if (updateBuilder is not null)
         {
-            updateBuilder = updateBuilder.Push(property, document);
+            updateBuilder = updateBuilder.Push(property, bsonValue);
         }
         else
         {
-            updateBuilder = updateDefinitionBuilder.Push(property, document);
+            updateBuilder = updateDefinitionBuilder.Push(property, bsonValue);
         }
     }
 

--- a/Source/Kernel/MongoDB/Sinks/MongoDBSink.cs
+++ b/Source/Kernel/MongoDB/Sinks/MongoDBSink.cs
@@ -30,20 +30,20 @@ public class MongoDBSink : ISink
     /// Initializes a new instance of the <see cref="MongoDBSink"/> class.
     /// </summary>
     /// <param name="model">The <see cref="Model"/> the sink is for.</param>
-    /// <param name="converter"><see cref="IMongoDBConverter"/> for dealing with conversion.</param>
-    /// <param name="collections"><see cref="IMongoDBSinkCollections"/> to use.</param>
-    /// <param name="changesetConverter"><see cref="IMongoDBChangesetConverter"/> for converting changesets.</param>
+    /// <param name="converterProvider"><see cref="IMongoDBConverter"/> for dealing with conversion.</param>
+    /// <param name="collections">Provider for <see cref="IMongoDBSinkCollections"/> to use.</param>
+    /// <param name="changesetConverter">Provider for <see cref="IMongoDBChangesetConverter"/> for converting changesets.</param>
     /// <param name="expandoObjectConverter"><see cref="IExpandoObjectConverter"/> for converting between documents and <see cref="ExpandoObject"/>.</param>
     public MongoDBSink(
         Model model,
-        IMongoDBConverter converter,
+        IMongoDBConverter converterProvider,
         IMongoDBSinkCollections collections,
         IMongoDBChangesetConverter changesetConverter,
         IExpandoObjectConverter expandoObjectConverter)
     {
         _expandoObjectConverter = expandoObjectConverter;
         _model = model;
-        _converter = converter;
+        _converter = converterProvider;
         _collections = collections;
         _changesetConverter = changesetConverter;
     }

--- a/Source/Kernel/MongoDB/Sinks/MongoDBSinkCollections.cs
+++ b/Source/Kernel/MongoDB/Sinks/MongoDBSinkCollections.cs
@@ -13,20 +13,23 @@ namespace Aksio.Cratis.Kernel.MongoDB.Sinks;
 /// </summary>
 public class MongoDBSinkCollections : IMongoDBSinkCollections
 {
-    readonly IMongoDatabase _database;
     readonly Model _model;
+    readonly IMongoDBSinkDatabaseProvider _databaseProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MongoDBSinkCollections"/> class.
     /// </summary>
-    /// <param name="database"><see cref="IMongoDatabase"/> to use.</param>
     /// <param name="model">The <see cref="Model"/> the context is for.</param>
-    public MongoDBSinkCollections(IMongoDatabase database, Model model)
+    /// <param name="databaseProvider">The <see cref="IMongoDBSinkDatabaseProvider"/>.</param>
+    public MongoDBSinkCollections(
+        Model model,
+        IMongoDBSinkDatabaseProvider databaseProvider)
     {
-        _database = database;
         _model = model;
+        _databaseProvider = databaseProvider;
     }
 
+    IMongoDatabase Database => _databaseProvider.GetDatabase();
     string ReplayCollectionName => $"replay-{_model.Name}";
 
     /// <inheritdoc/>
@@ -37,7 +40,7 @@ public class MongoDBSinkCollections : IMongoDBSinkCollections
     {
         var rewindName = ReplayCollectionName;
         var rewoundCollectionsPrefix = $"{_model.Name}-";
-        var collectionNames = (await _database.ListCollectionNamesAsync()).ToList();
+        var collectionNames = (await Database.ListCollectionNamesAsync()).ToList();
         var nextCollectionSequenceNumber = 1;
         var rewoundCollectionNames = collectionNames.Where(_ => _.StartsWith(rewoundCollectionsPrefix, StringComparison.InvariantCulture)).ToArray();
         if (rewoundCollectionNames.Length > 0)
@@ -60,12 +63,12 @@ public class MongoDBSinkCollections : IMongoDBSinkCollections
 
         if (collectionNames.Contains(_model.Name))
         {
-            await _database.RenameCollectionAsync(_model.Name, oldCollectionName);
+            await Database.RenameCollectionAsync(_model.Name, oldCollectionName);
         }
 
         if (collectionNames.Contains(rewindName))
         {
-            await _database.RenameCollectionAsync(rewindName, _model.Name);
+            await Database.RenameCollectionAsync(rewindName, _model.Name);
         }
     }
 
@@ -77,5 +80,5 @@ public class MongoDBSinkCollections : IMongoDBSinkCollections
     }
 
     /// <inheritdoc/>
-    public IMongoCollection<BsonDocument> GetCollection(bool isReplaying) => isReplaying ? _database.GetCollection<BsonDocument>(ReplayCollectionName) : _database.GetCollection<BsonDocument>(_model.Name);
+    public IMongoCollection<BsonDocument> GetCollection(bool isReplaying) => isReplaying ? Database.GetCollection<BsonDocument>(ReplayCollectionName) : Database.GetCollection<BsonDocument>(_model.Name);
 }

--- a/Source/Kernel/MongoDB/Sinks/MongoDBSinkDatabaseProvider.cs
+++ b/Source/Kernel/MongoDB/Sinks/MongoDBSinkDatabaseProvider.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using Aksio.Cratis.Kernel.Configuration;
+using Aksio.MongoDB;
+using MongoDB.Driver;
+
+namespace Aksio.Cratis.Kernel.MongoDB.Sinks;
+
+/// <summary>
+/// Represents an implementation of <see cref="IMongoDBSinkDatabaseProvider"/>.
+/// </summary>
+[Singleton]
+public class MongoDBSinkDatabaseProvider : IMongoDBSinkDatabaseProvider
+{
+    readonly ConcurrentDictionary<string, IMongoDatabase> _databases = new();
+    readonly IExecutionContextManager _executionContextManager;
+    readonly IMongoDBClientFactory _clientFactory;
+    readonly Storage _configuration;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoDBSinkDatabaseProvider"/> class.
+    /// </summary>
+    /// <param name="executionContextManager"><see cref="IExecutionContextManager"/> for working with execution context.</param>
+    /// <param name="clientFactory"><see cref="IMongoDBClientFactory"/> for creating MongoDB clients.</param>
+    /// <param name="configuration">The <see cref="Storage"/> configuration.</param>
+    public MongoDBSinkDatabaseProvider(
+        IExecutionContextManager executionContextManager,
+        IMongoDBClientFactory clientFactory,
+        Storage configuration)
+    {
+        _executionContextManager = executionContextManager;
+        _clientFactory = clientFactory;
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc/>
+    public IMongoDatabase GetDatabase()
+    {
+        var current = _executionContextManager.Current;
+        var key = $"{current.MicroserviceId}-{current.TenantId}";
+        if (_databases.TryGetValue(key, out var database)) return database;
+
+        var readModelsConfig = _configuration.Microservices.Get(current.MicroserviceId).Tenants[current.TenantId.ToString()].Get(WellKnownStorageTypes.ReadModels);
+        var url = new MongoUrl(readModelsConfig.ConnectionDetails.ToString());
+        var client = _clientFactory.Create(url);
+        database = client.GetDatabase(url.DatabaseName);
+        _databases[key] = database;
+        return database;
+    }
+}


### PR DESCRIPTION
### Fixed

- Fixing `MongoDBChangesetConverter` to support primitive types as children in child relationships.
- Fixing scoping for MongoDB SInk database so that it uses the correct database (per microservice, per tenant).
