### PR TITLE
Fix/null-values-in-conversion

### DIFF
--- a/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
+++ b/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
@@ -223,7 +223,7 @@ public static class ExpandoObjectExtensions
     public static ICollection<TChild> EnsureCollection<TChild>(this ExpandoObject target, PropertyPath childrenProperty, IArrayIndexers arrayIndexers)
     {
         var inner = target.EnsurePath(childrenProperty, arrayIndexers) as IDictionary<string, object>;
-        if (!inner.ContainsKey(childrenProperty.LastSegment.Value))
+        if (!inner.ContainsKey(childrenProperty.LastSegment.Value) || inner[childrenProperty.LastSegment.Value] is null)
         {
             inner[childrenProperty.LastSegment.Value] = new List<TChild>();
         }

--- a/Source/Infrastructure/Schemas/JsonSchemaExtensions.cs
+++ b/Source/Infrastructure/Schemas/JsonSchemaExtensions.cs
@@ -256,7 +256,9 @@ public static class JsonSchemaExtensions
     public static object? GetDefaultValue(this JsonSchemaProperty schemaProperty, ITypeFormats typeFormats)
     {
         var type = schemaProperty.GetTargetTypeForJsonSchemaProperty(typeFormats);
-        if (type?.IsPrimitive ?? false)
+        if (type is not null && (type.IsPrimitive || !type.IsByRef) &&
+                type != typeof(string) &&
+                type != typeof(object))
         {
             try
             {

--- a/Source/Infrastructure/Schemas/JsonSchemaExtensions.cs
+++ b/Source/Infrastructure/Schemas/JsonSchemaExtensions.cs
@@ -247,6 +247,30 @@ public static class JsonSchemaExtensions
         };
     }
 
+    /// <summary>
+    /// Get the default value for a <see cref="JsonSchemaProperty"/>.
+    /// </summary>
+    /// <param name="schemaProperty"><see cref="JsonSchemaProperty"/> to get default value for.</param>
+    /// <param name="typeFormats"><see cref="ITypeFormats"/> holding known JSON schema type formats.</param>
+    /// <returns>The default value.</returns>
+    public static object? GetDefaultValue(this JsonSchemaProperty schemaProperty, ITypeFormats typeFormats)
+    {
+        var type = schemaProperty.GetTargetTypeForJsonSchemaProperty(typeFormats);
+        if (type?.IsPrimitive ?? false)
+        {
+            try
+            {
+                return Activator.CreateInstance(type);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
     static void CollectPropertiesFrom(JsonSchema schema, List<JsonSchemaProperty> properties)
     {
         properties.AddRange(schema.ActualProperties.Select(_ => _.Value));

--- a/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/TargetType.cs
+++ b/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/TargetType.cs
@@ -59,4 +59,6 @@ public record TargetType(
     IEnumerable<int> IntArray,
     IDictionary<string, string> StringDictionary,
     IDictionary<string, int> IntDictionary,
-    IDictionary<string, OtherType> ComplexTypeDictionary);
+    IDictionary<string, OtherType> ComplexTypeDictionary,
+    string MissingStringFromSource,
+    int MissingIntFromSource);

--- a/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
+++ b/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
@@ -134,4 +134,7 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
     [Fact] void should_child_double_value_to_hold_correct_value() => ((double)result.children[0].doubleValue).ShouldEqual(child["doubleValue"].GetValue<double>());
     [Fact] void should_child_guid_value_to_be_of_guid_type() => ((object)result.children[0].guidValue).ShouldBeOfExactType<Guid>();
     [Fact] void should_child_guid_value_to_hold_correct_value() => ((Guid)result.children[0].guidValue).ShouldEqual(Guid.Parse(child["guidValue"].GetValue<string>()));
+
+    [Fact] void should_set_top_level_missing_string_from_source_to_null() => ((object)result.missingStringFromSource).ShouldBeNull();
+    [Fact] void should_set_top_level_missing_int_from_source_to_default_value() => ((int)result.missingIntFromSource).ShouldEqual(0);
 }

--- a/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_json_object.cs
+++ b/Specifications/Infrastructure/Json/for_ExpandoObjectConverter/when_converting_complex_structure_to_json_object.cs
@@ -105,4 +105,7 @@ public class when_converting_complex_structure_to_json_object : given.an_expando
     [Fact] void should_set_child_object_float_value_to_hold_correct_value() => result["children"].AsArray()[0]["floatValue"].GetValue<float>().ShouldEqual((float)child_dynamic.floatValue);
     [Fact] void should_set_child_object_double_value_to_hold_correct_value() => result["children"].AsArray()[0]["doubleValue"].GetValue<double>().ShouldEqual((double)child_dynamic.doubleValue);
     [Fact] void should_set_child_object_guid_value_to_hold_correct_value() => result["children"].AsArray()[0]["guidValue"].GetValue<Guid>().ShouldEqual(Guid.Parse((string)child_dynamic.guidValue));
+
+    [Fact] void should_set_top_level_missing_string_from_source_to_null() => result["missingStringFromSource"].ShouldBeNull();
+    [Fact] void should_set_top_level_missing_int_from_source_to_default_value() => result["missingIntFromSource"].GetValue<int>().ShouldEqual(0);
 }


### PR DESCRIPTION
### Fixed

- Converter from JSON to ExpandoObject and back now honors null values. If a property if missing from the JSON or the ExpandoObject but is in the schema, we set it to default value for primitives and null for non primitives.
