### PR TITLE
Stopping the rehydrate from failing during startup - but output the error

### DIFF
--- a/Source/Kernel/Grains/EventSequences/EventSequencesLogMessages.cs
+++ b/Source/Kernel/Grains/EventSequences/EventSequencesLogMessages.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.EventSequences;
+using Microsoft.Extensions.Logging;
+
+namespace Aksio.Cratis.Kernel.Grains.EventSequences;
+
+internal static partial class EventSequencesLogMessages
+{
+    [LoggerMessage(0, LogLevel.Error, "Failed when rehydrating event sequence {EventSequenceId} for microservice {MicroserviceId} and {TenantId}")]
+    internal static partial void FailedRehydratingEventSequence(this ILogger<EventSequences> logger, EventSequenceId eventSequenceId, MicroserviceId microserviceId, TenantId tenantId, Exception exception);
+}


### PR DESCRIPTION
### Fixed

- Stopping the rehydration of event sequences from failing at startup, instead log an error. We want the server to survive any non fatal errors at startup.

