### PR TITLE
Moving configuration of the CPU bound workers

### DIFF
--- a/Source/Kernel/Server/CpuBoundWorkersExtensions.cs
+++ b/Source/Kernel/Server/CpuBoundWorkersExtensions.cs
@@ -16,7 +16,7 @@ public static class CpuBoundWorkersExtensions
     /// </summary>
     /// <param name="builder">The <see cref="ISiloBuilder"/> to configure.</param>
     /// <returns><see cref="ISiloBuilder"/> for continuation.</returns>
-    public static ISiloBuilder ConfigureCpuBoundWorkers(this ISiloBuilder builder)
+    public static IHostBuilder ConfigureCpuBoundWorkers(this IHostBuilder builder)
     {
         var maxLevelOfParallelism = Environment.ProcessorCount - 2;
         if (maxLevelOfParallelism < 0)

--- a/Source/Kernel/Server/Program.cs
+++ b/Source/Kernel/Server/Program.cs
@@ -29,6 +29,7 @@ public static class Program
 
     public static IHostBuilder CreateHostBuilder(string[] args) =>
          Host.CreateDefaultBuilder(args)
+            .ConfigureCpuBoundWorkers()
             .UseMongoDB()
             .UseAksio(mvcOptions => mvcOptions.Filters.Add<KernelReadyResourceFilter>(0))
             .UseCratis(_ => _.InKernel())
@@ -36,7 +37,6 @@ public static class Program
                 .UseCluster()
                 .UseStreamCaching()
                 .AddBroadcastChannel(WellKnownBroadcastChannelNames.ProjectionChanged, _ => _.FireAndForgetDelivery = true)
-                .ConfigureCpuBoundWorkers()
                 .ConfigureSerialization()
                 .AddReplayStateManagement()
                 .UseTelemetry()


### PR DESCRIPTION
### Fixed

- Configuring the CPU bound workers as the first thing, seems to be a timing issue with this not being configured and dependencies to `LimitedConcurrencyLevelTaskScheduler`. 
