### PR TITLE
Fix/immediate-projection-logging

### DIFF
--- a/Source/Kernel/Engines/Projections/Definitions/ProjectionDefinitions.cs
+++ b/Source/Kernel/Engines/Projections/Definitions/ProjectionDefinitions.cs
@@ -52,7 +52,9 @@ public class ProjectionDefinitions : IProjectionDefinitions
     /// <inheritdoc/>
     public async Task Register(ProjectionDefinition definition)
     {
+        definition = definition with { LastUpdated = DateTimeOffset.UtcNow };
         _definitions[definition.Identifier] = definition;
+
         await _storage.Save(definition);
     }
 

--- a/Source/Kernel/Grains/Projections/ImmediateProjection.cs
+++ b/Source/Kernel/Grains/Projections/ImmediateProjection.cs
@@ -8,12 +8,15 @@ using Aksio.Cratis.Events;
 using Aksio.Cratis.EventSequences;
 using Aksio.Cratis.Json;
 using Aksio.Cratis.Kernel.Engines.Projections;
+using Aksio.Cratis.Kernel.Engines.Projections.Definitions;
 using Aksio.Cratis.Kernel.Grains.EventSequences;
 using Aksio.Cratis.Kernel.Keys;
 using Aksio.Cratis.Kernel.Schemas;
 using Aksio.Cratis.Projections;
+using Aksio.Cratis.Projections.Definitions;
 using Aksio.Cratis.Properties;
 using Aksio.DependencyInversion;
+using Microsoft.Extensions.Logging;
 using EngineProjection = Aksio.Cratis.Kernel.Engines.Projections.IProjection;
 
 namespace Aksio.Cratis.Kernel.Grains.Projections;
@@ -24,39 +27,48 @@ namespace Aksio.Cratis.Kernel.Grains.Projections;
 public class ImmediateProjection : Grain, IImmediateProjection
 {
     readonly ProviderFor<IProjectionManager> _projectionManagerProvider;
+    readonly ProviderFor<IProjectionDefinitions> _projectionDefinitions;
     readonly ProviderFor<ISchemaStore> _schemaStoreProvider;
     readonly IObjectComparer _objectComparer;
     readonly IEventSequenceStorage _eventProvider;
     readonly IExpandoObjectConverter _expandoObjectConverter;
     readonly IExecutionContextManager _executionContextManager;
+    readonly ILogger<ImmediateProjection> _logger;
     ImmediateProjectionKey? _projectionKey;
     EventSequenceNumber _lastHandledEventSequenceNumber;
     ExpandoObject? _initialState;
     ProjectionId _projectionId = ProjectionId.NotSet;
+    DateTimeOffset _lastUpdated = DateTimeOffset.MinValue;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ImmediateProjection"/> class.
     /// </summary>
-    /// <param name="projectionManagerProvider"><see cref="IProjectionManager"/> for working with engine projections.</param>
+    /// <param name="projectionManagerProvider">Provider for <see cref="IProjectionManager"/> for working with engine projections.</param>
+    /// <param name="projectionDefinitions">Provider for <see cref="IProjectionDefinitions"/> for working with the projection definitions.</param>
     /// <param name="schemaStoreProvider">Provider for <see cref="ISchemaStore"/> for event schemas.</param>
     /// <param name="objectComparer"><see cref="IObjectComparer"/> to compare objects with.</param>
     /// <param name="eventProvider"><see cref="IEventSequenceStorage"/> for getting events from storage.</param>
     /// <param name="expandoObjectConverter"><see cref="IExpandoObjectConverter"/> to convert between JSON and ExpandoObject.</param>
     /// <param name="executionContextManager">The <see cref="IExecutionContextManager"/>.</param>
+    /// <param name="logger">Logger for logging.</param>
     public ImmediateProjection(
         ProviderFor<IProjectionManager> projectionManagerProvider,
+        ProviderFor<IProjectionDefinitions> projectionDefinitions,
         ProviderFor<ISchemaStore> schemaStoreProvider,
         IObjectComparer objectComparer,
         IEventSequenceStorage eventProvider,
         IExpandoObjectConverter expandoObjectConverter,
-        IExecutionContextManager executionContextManager)
+        IExecutionContextManager executionContextManager,
+        ILogger<ImmediateProjection> logger)
     {
         _projectionManagerProvider = projectionManagerProvider;
+        _projectionDefinitions = projectionDefinitions;
         _schemaStoreProvider = schemaStoreProvider;
         _objectComparer = objectComparer;
         _eventProvider = eventProvider;
         _expandoObjectConverter = expandoObjectConverter;
         _executionContextManager = executionContextManager;
+        _logger = logger;
         _lastHandledEventSequenceNumber = EventSequenceNumber.Unavailable;
     }
 
