### PR TITLE
Add REST endpoint to fetch a defined range of appended events

### DIFF
--- a/Source/Workbench/API/events/store/sequence/GetAppendedEventsRange.ts
+++ b/Source/Workbench/API/events/store/sequence/GetAppendedEventsRange.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  **DO NOT EDIT** - This file is an automatically generated file.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QueryFor, QueryResultWithState, useQuery, PerformQuery } from '@aksio/applications/queries';
+import { PagedQueryResult } from './PagedQueryResult';
+import Handlebars from 'handlebars';
+
+const routeTemplate = Handlebars.compile('/api/events/store/{{microserviceId}}/{{tenantId}}/sequence/{{eventSequenceId}}?fromSequenceNumber={{fromSequenceNumber}}&toSequenceNumber={{toSequenceNumber}}&eventSourceId={{eventSourceId}}&eventTypes={{eventTypes}}');
+
+export interface GetAppendedEventsRangeArguments {
+    eventSequenceId: string;
+    microserviceId: string;
+    tenantId: string;
+    fromSequenceNumber: number;
+    toSequenceNumber: number;
+    eventSourceId: string;
+    eventTypes: any;
+}
+export class GetAppendedEventsRange extends QueryFor<PagedQueryResult, GetAppendedEventsRangeArguments> {
+    readonly route: string = '/api/events/store/{{microserviceId}}/{{tenantId}}/sequence/{{eventSequenceId}}?fromSequenceNumber={{fromSequenceNumber}}&toSequenceNumber={{toSequenceNumber}}&eventSourceId={{eventSourceId}}&eventTypes={{eventTypes}}';
+    readonly routeTemplate: Handlebars.TemplateDelegate = routeTemplate;
+    readonly defaultValue: PagedQueryResult = {} as any;
+
+    constructor() {
+        super(PagedQueryResult, false);
+    }
+
+    get requestArguments(): string[] {
+        return [
+            'eventSequenceId',
+            'microserviceId',
+            'tenantId',
+            'fromSequenceNumber',
+            'toSequenceNumber',
+            'eventSourceId',
+            'eventTypes',
+        ];
+    }
+
+    static use(args?: GetAppendedEventsRangeArguments): [QueryResultWithState<PagedQueryResult>, PerformQuery<GetAppendedEventsRangeArguments>] {
+        return useQuery<PagedQueryResult, GetAppendedEventsRange, GetAppendedEventsRangeArguments>(GetAppendedEventsRange, args);
+    }
+}


### PR DESCRIPTION
## Summary

Added endpoint necessary for client observers.

### Added

- Added `/api/events/store/{microserviceId}/{tenantId}/sequence/{eventSequenceId}/range` endpoint which allow for fetching of events based on event sequence number instead of paging.
