### PR TITLE
Fix/sequences-binding

### DIFF
--- a/Source/Clients/DotNET/ClientBuilder.cs
+++ b/Source/Clients/DotNET/ClientBuilder.cs
@@ -256,6 +256,11 @@ public class ClientBuilder : IClientBuilder
             Services.AddTransient(sp =>
             {
                 var tenantId = ExecutionContextManager.GetCurrent().TenantId;
+                return sp.GetRequiredService<IMultiTenantEventSequences>().ForTenant(tenantId);
+            });
+            Services.AddTransient(sp =>
+            {
+                var tenantId = ExecutionContextManager.GetCurrent().TenantId;
                 return sp.GetRequiredService<IMultiTenantEventSequences>().ForTenant(tenantId).EventLog;
             });
             Services.AddTransient(sp =>

--- a/Source/Clients/MongoDB/MongoCollectionAdapter.cs
+++ b/Source/Clients/MongoDB/MongoCollectionAdapter.cs
@@ -10,8 +10,6 @@ using MongoDB.Driver;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-#pragma warning disable AS0010, AS0013
-
 /// <summary>
 /// Represents an adapter for <see cref="IMongoCollection{T}"/> to overcome shortcomings of open generic service registrations with the default ServiceCollection registrations.
 /// </summary>


### PR DESCRIPTION
### Fixed

- Adding service registrations for `IEventSequences` for multi-tenant client, which was missing.
