### PR TITLE
Fixing compiler errors and broken specs after internal API changes

### DIFF
--- a/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/given/a_catchup_observer_and_a_request.cs
+++ b/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/given/a_catchup_observer_and_a_request.cs
@@ -7,7 +7,7 @@ public class a_catchup_observer_and_a_request : a_catchup_observer
 {
     void Establish()
     {
-        state_storage.State.Request = new(
+        state_storage.State.Request = new CatchUpObserverRequest(
             Guid.NewGuid(),
             new ObserverKey(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()),
             ObserverSubscription.Unsubscribed,

--- a/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/when_asking_if_can_resume/and_it_is_not_subscribed.cs
+++ b/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/when_asking_if_can_resume/and_it_is_not_subscribed.cs
@@ -12,7 +12,7 @@ public class and_it_is_not_subscribed : given.a_catchup_observer_and_a_request
 
     void Establish()
     {
-        observer = silo.AddProbe<IObserver>(state_storage.State.Request.ObserverId, state_storage.State.Request.ObserverKey);
+        observer = silo.AddProbe<IObserver>(((CatchUpObserverRequest)state_storage.State.Request).ObserverId, ((CatchUpObserverRequest)state_storage.State.Request).ObserverKey);
         observer.Setup(_ => _.IsSubscribed()).ReturnsAsync(false);
     }
 

--- a/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/when_asking_if_can_resume/and_it_is_subscribed.cs
+++ b/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/when_asking_if_can_resume/and_it_is_subscribed.cs
@@ -12,7 +12,7 @@ public class and_it_is_subscribed : given.a_catchup_observer_and_a_request
 
     void Establish()
     {
-        observer = silo.AddProbe<IObserver>(state_storage.State.Request.ObserverId, state_storage.State.Request.ObserverKey);
+        observer = silo.AddProbe<IObserver>(((CatchUpObserverRequest)state_storage.State.Request).ObserverId, ((CatchUpObserverRequest)state_storage.State.Request).ObserverKey);
         observer.Setup(_ => _.IsSubscribed()).ReturnsAsync(true);
     }
 

--- a/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/when_completed.cs
+++ b/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/when_completed.cs
@@ -12,7 +12,7 @@ public class when_completed : given.a_catchup_observer_and_a_request
 
     void Establish()
     {
-        observer = silo.AddProbe<IObserver>(state_storage.State.Request.ObserverId, state_storage.State.Request.ObserverKey);
+        observer = silo.AddProbe<IObserver>(((CatchUpObserverRequest)state_storage.State.Request).ObserverId, ((CatchUpObserverRequest)state_storage.State.Request).ObserverKey);
         state_storage.State.HandledCount = 42;
     }
 

--- a/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/when_preparing_steps.cs
+++ b/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/when_preparing_steps.cs
@@ -17,7 +17,7 @@ public class when_preparing_steps : given.a_catchup_observer_and_a_request
     void Establish()
     {
         index = new();
-        indexes.Setup(_ => _.GetFor(state_storage.State.Request.ObserverId, state_storage.State.Request.ObserverKey)).ReturnsAsync(index.Object);
+        indexes.Setup(_ => _.GetFor(((CatchUpObserverRequest)state_storage.State.Request).ObserverId, ((CatchUpObserverRequest)state_storage.State.Request).ObserverKey)).ReturnsAsync(index.Object);
 
         keys = new[]
         {
@@ -25,16 +25,16 @@ public class when_preparing_steps : given.a_catchup_observer_and_a_request
             new Key(Guid.NewGuid(), ArrayIndexers.NoIndexers),
             new Key(Guid.NewGuid(), ArrayIndexers.NoIndexers)
         };
-        index.Setup(_ => _.GetKeys(state_storage.State.Request.FromEventSequenceNumber)).Returns(() => new ObserverKeysForTesting(keys));
+        index.Setup(_ => _.GetKeys(((CatchUpObserverRequest)state_storage.State.Request).FromEventSequenceNumber)).Returns(() => new ObserverKeysForTesting(keys));
     }
 
-    async Task Because() => job_steps = await job.WrappedPrepareSteps(state_storage.State.Request);
+    async Task Because() => job_steps = await job.WrappedPrepareSteps((CatchUpObserverRequest)state_storage.State.Request);
 
     [Fact] void should_generate_same_amount_of_steps_as_keys() => job_steps.Count.ShouldEqual(keys.Count());
-    [Fact] void should_set_correct_observer_id_for_all_steps() => job_steps.All(_ => ((HandleEventsForPartitionArguments)_.Request).ObserverId == state.Request.ObserverId).ShouldBeTrue();
-    [Fact] void should_set_correct_observer_key_for_all_steps() => job_steps.All(_ => ((HandleEventsForPartitionArguments)_.Request).ObserverKey == state.Request.ObserverKey).ShouldBeTrue();
-    [Fact] void should_set_correct_subscription_for_all_steps() => job_steps.All(_ => ((HandleEventsForPartitionArguments)_.Request).ObserverSubscription == state.Request.ObserverSubscription).ShouldBeTrue();
+    [Fact] void should_set_correct_observer_id_for_all_steps() => job_steps.All(_ => ((HandleEventsForPartitionArguments)_.Request).ObserverId == ((CatchUpObserverRequest)state.Request).ObserverId).ShouldBeTrue();
+    [Fact] void should_set_correct_observer_key_for_all_steps() => job_steps.All(_ => ((HandleEventsForPartitionArguments)_.Request).ObserverKey == ((CatchUpObserverRequest)state.Request).ObserverKey).ShouldBeTrue();
+    [Fact] void should_set_correct_subscription_for_all_steps() => job_steps.All(_ => ((HandleEventsForPartitionArguments)_.Request).ObserverSubscription == ((CatchUpObserverRequest)state.Request).ObserverSubscription).ShouldBeTrue();
     [Fact] void should_correct_keys() => job_steps.Select(_ => ((HandleEventsForPartitionArguments)_.Request).Partition).ShouldContainOnly(keys);
-    [Fact] void should_set_correct_from_event_sequence_number() => job_steps.All(_ => ((HandleEventsForPartitionArguments)_.Request).StartEventSequenceNumber == state.Request.FromEventSequenceNumber).ShouldBeTrue();
-    [Fact] void should_set_correct_event_types() => job_steps.All(_ => ((HandleEventsForPartitionArguments)_.Request).EventTypes == state.Request.EventTypes).ShouldBeTrue();
+    [Fact] void should_set_correct_from_event_sequence_number() => job_steps.All(_ => ((HandleEventsForPartitionArguments)_.Request).StartEventSequenceNumber == ((CatchUpObserverRequest)state.Request).FromEventSequenceNumber).ShouldBeTrue();
+    [Fact] void should_set_correct_event_types() => job_steps.All(_ => ((HandleEventsForPartitionArguments)_.Request).EventTypes == ((CatchUpObserverRequest)state.Request).EventTypes).ShouldBeTrue();
 }

--- a/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/when_step_completes.cs
+++ b/Specifications/Kernel/Grains/Observation/Jobs/for_CatchUpObserver/when_step_completes.cs
@@ -12,7 +12,7 @@ public class when_step_completes : given.a_catchup_observer_and_a_request
 
     void Establish()
     {
-        observer = silo.AddProbe<IObserver>(state_storage.State.Request.ObserverId, state_storage.State.Request.ObserverKey);
+        observer = silo.AddProbe<IObserver>(((CatchUpObserverRequest)state_storage.State.Request).ObserverId, ((CatchUpObserverRequest)state_storage.State.Request).ObserverKey);
         state.HandledCount = 42;
     }
 

--- a/Specifications/Kernel/Grains/Observation/States/for_CatchUp/given/a_catch_up_state.cs
+++ b/Specifications/Kernel/Grains/Observation/States/for_CatchUp/given/a_catch_up_state.cs
@@ -17,13 +17,15 @@ public class a_catch_up_state : Specification
     protected ObserverState stored_state;
     protected ObserverState resulting_stored_state;
     protected CatchUp state;
+    protected ObserverId observer_id;
 
     void Establish()
     {
         observer = new();
+        observer_id = Guid.NewGuid();
         observer_key = new(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
         jobs_manager = new();
-        state = new CatchUp(observer_key, jobs_manager.Object, Mock.Of<ILogger<CatchUp>>());
+        state = new CatchUp(observer_id, observer_key, jobs_manager.Object, Mock.Of<ILogger<CatchUp>>());
         state.SetStateMachine(observer.Object);
 
         stored_state = new ObserverState

--- a/Specifications/Kernel/Grains/Observation/States/for_CatchUp/when_entering/and_a_catch_up_is_already_running.cs
+++ b/Specifications/Kernel/Grains/Observation/States/for_CatchUp/when_entering/and_a_catch_up_is_already_running.cs
@@ -15,7 +15,7 @@ public class and_a_catch_up_is_already_running : given.a_catch_up_state
             .Setup(_ => _.GetJobsOfType<ICatchUpObserver, CatchUpObserverRequest>())
             .ReturnsAsync(new[]
                 {
-                    new JobState<CatchUpObserverRequest>
+                    new JobState
                     {
                         Id = JobId.New(),
                         Request = new CatchUpObserverRequest(

--- a/Specifications/Kernel/Grains/Observation/States/for_CatchUp/when_entering/and_a_paused_catch_up_job_exists.cs
+++ b/Specifications/Kernel/Grains/Observation/States/for_CatchUp/when_entering/and_a_paused_catch_up_job_exists.cs
@@ -9,10 +9,10 @@ namespace Aksio.Cratis.Kernel.Grains.Observation.States.for_CatchUp.when_enterin
 
 public class and_a_paused_catch_up_job_exists : given.a_catch_up_state
 {
-    JobState<CatchUpObserverRequest> paused_job;
+    JobState paused_job;
     void Establish()
     {
-        paused_job = new JobState<CatchUpObserverRequest>
+        paused_job = new JobState
         {
             Id = JobId.New(),
             Request = new CatchUpObserverRequest(

--- a/Specifications/Kernel/Grains/Observation/States/for_CatchUp/when_entering/and_no_jobs_are_running.cs
+++ b/Specifications/Kernel/Grains/Observation/States/for_CatchUp/when_entering/and_no_jobs_are_running.cs
@@ -33,7 +33,7 @@ public class and_no_jobs_are_running : given.a_catch_up_state
 
         jobs_manager
             .Setup(_ => _.GetJobsOfType<ICatchUpObserver, CatchUpObserverRequest>())
-            .ReturnsAsync(Enumerable.Empty<JobState<CatchUpObserverRequest>>().ToImmutableList());
+            .ReturnsAsync(Enumerable.Empty<JobState>().ToImmutableList());
 
         jobs_manager
             .Setup(_ => _.Start<ICatchUpObserver, CatchUpObserverRequest>(IsAny<JobId>(), IsAny<CatchUpObserverRequest>()))

--- a/Specifications/Kernel/Grains/Observation/States/for_Replay/given/a_replay_state.cs
+++ b/Specifications/Kernel/Grains/Observation/States/for_Replay/given/a_replay_state.cs
@@ -20,14 +20,17 @@ public class a_replay_state : Specification
     protected ObserverState stored_state;
     protected ObserverState resulting_stored_state;
     protected Replay state;
+    protected ObserverId observer_id;
 
     void Establish()
     {
         observer = new();
+        observer_id = Guid.NewGuid();
         observer_key = new(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
         observer_service_client = new();
         jobs_manager = new();
         state = new Replay(
+            observer_id,
             observer_key,
             observer_service_client.Object,
             jobs_manager.Object,
@@ -36,7 +39,7 @@ public class a_replay_state : Specification
 
         stored_state = new ObserverState
         {
-            ObserverId = Guid.NewGuid(),
+            ObserverId = observer_id,
             RunningState = ObserverRunningState.CatchingUp,
         };
 
@@ -51,6 +54,6 @@ public class a_replay_state : Specification
 
         jobs_manager
             .Setup(_ => _.GetJobsOfType<IReplayObserver, ReplayObserverRequest>())
-            .ReturnsAsync(Enumerable.Empty<JobState<ReplayObserverRequest>>().ToImmutableList());
+            .ReturnsAsync(Enumerable.Empty<JobState>().ToImmutableList());
     }
 }

--- a/Specifications/Kernel/Grains/Observation/States/for_Replay/when_entering/and_a_paused_replay_job_exists.cs
+++ b/Specifications/Kernel/Grains/Observation/States/for_Replay/when_entering/and_a_paused_replay_job_exists.cs
@@ -9,7 +9,7 @@ namespace Aksio.Cratis.Kernel.Grains.Observation.States.for_Replay.when_entering
 
 public class and_a_paused_replay_job_exists : given.a_replay_state
 {
-    JobState<ReplayObserverRequest> paused_job;
+    JobState paused_job;
     ObserverDetails observer_details;
 
     void Establish()
@@ -19,7 +19,7 @@ public class and_a_paused_replay_job_exists : given.a_replay_state
             Type = ObserverType.Client
         };
 
-        paused_job = new JobState<ReplayObserverRequest>
+        paused_job = new JobState
         {
             Id = JobId.New(),
             Request = new ReplayObserverRequest(

--- a/Specifications/Kernel/Grains/Observation/States/for_Replay/when_entering/and_a_replay_job_is_already_running.cs
+++ b/Specifications/Kernel/Grains/Observation/States/for_Replay/when_entering/and_a_replay_job_is_already_running.cs
@@ -15,7 +15,7 @@ public class and_a_replay_job_is_already_running : given.a_replay_state
             .Setup(_ => _.GetJobsOfType<IReplayObserver, ReplayObserverRequest>())
             .ReturnsAsync(new[]
                 {
-                    new JobState<ReplayObserverRequest>
+                    new JobState
                     {
                         Id = JobId.New(),
                         Request = new ReplayObserverRequest(

--- a/Specifications/Kernel/Grains/Observation/States/for_Replay/when_leaving/and_a_replay_job_is_already_running.cs
+++ b/Specifications/Kernel/Grains/Observation/States/for_Replay/when_leaving/and_a_replay_job_is_already_running.cs
@@ -20,7 +20,7 @@ public class and_a_replay_job_is_already_running : given.a_replay_state
             .Setup(_ => _.GetJobsOfType<IReplayObserver, ReplayObserverRequest>())
             .ReturnsAsync(new[]
                 {
-                    new JobState<ReplayObserverRequest>
+                    new JobState
                     {
                         Id = JobId.New(),
                         Request = new ReplayObserverRequest(


### PR DESCRIPTION
### Fixed

- Serialization to and from MongoDB fixed for types with `object` properties. These are now getting a discriminator value that makes sense and is possible to get back to the original type. Allowing any types to be considered.
- Internal fallback JSON serialization for Grain communication with support for types with `object` properties.
- Adding metadata to the JSON schema for properties that hold a nullable `ConceptAs<>` type allowing the Kernel to treat these as nullables and not give a default value if the value is indeed null.

