### PR TITLE
Fixing support for array of primitive types as children during conversion

### DIFF
--- a/Source/Kernel/MongoDB/ExpandoObjectConverter.cs
+++ b/Source/Kernel/MongoDB/ExpandoObjectConverter.cs
@@ -114,8 +114,10 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
         return value.ToBsonValueBasedOnSchemaPropertyType(schemaProperty);
     }
 
-    object? ConvertFromBsonValue(BsonValue bsonValue, JsonSchemaProperty schemaProperty)
+    object? ConvertFromBsonValue(BsonValue bsonValue, JsonSchema schemaProperty)
     {
+        schemaProperty = schemaProperty.IsArray ? schemaProperty.Item.Reference ?? schemaProperty.Item : schemaProperty.ActualTypeSchema;
+
         if (bsonValue is BsonDocument childDocument)
         {
             if (schemaProperty.IsDictionary)
@@ -125,7 +127,7 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
 
             return ToExpandoObject(
                 childDocument,
-                schemaProperty.IsArray ? schemaProperty.Item.Reference ?? schemaProperty.Item : schemaProperty.ActualTypeSchema);
+                schemaProperty);
         }
 
         if (bsonValue is BsonArray array)
@@ -206,7 +208,7 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
 
         if (value is BsonArray array)
         {
-            return array.Select(_ => ConvertUnknownSchemaTypeToClrType(value)).ToArray();
+            return array.Select(_ => ConvertUnknownSchemaTypeToClrType(_)).ToArray();
         }
 
         switch (value.BsonType)
@@ -236,7 +238,7 @@ public class ExpandoObjectConverter : IExpandoObjectConverter
         return null;
     }
 
-    object? ConvertBsonValueFromUnknownFormat(BsonValue value, JsonSchemaProperty schemaProperty)
+    object? ConvertBsonValueFromUnknownFormat(BsonValue value, JsonSchema schemaProperty)
     {
         var type = (schemaProperty.Type == JsonObjectType.None && schemaProperty.HasReference) ?
                 schemaProperty.Reference.Type :

--- a/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/TargetType.cs
+++ b/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/TargetType.cs
@@ -14,6 +14,8 @@ public record TargetType(
     DateOnly DateOnlyValue,
     TimeOnly TimeOnlyValue,
     OtherType Reference,
+    IEnumerable<int> IntChildren,
+    IEnumerable<string> StringChildren,
     IEnumerable<OtherType> Children,
     IDictionary<string, string> StringDictionary,
     IDictionary<string, int> IntDictionary,

--- a/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/when_converting_complex_structure_to_bson_document.cs
+++ b/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/when_converting_complex_structure_to_bson_document.cs
@@ -44,6 +44,9 @@ public class when_converting_complex_structure_to_bson_document : given.an_expan
             { "second", 43 }
         };
 
+        expando.intChildren = new int[] { 1, 2, 3 };
+        expando.stringChildren = new string[] { "first", "second", "third" };
+
         dynamic child_expando = new ExpandoObject();
         child_expando.intValue = 44;
         child_expando.floatValue = 44.44f;
@@ -116,4 +119,12 @@ public class when_converting_complex_structure_to_bson_document : given.an_expan
     [Fact] void should_child_object_double_value_to_hold_correct_value() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("doubleValue").Value.AsDouble.ShouldEqual((double)child_dynamic.doubleValue);
     [Fact] void should_child_object_guid_value_to_be_of_binary_type() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("guidValue").Value.ShouldBeOfExactType<BsonBinaryData>();
     [Fact] void should_child_object_guid_value_to_hold_correct_value() => result.GetElement("children").Value.AsBsonArray[0].AsBsonDocument.GetElement("guidValue").Value.AsGuid.ShouldEqual(Guid.Parse((string)child_dynamic.guidValue));
+
+    [Fact] void should_have_first_integer_child_with_correct_value() => result.GetElement("intChildren").Value.AsBsonArray[0].AsInt32.ShouldEqual((int)source_dynamic.intChildren[0]);
+    [Fact] void should_have_second_integer_child_with_correct_value() => result.GetElement("intChildren").Value.AsBsonArray[1].AsInt32.ShouldEqual((int)source_dynamic.intChildren[1]);
+    [Fact] void should_have_third_integer_child_with_correct_value() => result.GetElement("intChildren").Value.AsBsonArray[2].AsInt32.ShouldEqual((int)source_dynamic.intChildren[2]);
+
+    [Fact] void should_have_first_string_child_with_correct_value() => result.GetElement("stringChildren").Value.AsBsonArray[0].AsString.ShouldEqual((string)source_dynamic.stringChildren[0]);
+    [Fact] void should_have_second_string_child_with_correct_value() => result.GetElement("stringChildren").Value.AsBsonArray[1].AsString.ShouldEqual((string)source_dynamic.stringChildren[1]);
+    [Fact] void should_have_third_string_child_with_correct_value() => result.GetElement("stringChildren").Value.AsBsonArray[2].AsString.ShouldEqual((string)source_dynamic.stringChildren[2]);
 }

