### PR TITLE
Binding the LimitedConcurrencyLevelTaskScheduler as a Singleton

### DIFF
--- a/Source/Kernel/Server/CpuBoundWorkersExtensions.cs
+++ b/Source/Kernel/Server/CpuBoundWorkersExtensions.cs
@@ -23,7 +23,7 @@ public static class CpuBoundWorkersExtensions
         {
             maxLevelOfParallelism = 1;
         }
-        builder.ConfigureServices((services) => services.AddSingleton((IServiceProvider _) => new LimitedConcurrencyLevelTaskScheduler(maxLevelOfParallelism)));
+        builder.ConfigureServices((services) => services.AddSingleton(new LimitedConcurrencyLevelTaskScheduler(maxLevelOfParallelism)));
 
         return builder;
     }


### PR DESCRIPTION
### Fixed

- Moved to a concrete singleton instead of a provider that provides the singleton for `LimitedConcurrencyLevelTaskScheduler`.
