### PR TITLE
Fix/children-with-composite-keys

### DIFF
--- a/Source/Infrastructure/Changes/CollectionExtensions.cs
+++ b/Source/Infrastructure/Changes/CollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Dynamic;
 using Aksio.Cratis.Dynamic;
+using Aksio.Cratis.Objects;
 using Aksio.Cratis.Properties;
 
 namespace Aksio.Cratis.Changes;
@@ -78,6 +79,6 @@ public static class CollectionExtensions
         }
 
         if (items is IEnumerable<ExpandoObject> expandoObjectItems) return ExpandoObjectExtensions.Contains(expandoObjectItems, identityProperty, key);
-        return items.Any(_ => identityProperty.GetValue(_!, ArrayIndexers.NoIndexers)!.Equals(key));
+        return items.Any(_ => identityProperty.GetValue(_!, ArrayIndexers.NoIndexers)!.IsEqualTo(key));
     }
 }

--- a/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
+++ b/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
@@ -187,8 +187,10 @@ public static class ExpandoObjectExtensions
                         else
                         {
                             element = collection
-                            .Cast<IDictionary<string, object>>()
-                            .SingleOrDefault(item => item.ContainsKey(indexer.IdentifierProperty.Path) && item[indexer.IdentifierProperty.Path].Equals(indexer.Identifier));
+                                .Cast<IDictionary<string, object>>()
+                                .SingleOrDefault(item =>
+                                    item.ContainsKey(indexer.IdentifierProperty.Path) &&
+                                    item[indexer.IdentifierProperty.Path].IsEqualTo(indexer.Identifier));
                         }
 
                         if (element == default)

--- a/Source/Infrastructure/Objects/ObjectExtensions.cs
+++ b/Source/Infrastructure/Objects/ObjectExtensions.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using Aksio.Concepts;
 using Aksio.Cratis.Dynamic;
 using Aksio.Cratis.Properties;
+using Aksio.Cratis.Reflection;
 using Aksio.Json;
 using Aksio.Strings;
 
@@ -118,6 +119,38 @@ public static class ObjectExtensions
         }
 
         return currentInstance!;
+    }
+
+    /// <summary>
+    /// Check for equality between two objects.
+    /// </summary>
+    /// <param name="left">Left object to compare with.</param>
+    /// <param name="right">Right object to compare with.</param>
+    /// <returns>True if the two are equal, false if not.</returns>
+    /// <remarks>
+    /// This method recognizes <see cref="ExpandoObject"/> and will compare the key/value pairs.
+    /// If its not an <see cref="ExpandoObject"/>, it will use the <see cref="object.Equals(object)"/> method.
+    /// </remarks>
+    public static bool IsEqualTo(this object left, object right)
+    {
+        if (left is null && right is null) return true;
+        if (left is null || right is null) return false;
+
+        if (left is ExpandoObject leftAsExpandoObject && right is ExpandoObject rightAsExpandoObject)
+        {
+            var leftKeyValuePairs = leftAsExpandoObject.GetKeyValuePairs().ToDictionary(_ => _.Key, _ => _.Value);
+            var rightKeyValuePairs = rightAsExpandoObject.GetKeyValuePairs().ToDictionary(_ => _.Key, _ => _.Value);
+
+            foreach (var (key, value) in leftKeyValuePairs)
+            {
+                if (!rightKeyValuePairs.ContainsKey(key)) return false;
+                if (!IsEqualTo(value, rightKeyValuePairs[key])) return false;
+            }
+
+            return true;
+        }
+
+        return left.Equals(right);
     }
 
     static object CreateInstanceOf(Type type)

--- a/Specifications/Infrastructure/Changes/for_CollectionExtensions/when_checking_if_contains_known_object_by_composite_expando_object_based_key.cs
+++ b/Specifications/Infrastructure/Changes/for_CollectionExtensions/when_checking_if_contains_known_object_by_composite_expando_object_based_key.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Aksio.Cratis.Changes.for_CollectionExtensions;
+
+public class when_checking_if_contains_known_object_by_composite_expando_object_based_key : Specification
+{
+    record Item(ExpandoObject Key, string Value);
+    IEnumerable<Item> items;
+    bool result;
+
+    ExpandoObject first_key;
+    ExpandoObject second_key;
+
+    void Establish()
+    {
+        first_key = new ExpandoObject();
+
+        ((dynamic)first_key).FirstCompositeProperty = "FirstKey FirstProperty";
+        ((dynamic)first_key).SecondCompositeProperty = "FirstKey SecondProperty";
+
+        second_key = new ExpandoObject();
+        ((dynamic)second_key).FirstCompositeProperty = "SecondKey FirstProperty";
+        ((dynamic)second_key).SecondCompositeProperty = "SecondKey SecondProperty";
+
+        items = new[]
+        {
+            new Item(first_key, "First Value"),
+            new Item(second_key, "Second Value")
+        };
+    }
+
+    void Because() => result = items.Contains(nameof(Item.Key), second_key);
+
+    [Fact] void should_contain_the_object() => result.ShouldBeTrue();
+}