@@ -75,12 +87,20 @@ public class ImmediateProjection : Grain, IImmediateProjection
         // TODO: This is a temporary work-around till we fix #264 & #265
         _executionContextManager.Establish(_projectionKey!.TenantId, _executionContextManager.Current.CorrelationId, _projectionKey.MicroserviceId);
 
+        var projectionChanged = false;
+
         var projection = _projectionManagerProvider().Get(_projectionId);
+        var (foundProjection, definition) = await _projectionDefinitions().TryGetFor(_projectionId);
+        if (foundProjection && definition is not null)
+        {
+            projectionChanged = definition.LastUpdated > _lastUpdated;
+            _lastUpdated = definition.LastUpdated ?? DateTimeOffset.UtcNow;
+        }
 
         var fromSequenceNumber = _lastHandledEventSequenceNumber == EventSequenceNumber.Unavailable ? EventSequenceNumber.First : _lastHandledEventSequenceNumber.Next();
         var eventSequence = GrainFactory.GetGrain<IEventSequence>(_projectionKey.EventSequenceId, new MicroserviceAndTenant(_projectionKey.MicroserviceId, _projectionKey.TenantId));
         var tail = await eventSequence.GetTailSequenceNumberForEventTypes(projection.EventTypes);
-        if (tail != EventSequenceNumber.Unavailable && tail < fromSequenceNumber && _initialState != null)
+        if (tail != EventSequenceNumber.Unavailable && tail < fromSequenceNumber && _initialState != null && !projectionChanged)
         {
             var initialStateAsJson = _expandoObjectConverter.ToJsonObject(_initialState, projection.Model.Schema);
             return new(initialStateAsJson, Enumerable.Empty<PropertyPath>(), 0);
@@ -96,7 +116,7 @@ public class ImmediateProjection : Grain, IImmediateProjection
         var modelKey = _projectionKey.ModelKey.IsSpecified ? (EventSourceId)_projectionKey.ModelKey.Value : null!;
         var cursor = await _eventProvider.GetFromSequenceNumber(EventSequenceId.Log, fromSequenceNumber, modelKey, projection.EventTypes);
         var projectedEventsCount = 0;
-        var state = _initialState ?? new ExpandoObject();
+        var state = GetInitialState(projection, definition);
         while (await cursor.MoveNext())
         {
             if (!cursor.Current.Any())
@@ -147,6 +167,21 @@ public class ImmediateProjection : Grain, IImmediateProjection
     {
         DeactivateOnIdle();
         return Task.CompletedTask;
+    }
+
+    ExpandoObject GetInitialState(EngineProjection projection, ProjectionDefinition? projectionDefinition)
+    {
+        if (_initialState is not null)
+        {
+            return _initialState;
+        }
+
+        if (projectionDefinition?.InitialModelState is not null)
+        {
+            return _expandoObjectConverter.ToExpandoObject(projectionDefinition.InitialModelState, projection.Model.Schema);
+        }
+
+        return new ExpandoObject();
     }
 
     async Task<(int ProjectedEventsCount, ExpandoObject State)> HandleEvents(EngineProjection projection, HashSet<PropertyPath> affectedProperties, ExpandoObject initialState, AppendedEvent[] events)

--- a/Source/Kernel/Grains/Projections/ImmediateProjection.cs
+++ b/Source/Kernel/Grains/Projections/ImmediateProjection.cs
@@ -84,6 +84,8 @@ public class ImmediateProjection : Grain, IImmediateProjection
     /// <inheritdoc/>
     public async Task<ImmediateProjectionResult> GetModelInstance()
     {
+        using (_logger.BeginImmediateProjectionScope(_projectionId, _projectionKey!))
+
         // TODO: This is a temporary work-around till we fix #264 & #265
         _executionContextManager.Establish(_projectionKey!.TenantId, _executionContextManager.Current.CorrelationId, _projectionKey.MicroserviceId);
 

--- a/Source/Kernel/Grains/Projections/ImmediateProjection.cs
+++ b/Source/Kernel/Grains/Projections/ImmediateProjection.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Dynamic;
-using System.Text.Json.Nodes;
 using Aksio.Cratis.Changes;
 using Aksio.Cratis.Dynamic;
 using Aksio.Cratis.Events;

--- a/Source/Kernel/Grains/Projections/ImmediateProjectionsLogging.cs
+++ b/Source/Kernel/Grains/Projections/ImmediateProjectionsLogging.cs
@@ -1,11 +1,27 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Aksio.Cratis.Projections;
 using Microsoft.Extensions.Logging;
 
 namespace Aksio.Cratis.Kernel.Grains.Projections;
 
+#pragma warning disable SA1600 // Elements should be documented
+#pragma warning disable MA0048 // File name must match type name
+
 internal static partial class ImmediateProjectionsLogMessages
 {
     internal static partial void GettingModelInstance(this ILogger<ImmediateProjection> logger);
+}
+
+internal static class ImmediateProjectionScopes
+{
+    internal static IDisposable? BeginImmediateProjectionScope(this ILogger<ImmediateProjection> logger, ProjectionId projectionId, ImmediateProjectionKey projectionKey) =>
+        logger.BeginScope(new Dictionary<string, object>
+        {
+            ["ProjectionId"] = projectionId,
+            ["MicroserviceId"] = projectionKey.MicroserviceId,
+            ["TenantId"] = projectionKey.TenantId,
+            ["EventSequenceId"] = projectionKey.EventSequenceId
+        });
 }

--- a/Source/Kernel/Grains/Projections/ImmediateProjectionsLogging.cs
+++ b/Source/Kernel/Grains/Projections/ImmediateProjectionsLogging.cs
@@ -11,7 +11,17 @@ namespace Aksio.Cratis.Kernel.Grains.Projections;
 
 internal static partial class ImmediateProjectionsLogMessages
 {
+    [LoggerMessage(0, LogLevel.Trace, "Getting model instance for projection.")]
     internal static partial void GettingModelInstance(this ILogger<ImmediateProjection> logger);
+
+    [LoggerMessage(1, LogLevel.Trace, "Using cached model instance for projection.")]
+    internal static partial void UsingCachedModelInstance(this ILogger<ImmediateProjection> logger);
+
+    [LoggerMessage(2, LogLevel.Trace, "No event types for projections, returning empty.")]
+    internal static partial void NoEventTypes(this ILogger<ImmediateProjection> logger);
+
+    [LoggerMessage(4, LogLevel.Error, "Failed getting model instance for projection.")]
+    internal static partial void FailedGettingModelInstance(this ILogger<ImmediateProjection> logger, Exception exception);
 }
 
 internal static class ImmediateProjectionScopes
@@ -22,6 +32,7 @@ internal static class ImmediateProjectionScopes
             ["ProjectionId"] = projectionId,
             ["MicroserviceId"] = projectionKey.MicroserviceId,
             ["TenantId"] = projectionKey.TenantId,
-            ["EventSequenceId"] = projectionKey.EventSequenceId
+            ["EventSequenceId"] = projectionKey.EventSequenceId,
+            ["SessionId"] = projectionKey.CorrelationId ?? string.Empty
         });
 }

