### PR TITLE
Make eventTypes optional, as it should be.

### DIFF
--- a/Source/Kernel/Read/EventSequences/EventSequence.cs
+++ b/Source/Kernel/Read/EventSequences/EventSequence.cs
@@ -173,7 +173,7 @@ public class EventSequence : ControllerBase
         [FromQuery(Name = "eventTypes[]")] IEnumerable<string> eventTypes = null!)
     {
         var result = new List<AppendedEventWithJsonAsContent>();
-        var parsedEventTypes = eventTypes.Select(EventType.Parse).ToArray();
+        var parsedEventTypes = eventTypes?.Select(EventType.Parse).ToArray();
 
         var correlationId = _executionContextManager.Current.CorrelationId;
         _executionContextManager.Establish(tenantId, correlationId, microserviceId);


### PR DESCRIPTION
## Summary

Minor bugfix.

### Fixed

- Fixes `/api/events/store/{microserviceId}/{tenantId}/sequence/{eventSequenceId}/all` endpoint to have eventTypes actually be optional as it should.