--- a/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
+++ b/Specifications/Kernel/MongoDB/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
@@ -42,6 +42,18 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
             new BsonElement("dateOnlyValue", new BsonDateTime(DateTime.Parse("2022-10-31T14:51:32.8450000Z"))),
             new BsonElement("timeOnlyValue", new BsonDateTime(DateTime.Parse("2022-10-31T14:51:32.8450000Z"))),
             new BsonElement("reference", reference),
+            new BsonElement("intChildren", new BsonArray(new BsonValue[]
+            {
+                new BsonInt32(1),
+                new BsonInt32(2),
+                new BsonInt32(3)
+            }.AsEnumerable())),
+            new BsonElement("stringChildren", new BsonArray(new BsonValue[]
+            {
+                new BsonString("first"),
+                new BsonString("second"),
+                new BsonString("third")
+            }.AsEnumerable())),
             new BsonElement("children", new BsonArray(new BsonDocument[]
             {
                 child
@@ -98,7 +110,6 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
     [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_double_value() => ((double)result.complexTypeDictionary["first"].doubleValue).ShouldEqual(source.GetElement("complexTypeDictionary").Value.AsBsonDocument.GetElement("first").Value.AsBsonDocument.GetElement("doubleValue").Value.AsDouble);
     [Fact] void should_set_top_level_complex_type_dictionary_first_item_correct_guid_value() => ((Guid)result.complexTypeDictionary["first"].guidValue).ShouldEqual(Guid.Parse(source.GetElement("complexTypeDictionary").Value.AsBsonDocument.GetElement("first").Value.AsBsonDocument.GetElement("guidValue").Value.AsString));
 
-
     [Fact] void should_reference_level_int_value_to_be_of_int_type() => ((object)result.reference.intValue).ShouldBeOfExactType<int>();
     [Fact] void should_reference_level_int_value_to_hold_correct_value() => ((int)result.reference.intValue).ShouldEqual(reference.GetElement("intValue").Value.AsInt32);
     [Fact] void should_reference_level_float_value_to_be_of_float_type() => ((object)result.reference.floatValue).ShouldBeOfExactType<float>();
@@ -116,4 +127,12 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
     [Fact] void should_child_double_value_to_hold_correct_value() => ((double)result.children[0].doubleValue).ShouldEqual(child.GetElement("doubleValue").Value.AsDouble);
     [Fact] void should_child_guid_value_to_be_of_guid_type() => ((object)result.children[0].guidValue).ShouldBeOfExactType<Guid>();
     [Fact] void should_child_guid_value_to_hold_correct_value() => ((Guid)result.children[0].guidValue).ShouldEqual(Guid.Parse(child.GetElement("guidValue").Value.AsString));
+
+    [Fact] void should_have_first_integer_child_with_correct_value() => ((int)result.intChildren[0]).ShouldEqual(1);
+    [Fact] void should_have_second_integer_child_with_correct_value() => ((int)result.intChildren[1]).ShouldEqual(2);
+    [Fact] void should_have_third_integer_child_with_correct_value() => ((int)result.intChildren[2]).ShouldEqual(3);
+
+    [Fact] void should_have_first_string_child_with_correct_value() => ((string)result.stringChildren[0]).ShouldEqual("first");
+    [Fact] void should_have_second_string_child_with_correct_value() => ((string)result.stringChildren[1]).ShouldEqual("second");
+    [Fact] void should_have_third_string_child_with_correct_value() => ((string)result.stringChildren[2]).ShouldEqual("third");
 }


### PR DESCRIPTION
### Fixed

- Fixing BSON to `ExpandoObject` converter to support collections of primitives such as `int` and `string`. It made the items `null` before.