--- a/Source/Kernel/Grains/Projections/ImmediateProjectionsLogging.cs
+++ b/Source/Kernel/Grains/Projections/ImmediateProjectionsLogging.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Aksio.Cratis.Kernel.Grains.Projections;
+
+internal static partial class ImmediateProjectionsLogMessages
+{
+    internal static partial void GettingModelInstance(this ILogger<ImmediateProjection> logger);
+}

--- a/Source/Kernel/Shared/Projections/Definitions/ProjectionDefinition.cs
+++ b/Source/Kernel/Shared/Projections/Definitions/ProjectionDefinition.cs
@@ -22,6 +22,7 @@ namespace Aksio.Cratis.Projections.Definitions;
 /// <param name="All">The full <see cref="AllDefinition"/>.</param>
 /// <param name="FromEventProperty">Optional <see cref="FromEventPropertyDefinition"/> definition.</param>
 /// <param name="RemovedWith">The definition of what removes a child, if any.</param>
+/// <param name="LastUpdated">The last time the projection definition was updated.</param>
 public record ProjectionDefinition(
     ProjectionId Identifier,
     ProjectionName Name,
@@ -34,7 +35,8 @@ public record ProjectionDefinition(
     IDictionary<PropertyPath, ChildrenDefinition> Children,
     AllDefinition All,
     FromEventPropertyDefinition? FromEventProperty = default,
-    RemovedWithDefinition? RemovedWith = default)
+    RemovedWithDefinition? RemovedWith = default,
+    DateTimeOffset? LastUpdated = default)
 {
     /// <summary>
     /// Checks if the definition is empty or not. Empty meaning that there is no definition.


### PR DESCRIPTION
### Fixed

- Added logging to `GetModelInstance()` for immediate projections.
- Added last updated to projection definitions.
- Immediate projection now uses the `LastUpdated` property of a projection to decide if ti should rewind the sequence number if it is newer than what the "cached" state is based on.
