### PR TITLE
removing .Value from the GTE/LTE queries. This seems to be wrong

### DIFF
--- a/Source/Kernel/MongoDB/EventSequences/EventSequenceQueries.cs
+++ b/Source/Kernel/MongoDB/EventSequences/EventSequenceQueries.cs
@@ -15,12 +15,12 @@ public static class EventSequenceQueries
     /// </summary>
     /// <param name="query">The query to sort.</param>
     /// <returns>The resulting query for continuation.</returns>
-    public static IFindFluent<Event, Event> SortBySequenceNumber(this IFindFluent<Event, Event> query) => query.SortBy(_ => _.SequenceNumber.Value);
+    public static IFindFluent<Event, Event> SortBySequenceNumber(this IFindFluent<Event, Event> query) => query.SortBy(_ => _.SequenceNumber);
 
     /// <summary>
     /// Sort by sequence number descending.
     /// </summary>
     /// <param name="query">The query to sort.</param>
     /// <returns>The resulting query for continuation.</returns>
-    public static IFindFluent<Event, Event> SortByDescendingSequenceNumber(this IFindFluent<Event, Event> query) => query.SortByDescending(_ => _.SequenceNumber.Value);
+    public static IFindFluent<Event, Event> SortByDescendingSequenceNumber(this IFindFluent<Event, Event> query) => query.SortByDescending(_ => _.SequenceNumber);
 }

--- a/Source/Kernel/MongoDB/EventSequences/MongoDBEventSequenceStorage.cs
+++ b/Source/Kernel/MongoDB/EventSequences/MongoDBEventSequenceStorage.cs
@@ -71,7 +71,7 @@ public class MongoDBEventSequenceStorage : IEventSequenceStorage
         var filters = new List<FilterDefinition<Event>>();
         if (lastEventSequenceNumber is not null)
         {
-            filters.Add(Builders<Event>.Filter.Lte(_ => _.SequenceNumber, lastEventSequenceNumber.Value));
+            filters.Add(Builders<Event>.Filter.Lte(_ => _.SequenceNumber, lastEventSequenceNumber));
         }
         if (eventTypes?.Any() ?? false)
         {
@@ -375,7 +375,7 @@ public class MongoDBEventSequenceStorage : IEventSequenceStorage
         var collection = _eventStoreDatabaseProvider().GetEventSequenceCollectionFor(eventSequenceId);
         var filters = new List<FilterDefinition<Event>>
             {
-                Builders<Event>.Filter.Gte(_ => _.SequenceNumber, sequenceNumber.Value)
+                Builders<Event>.Filter.Gte(_ => _.SequenceNumber, sequenceNumber)
             };
 
         if (eventTypes?.Any() ?? false)
@@ -483,7 +483,7 @@ public class MongoDBEventSequenceStorage : IEventSequenceStorage
         var collection = GetCollectionFor(eventSequenceId);
         var filters = new List<FilterDefinition<Event>>
             {
-                Builders<Event>.Filter.Gte(_ => _.SequenceNumber, sequenceNumber.Value)
+                Builders<Event>.Filter.Gte(_ => _.SequenceNumber, sequenceNumber)
             };
 
         if (eventSourceId?.IsSpecified == true)
@@ -517,8 +517,8 @@ public class MongoDBEventSequenceStorage : IEventSequenceStorage
         var collection = GetCollectionFor(eventSequenceId);
         var filters = new List<FilterDefinition<Event>>
             {
-                Builders<Event>.Filter.Gte(_ => _.SequenceNumber, start.Value),
-                Builders<Event>.Filter.Lte(_ => _.SequenceNumber, end.Value)
+                Builders<Event>.Filter.Gte(_ => _.SequenceNumber, start),
+                Builders<Event>.Filter.Lte(_ => _.SequenceNumber, end)
             };
 
         if (eventSourceId?.IsSpecified == true)


### PR DESCRIPTION
### Fixed

- Fixed the EventSequence queries that used `.Value` for the sequence number to be just the actual value. This seems to fix a problem where it tries to add a `Convert()` method to the query, which is not something that can be translated to MongoDB.
