### PR TITLE
Fix/applications

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <ApplicationModel>1.5.3</ApplicationModel>
+    <ApplicationModel>1.5.4</ApplicationModel>
     <Orleans>7.2.4</Orleans>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/Workbench/package.json
+++ b/Source/Workbench/package.json
@@ -23,8 +23,8 @@
         "up": "yarn g:up"
     },
     "dependencies": {
-        "@aksio/applications": "1.2.2",
-        "@aksio/applications-mui": "1.2.2",
+        "@aksio/applications": "1.5.4",
+        "@aksio/applications-mui": "1.5.4",
         "@aksio/fundamentals": "1.5.1",
         "@aksio/typescript": "1.4.2",
         "@ctrl/tinycolor": "3.4.1",


### PR DESCRIPTION
### Fixed

- Latest version of `Aksio.Applications``
- Fixing serialization of JobSteps and Recommendations. Looks like the latest version of MongoDB.Driver is explicitly looking at the type definition of the owning type when serializing, rather than doing a `.GetType()`. It will default to an `ObjectSerializer` if the definition is set to `object` while the actual instance is a different type and it will then fall over.