--- a/Specifications/Infrastructure/Dynamic/for_ExpandoObjectExtensions/when_ensuring_complex_path_with_multiple_arrays_indexed_by_composite_expando_object_keys.cs
+++ b/Specifications/Infrastructure/Dynamic/for_ExpandoObjectExtensions/when_ensuring_complex_path_with_multiple_arrays_indexed_by_composite_expando_object_keys.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Aksio.Cratis.Properties;
+
+namespace Aksio.Cratis.Dynamic.for_ExpandoObjectExtensions;
+
+public class when_ensuring_complex_path_with_multiple_arrays_indexed_by_composite_expando_object_keys : Specification
+{
+    ExpandoObject initial;
+    PropertyPath property_path;
+    ExpandoObject result;
+    ArrayIndexer first_array_indexer;
+    ArrayIndexer second_array_indexer;
+    ExpandoObject first_key;
+    ExpandoObject second_key;
+
+    void Establish()
+    {
+        first_key = new ExpandoObject();
+
+        ((dynamic)first_key).FirstCompositeProperty = "FirstKey FirstProperty";
+        ((dynamic)first_key).SecondCompositeProperty = "FirstKey SecondProperty";
+
+        second_key = new ExpandoObject();
+        ((dynamic)second_key).FirstCompositeProperty = "SecondKey FirstProperty";
+        ((dynamic)second_key).SecondCompositeProperty = "SecondKey SecondProperty";
+
+        initial = new
+        {
+            first_level = new
+            {
+                second_level = new[]
+                {
+                    new
+                    {
+                        identifier = new
+                        {
+                            ((dynamic)first_key).FirstCompositeProperty,
+                            ((dynamic)first_key).SecondCompositeProperty
+                        },
+                        third_level = new
+                        {
+                            forth_level = new[]
+                            {
+                                new
+                                {
+                                    identifier = new
+                                    {
+                                        ((dynamic)second_key).FirstCompositeProperty,
+                                        ((dynamic)second_key).SecondCompositeProperty
+                                    },
+                                    fifth_level = 42
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }.AsExpandoObject();
+        property_path = new("first_level.[second_level].third_level.[forth_level].fifth_level");
+        first_array_indexer = new("first_level.[second_level]", "identifier", first_key);
+        second_array_indexer = new("first_level.[second_level].third_level.[forth_level]", "identifier", second_key);
+    }
+
+    void Because() => result = initial.EnsurePath(property_path, new ArrayIndexers(new[] { first_array_indexer, second_array_indexer }));
+
+    [Fact] void should_return_existing_object() => ((int)((dynamic)result).fifth_level).ShouldEqual(42);
+}

--- a/Specifications/Infrastructure/Objects/for_ObjectExtensions/when_comparing_two_expando_objects_that_have_the_same_content.cs
+++ b/Specifications/Infrastructure/Objects/for_ObjectExtensions/when_comparing_two_expando_objects_that_have_the_same_content.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Aksio.Cratis.Objects.for_ObjectExtensions;
+
+public class when_comparing_two_expando_objects_that_have_the_same_content : Specification
+{
+    ExpandoObject left;
+    ExpandoObject right;
+    bool result;
+
+    void Establish()
+    {
+        left = new();
+        ((dynamic)left).Something = "Hello";
+        ((dynamic)left).Another = "World";
+
+        right = new();
+        ((dynamic)right).Something = "Hello";
+        ((dynamic)right).Another = "World";
+    }
+
+    void Because() => result = left.IsEqualTo(right);
+
+    [Fact] void should_be_equal() => result.ShouldBeTrue();
+}

--- a/Specifications/Infrastructure/Objects/for_ObjectExtensions/when_comparing_two_expando_objects_that_with_different_content.cs
+++ b/Specifications/Infrastructure/Objects/for_ObjectExtensions/when_comparing_two_expando_objects_that_with_different_content.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Aksio.Cratis.Objects.for_ObjectExtensions;
+
+public class when_comparing_two_expando_objects_that_with_different_content : Specification
+{
+    ExpandoObject left;
+    ExpandoObject right;
+    bool result;
+
+    void Establish()
+    {
+        left = new();
+        ((dynamic)left).Something = "World";
+        ((dynamic)left).Another = "Hello";
+
+        right = new();
+        ((dynamic)right).Something = "Hello";
+        ((dynamic)right).Another = "World";
+    }
+
+    void Because() => result = left.IsEqualTo(right);
+
+    [Fact] void should_not_be_equal() => result.ShouldBeFalse();
+}


### PR DESCRIPTION
### Fixed

- Children with composite keys are now recognized when creating changesets within projections. Two items with same key will now not result in a `ChildAdded` change. This accidently worked when running it with MongoDB but got highlighted as a problem when running unit tests for projections.
