### PR TITLE
Fix/reducer-replay

### DIFF
--- a/Source/Kernel/Engines/Observation/Reducers/ReducerPipeline.cs
+++ b/Source/Kernel/Engines/Observation/Reducers/ReducerPipeline.cs
@@ -46,7 +46,7 @@ public class ReducerPipeline : IReducerPipeline
             await Sink.BeginReplay();
         }
 
-        var isReplaying = context.ObservationState == EventObservationState.Replay;
+        var isReplaying = context.ObservationState.HasFlag(EventObservationState.Replay);
         var initial = await Sink.FindOrDefault(context.Key, isReplaying);
 
         var reduced = await reducer(context.Events, initial);

--- a/Source/Kernel/Engines/Projections/Definitions/ProjectionDefinitions.cs
+++ b/Source/Kernel/Engines/Projections/Definitions/ProjectionDefinitions.cs
@@ -66,9 +66,14 @@ public class ProjectionDefinitions : IProjectionDefinitions
         {
             return (true, false);
         }
-        var incoming = _projectionSerializer.Serialize(projectionDefinition);
-        var existing = _projectionSerializer.Serialize(_definitions[projectionDefinition.Identifier]);
-        var changed = !incoming.ToString().Equals(existing.ToString());
+
+        var incoming = projectionDefinition with { LastUpdated = null };
+        var existing = _definitions[projectionDefinition.Identifier] with { LastUpdated = null };
+        var incomingJson = _projectionSerializer.Serialize(incoming);
+        var existingJson = _projectionSerializer.Serialize(existing);
+        var incomingAsJsonString = incomingJson.ToJsonString();
+        var existingAsJsonString = existingJson.ToJsonString();
+        var changed = !incomingAsJsonString.Equals(existingAsJsonString);
         return (false, changed);
     }
 


### PR DESCRIPTION
### Fixed

- Equality check for projection definitions is now ignoring the `LastUpdated` property, which caused it to always be changed.
- Fixing reducer pipeline to look at the flag `Replay` rather than comparing the entire value `Replay`. This caused the first event not to be considered part of replay and ended up in the sink being saved to the regular collection rather than the temporary replay collection.